### PR TITLE
molecules should display also if they fail to kekulize

### DIFF
--- a/packages/Chem/src/widgets/scaffold-tree.ts
+++ b/packages/Chem/src/widgets/scaffold-tree.ts
@@ -2,7 +2,7 @@ import * as ui from 'datagrok-api/ui';
 import * as DG from 'datagrok-api/dg';
 import * as grok from 'datagrok-api/grok';
 import $ from "cash-dom";
-import {_rdKitModule} from '../utils/chem-common-rdkit';
+import {_rdKitModule, getMolSafe} from '../utils/chem-common-rdkit';
 import {isMolBlock} from "../utils/convert-notation-utils";
 import {chem} from "datagrok-api/grok";
 import {toJs, TreeViewGroup, TreeViewNode} from "datagrok-api/dg";
@@ -256,9 +256,9 @@ function renderMolecule(molStr: string, width: number, height: number, skipDraw:
     g!.fillText(text, Math.floor((width - lineWidth) / 2), Math.floor((height - fontHeight) / 2));
   } else {
     molStr = processUnits(molStr);
-    const mol = getMol(molStr);
+    const { mol, kekulize } = getMolSafe(molStr);
     if (mol !== null) {
-      drawRdKitMoleculeToOffscreenCanvas(mol, CELL_CANVAS_WIDTH, CELL_CANVAS_HEIGHT, offscreen, null);
+      drawRdKitMoleculeToOffscreenCanvas(mol, CELL_CANVAS_WIDTH, CELL_CANVAS_HEIGHT, offscreen, null, kekulize);
       mol.delete();
     }
   }


### PR DESCRIPTION
Please see the attached CSV file.
[fail_to_display_dg.csv](https://github.com/datagrok-ai/public/files/10548812/fail_to_display_dg.csv)

With the current `Chem` package the molecules in the `Core` column show up as a red cross as they fail to kekulize:
![image](https://user-images.githubusercontent.com/5244385/215823567-6729058c-6852-4537-a58d-c14d0343a11f.png)
Also, an uncaught exception shows up in the console:
![image](https://user-images.githubusercontent.com/5244385/215823607-1d833661-b159-4285-afcc-775538c89657.png)
This should not happen - in such cases structures should be shown in their aromatic form.
This PR fixes the problem:
![image](https://user-images.githubusercontent.com/5244385/215823810-31565873-3af9-4fd6-9a5d-0a6926b6559e.png)
