### PR TITLE
GROK-12450: Viewers | Filters: Custom filter test

### DIFF
--- a/packages/ApiTests/src/package-test.ts
+++ b/packages/ApiTests/src/package-test.ts
@@ -48,6 +48,7 @@ import './ui/tags';
 import './ui/sharing';
 import './package/upload';
 import './viewers/viewers';
+import './viewers/filters';
 import './grid/grid';
 import './grid/color-coding';
 // import './connections/queries-test';
@@ -74,6 +75,7 @@ import './gui/project-upload';
 // import './gui/viewers/word-cloud';
 
 import {runTests, tests, TestContext} from '@datagrok-libraries/utils/src/test';
+
 export const _package = new DG.Package();
 export {tests};
 
@@ -94,7 +96,7 @@ export async function test(category: string, test: string, testContext: TestCont
 //top-menu: Tools | Dev | Test Packages
 export async function testPackages(): Promise<DG.DataFrame> {
   const funcs = DG.Func.find({name: 'test'});
-  const dfs:DG.DataFrame[] = [];
+  const dfs: DG.DataFrame[] = [];
   for (const f of funcs) {
     if (f.package?.name != null) {
       grok.shell.closeAll();

--- a/packages/ApiTests/src/package.ts
+++ b/packages/ApiTests/src/package.ts
@@ -4,9 +4,11 @@ import * as grok from 'datagrok-api/grok';
 import * as DG from 'datagrok-api/dg';
 
 import {TestViewerForProperties} from './viewers/test-viewer-for-properties';
+import {TestCustomFilter} from './viewers/test-custom-filter';
 import {expectTable as _expectTable} from '@datagrok-libraries/utils/src/test';
-// import {hashDataFrame} from '@datagrok-libraries/utils/src/dataframe-utils';
 
+
+// -- Viewers --
 
 //name: TestViewerForProperties
 //description: Viewer to test properties and others
@@ -14,6 +16,17 @@ import {expectTable as _expectTable} from '@datagrok-libraries/utils/src/test';
 //output: viewer result
 export function testViewerForProperties() {
   return new TestViewerForProperties();
+}
+
+// -- Filters --
+
+//name: testCustomFilter
+//description: Test custom filter
+//tags: filter
+//output: filter result
+export function testCustomFilter(): DG.Filter {
+  const flt: TestCustomFilter = new TestCustomFilter();
+  return flt;
 }
 
 //name: getTable

--- a/packages/ApiTests/src/viewers/filters.ts
+++ b/packages/ApiTests/src/viewers/filters.ts
@@ -1,0 +1,74 @@
+import * as ui from 'datagrok-api/ui';
+import * as grok from 'datagrok-api/grok';
+import * as DG from 'datagrok-api/dg';
+
+import {
+  after,
+  before,
+  category,
+  expect,
+  test,
+  delay,
+  awaitCheck,
+  expectArray
+} from '@datagrok-libraries/utils/src/test';
+import {TableView} from 'datagrok-api/dg';
+import {_package} from '../package-test';
+
+import $ from 'cash-dom';
+
+category('Viewers: Filters', () => {
+  const csv1: string = `id1,id2,id3
+id1_0001,id2_001,id3_1
+id1_0002,id2_002,id3_2
+id1_0003,id2_003,id3_3`;
+
+  test('twoCategorical', async () => {
+    const df: DG.DataFrame = DG.DataFrame.fromCsv(csv1);
+    const view: TableView = grok.shell.addTableView(df);
+
+    const filterList: { [p: string]: string }[] = [
+      {column: 'id1', type: DG.FILTER_TYPE.CATEGORICAL, label: 'id1 label'},
+      {column: 'id2', type: DG.FILTER_TYPE.CATEGORICAL, label: 'id2 label'},
+    ];
+    const filtersViewer = view.filters({filters: filterList}) as DG.Viewer;
+    const filtersViewerDn: DG.DockNode = view.dockManager.dock(
+      filtersViewer, DG.DOCK_TYPE.LEFT, null, 'Filters', 0.4);
+
+    await awaitCheck(() => {
+      let ok: boolean = true;
+
+      const fltColNameList = $(filtersViewer.root)
+        .find('div.d4-flex-row.d4-filter-header label.d4-filter-column-name').get()
+        .map((lbl) => lbl.innerText);
+
+      expectArray(fltColNameList, ['id1', 'id2']);
+      return ok;
+    }, 'cannot find all filters', 3000);
+  });
+
+  test('customBetweenCategorical', async () => {
+    const df: DG.DataFrame = DG.DataFrame.fromCsv(csv1);
+    const view: TableView = grok.shell.addTableView(df);
+
+    const filterList: { [p: string]: string }[] = [
+      {column: 'id1', type: DG.FILTER_TYPE.CATEGORICAL, label: 'id1 label'},
+      {column: 'id3', type: `${_package.name}:TestCustomFilter`, label: 'custom label'},
+      {column: 'id2', type: DG.FILTER_TYPE.CATEGORICAL, label: 'id2 label'},
+    ];
+    const filtersViewer = view.filters({filters: filterList}) as DG.Viewer;
+    const filtersViewerDn: DG.DockNode = view.dockManager.dock(
+      filtersViewer, DG.DOCK_TYPE.LEFT, null, 'Filters', 0.4);
+
+    await awaitCheck(() => {
+      let ok: boolean = true;
+
+      const fltColNameList = $(filtersViewer.root)
+        .find('div.d4-flex-row.d4-filter-header label.d4-filter-column-name').get()
+        .map((lbl) => lbl.innerText);
+
+      expectArray(fltColNameList, ['id1', 'id3', 'id2']);
+      return ok;
+    }, 'cannot find all filters', 3000);
+  });
+});

--- a/packages/ApiTests/src/viewers/filters.ts
+++ b/packages/ApiTests/src/viewers/filters.ts
@@ -3,14 +3,10 @@ import * as grok from 'datagrok-api/grok';
 import * as DG from 'datagrok-api/dg';
 
 import {
-  after,
-  before,
   category,
-  expect,
   test,
-  delay,
   awaitCheck,
-  expectArray
+  expectArray,
 } from '@datagrok-libraries/utils/src/test';
 import {TableView} from 'datagrok-api/dg';
 import {_package} from '../package-test';
@@ -32,18 +28,15 @@ id1_0003,id2_003,id3_3`;
       {column: 'id2', type: DG.FILTER_TYPE.CATEGORICAL, label: 'id2 label'},
     ];
     const filtersViewer = view.filters({filters: filterList}) as DG.Viewer;
-    const filtersViewerDn: DG.DockNode = view.dockManager.dock(
-      filtersViewer, DG.DOCK_TYPE.LEFT, null, 'Filters', 0.4);
+    view.dockManager.dock(filtersViewer, DG.DOCK_TYPE.LEFT, null, 'Filters', 0.4);
 
     await awaitCheck(() => {
-      let ok: boolean = true;
-
       const fltColNameList = $(filtersViewer.root)
         .find('div.d4-flex-row.d4-filter-header label.d4-filter-column-name').get()
         .map((lbl) => lbl.innerText);
 
       expectArray(fltColNameList, ['id1', 'id2']);
-      return ok;
+      return true;
     }, 'cannot find all filters', 3000);
   });
 
@@ -57,18 +50,14 @@ id1_0003,id2_003,id3_3`;
       {column: 'id2', type: DG.FILTER_TYPE.CATEGORICAL, label: 'id2 label'},
     ];
     const filtersViewer = view.filters({filters: filterList}) as DG.Viewer;
-    const filtersViewerDn: DG.DockNode = view.dockManager.dock(
-      filtersViewer, DG.DOCK_TYPE.LEFT, null, 'Filters', 0.4);
 
     await awaitCheck(() => {
-      let ok: boolean = true;
-
       const fltColNameList = $(filtersViewer.root)
         .find('div.d4-flex-row.d4-filter-header label.d4-filter-column-name').get()
         .map((lbl) => lbl.innerText);
 
       expectArray(fltColNameList, ['id1', 'id3', 'id2']);
-      return ok;
+      return true;
     }, 'cannot find all filters', 3000);
   });
 });

--- a/packages/ApiTests/src/viewers/test-custom-filter.ts
+++ b/packages/ApiTests/src/viewers/test-custom-filter.ts
@@ -1,0 +1,30 @@
+import * as ui from 'datagrok-api/ui';
+import * as grok from 'datagrok-api/grok';
+import * as DG from 'datagrok-api/dg';
+
+import $ from 'cash-dom';
+
+export class TestCustomFilter extends DG.Filter {
+  get filterSummary(): string {
+    return '';
+  }
+
+  constructor() {
+    super();
+  }
+
+  applyState(state: any) {
+    if (typeof state.column == 'string' || state.column instanceof String) {
+      const columnName: string = state.column;
+      delete state.column;
+      state.columnName = columnName;
+    }
+    super.applyState(state);
+  }
+
+  // -- Filter --
+
+  applyFilter(): void {
+    const k = 11;
+  }
+}

--- a/packages/ApiTests/src/viewers/test-custom-filter.ts
+++ b/packages/ApiTests/src/viewers/test-custom-filter.ts
@@ -25,6 +25,5 @@ export class TestCustomFilter extends DG.Filter {
   // -- Filter --
 
   applyFilter(): void {
-    const k = 11;
   }
 }


### PR DESCRIPTION
There was a problem to display the custom PTM filter in MLB.

The problem was solved by specifying a column name to associate the custom filter with, though the PTM filter works on data of multiple columns.

Tests for the ApiTests package have been created to test displaying custom filters, they also are examples showing how to use custom filters.