### PR TITLE
Changed getCredentials().parameters return type to Record

### DIFF
--- a/js-api/src/entities.ts
+++ b/js-api/src/entities.ts
@@ -497,7 +497,7 @@ export class Credentials extends Entity {
   }
 
   /** Collection of parameters: login, password, API key, etc. */
-  get parameters(): object { return api.grok_Credentials_Parameters(this.dart); }
+  get parameters(): Record<string, string> { return api.grok_Credentials_Parameters(this.dart); }
 }
 
 /** Represents a script environment */


### PR DESCRIPTION
Current `object` type forces to use `@ts-ignore` in all places the `getCredentials` is used. Since `object` type has no own props, any access to `getCredentials().parameters` raises compilation error. 

The canonical way to get param (`getCredentials().parameters[%paramName%]`) is ideally described by `Record<string, string>` type.