### PR TITLE
Integrates #554

### DIFF
--- a/packages/Chem/src/rdkit-api.ts
+++ b/packages/Chem/src/rdkit-api.ts
@@ -41,6 +41,7 @@ export interface RDMol {
   get_morgan_fp_as_uint8array(radius: number, fplen: number): Uint8Array;
 
   is_valid(): boolean;
+  has_coords(): boolean;
 
   get_stereo_tags(): string;
   get_aromatic_form(): string;

--- a/packages/Chem/src/rendering/rdkit-cell-renderer.ts
+++ b/packages/Chem/src/rendering/rdkit-cell-renderer.ts
@@ -102,6 +102,9 @@ M  END
             mol.set_new_coords(true);
           }
           if (!scaffoldIsMolBlock || molRegenerateCoords) {
+            if (!mol.has_coords()) {
+              mol.set_new_coords();
+            }
             mol!.normalize_depiction();
             mol!.straighten_depiction();
           }


### PR DESCRIPTION
Integrates #554.
Make sure the molecule has coordinates before calling `normalize_depiction()` and `straighten_depiction()`