### PR TITLE
Charts: added SurfacePlot axes min and max values defaults

### DIFF
--- a/packages/Charts/src/surface-plot.ts
+++ b/packages/Charts/src/surface-plot.ts
@@ -88,12 +88,18 @@ export class SurfacePlot extends EChartViewer {
       },
       xAxis3D: {
         type: 'value',
+        min: 'dataMin',
+        max: 'dataMax',
       },
       yAxis3D: {
         type: 'value',
+        min: 'dataMin',
+        max: 'dataMax',
       },
       zAxis3D: {
         type: 'value',
+        min: 'dataMin',
+        max: 'dataMax',
       },
       grid3D: {
         show: true,
@@ -193,8 +199,8 @@ export class SurfacePlot extends EChartViewer {
         this.wireframe = newVal;
         break;
       }
+      this.render();
     }
-    this.render();
   }
 
   render(computeData=false, filter=true) {


### PR DESCRIPTION
Fixed bug with re-render on calling `render(true)`. 

Added default min and max value of axes based on data provided. 