### PR TITLE
GROK-12136: Bio | Stability: Fix Bio default share

### DIFF
--- a/packages/Bio/package.json
+++ b/packages/Bio/package.json
@@ -5,7 +5,7 @@
     "name": "Leonid Stolbov",
     "email": "lstolbov@datagrok.ai"
   },
-  "version": "2.3.9",
+  "version": "2.3.10",
   "description": "Bioinformatics support (import/export of sequences, conversion, visualization, analysis). [See more](https://github.com/datagrok-ai/public/blob/master/packages/Bio/README.md) for details.",
   "repository": {
     "type": "git",
@@ -67,6 +67,9 @@
   },
   "canEdit": [
     "Developers"
+  ],
+  "canView": [
+    "All users"
   ],
   "sources": [
     "css/helm.css"


### PR DESCRIPTION
Fix Bio package default share allowing canView for All users