### PR TITLE
Avoid that RdKitSubstructLibrary crashes on invalid mols and a few other clean-ups

### DIFF
--- a/packages/Chem/src/rdkit_substruct_library.js
+++ b/packages/Chem/src/rdkit_substruct_library.js
@@ -46,10 +46,22 @@ class RdKitSubstructLibrary {
 
   search(query) {
 
-    if (this.library == null) { return "[]"; }
-    const queryMol = this.rdKitModule.get_mol(query, "{\"mergeQueryHs\":true}");
-    const matches = this.library.get_matches(queryMol, false, 1, -1);
-    queryMol.delete();
+    let matches = "[]";
+    if (this.library) {
+      try {
+        const queryMol = this.rdKitModule.get_mol(query, "{\"mergeQueryHs\":true}");
+        if (queryMol) {
+          if (queryMol.is_valid()) {
+            matches = this.library.get_matches(queryMol, false, 1, -1);
+          }
+          queryMol.delete();
+        }
+      } catch (e) {
+        console.error(
+          "Possibly a malformed query: `" + query + "`");
+        // Won't rethrow
+      }
+    }
     return matches;
 
   }


### PR DESCRIPTION
- if `RdKitSubstructLibrary.search()` is passed an invalid query, return no matches rather than crashing
  Currently if `get_mol` throws an exception inside `RdKitSubstructLibrary.search()`, an uncaught exception in Promise will be raised, causing the UI to hang
- the renderer should not attempt to call `is_valid()` on a `null` mol
  in `_fetchMolGetOrCreate` the first `try..catch` block can set mol to `null`, so calling `mol.is_valid()` is bound to throw an exception, which in turn causes unnecessary verbose logging in the console
- the renderer should check if `rdkitScaffoldMol` is not `null` and valid before passing it to `generate_aligned_coords()`
  to avoid throwing unnecessary exceptions
  same as above - avoid unnecessary logging that clutters the console
- mols which are invalid should still be deleted to avoid leaking memory
  currently invalid mols were not deleted causing a potential memory leak