### PR TITLE
atanas/GROK-12547: Bio: fix detect macromolecule and tests

### DIFF
--- a/packages/Bio/detectors.js
+++ b/packages/Bio/detectors.js
@@ -181,6 +181,7 @@ class BioPackageDetectors extends DG.Package {
 
         // TODO: If separator detected, then extra efforts to detect alphabet are allowed.
         const alphabet = this.detectAlphabet(stats.freq, candidateAlphabets, gapSymbol);
+        if (units === NOTATION.FASTA && alphabet === ALPHABET.UN && !alphabetIsMultichar) return null;
 
         // const forbidden = this.checkForbiddenWoSeparator(stats.freq);
         col.setTag(DG.TAGS.UNITS, units);

--- a/packages/Bio/detectors.js
+++ b/packages/Bio/detectors.js
@@ -44,6 +44,10 @@ const UnitsHandler = {
 const isUrlRe = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/i;
 
 class BioPackageDetectors extends DG.Package {
+
+  /** Parts of the column name required in the column's name under the detector. It must be in lowercase. */
+  requiredColNamePartList = ['seq', 'msa', 'dna', 'rna', 'fasta', 'helm', 'sense', 'protein'];
+
   peptideFastaAlphabet = new Set([
     'G', 'L', 'Y', 'S', 'E', 'Q', 'D', 'N', 'F', 'A',
     'K', 'R', 'H', 'C', 'V', 'P', 'W', 'I', 'M', 'T',
@@ -84,6 +88,11 @@ class BioPackageDetectors extends DG.Package {
   detectMacromolecule(col) {
     const t1 = Date.now();
     try {
+      const colName = col.name;
+      if (!this.requiredColNamePartList.some(
+        (requiredColNamePart) => colName.toLowerCase().includes(requiredColNamePart),
+      )) return null;
+
       // Fail early
       if (col.type !== DG.TYPE.STRING) return null;
 

--- a/packages/Bio/package.json
+++ b/packages/Bio/package.json
@@ -5,7 +5,7 @@
     "name": "Leonid Stolbov",
     "email": "lstolbov@datagrok.ai"
   },
-  "version": "2.3.10",
+  "version": "2.3.11",
   "description": "Bioinformatics support (import/export of sequences, conversion, visualization, analysis). [See more](https://github.com/datagrok-ai/public/blob/master/packages/Bio/README.md) for details.",
   "repository": {
     "type": "git",
@@ -24,6 +24,7 @@
     "dayjs": "^1.11.4",
     "openchemlib": "6.0.1",
     "rxjs": "^6.5.5",
+    "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.1",
     "wu": "latest"
   },

--- a/packages/Bio/src/package.ts
+++ b/packages/Bio/src/package.ts
@@ -297,7 +297,7 @@ export function SeqActivityCliffsEditor(call: DG.FuncCall) {
   const funcEditor = new ActivityCliffsFunctionEditor(DG.SEMTYPE.MACROMOLECULE);
   ui.dialog({title: 'Activity Cliffs'})
     .add(funcEditor.paramsUI)
-    .onOK(async () => {      
+    .onOK(async () => {
       call.func.prepare(funcEditor.funcParams).call(true);
     })
     .show();
@@ -352,7 +352,7 @@ export function SequenceSpaceEditor(call: DG.FuncCall) {
   const funcEditor = new SequenceSpaceFunctionEditor(DG.SEMTYPE.MACROMOLECULE);
   ui.dialog({title: 'Sequence Space'})
     .add(funcEditor.paramsUI)
-    .onOK(async () => {      
+    .onOK(async () => {
       call.func.prepare(funcEditor.funcParams).call(true);
     })
     .show();
@@ -704,7 +704,7 @@ export function similaritySearchViewer(): SequenceSimilarityViewer {
 //output: viewer result
 export function similaritySearchTopMenu(): void {
   const view = (grok.shell.v as DG.TableView);
-  const viewer = view.addViewer('SequenceSimilaritySearchViewer');
+  const viewer = view.addViewer('Sequence Similarity Search');
   view.dockManager.dock(viewer, 'down');
 }
 
@@ -722,7 +722,7 @@ export function diversitySearchViewer(): SequenceDiversityViewer {
 //output: viewer result
 export function diversitySearchTopMenu() {
   const view = (grok.shell.v as DG.TableView);
-  const viewer = view.addViewer('SequenceDiversitySearchViewer');
+  const viewer = view.addViewer('Sequence Diversity Search');
   view.dockManager.dock(viewer, 'down');
 }
 

--- a/packages/Bio/src/tests/detectors-tests.ts
+++ b/packages/Bio/src/tests/detectors-tests.ts
@@ -148,11 +148,11 @@ MWRSWY-CKHP
     testSmilesShort = 'testSmilesShort',
     testCerealCsv = 'testCerealCsv',
     testActivityCliffsCsv = 'testActivityCliffsCsv',
-    testSpgi100 = 'testSpgi100',
     testUnichemSources = 'testUnichemSources',
     testDmvOffices = 'testDmvOffices',
     testAlertCollection = 'testAlertCollection',
     testSpgi = 'testSpgi',
+    testSpgi100 = 'testSpgi100',
     testUrl = 'testUrl',
   }
 
@@ -172,10 +172,10 @@ MWRSWY-CKHP
     [Samples.testSmilesShort]: 'System:AppData/Bio/tests/testSmilesShort.csv',
     [Samples.testActivityCliffsCsv]: 'System:AppData/Bio/tests/testActivityCliffs.csv', // smiles
     [Samples.testCerealCsv]: 'System:AppData/Bio/tests/testCereal.csv',
-    [Samples.testSpgi100]: 'System:AppData/Bio/tests/testSpgi100.csv',
     [Samples.testUnichemSources]: 'System:AppData/Bio/tests/testUnichemSources.csv',
     [Samples.testDmvOffices]: 'System:AppData/Bio/tests/testDmvOffices.csv',
     [Samples.testAlertCollection]: 'System:AppData/Bio/tests/testAlertCollection.csv',
+    [Samples.testSpgi100]: 'System:AppData/Bio/tests/testSpgi100.csv',
     [Samples.testSpgi]: 'System:AppData/Bio/tests/SPGI-derived.csv',
     [Samples.testUrl]: 'System:AppData/Bio/tests/testUrl.csv',
   };
@@ -276,160 +276,108 @@ MWRSWY-CKHP
       NOTATION.SEPARATOR, ALIGNMENT.SEQ_MSA, ALPHABET.DNA, 4, false, '-');
   });
 
-  test('SamplesFastaCsvPt', async () => {
-    await _testPos(readSamples(Samples.fastaCsv), 'sequence',
-      NOTATION.FASTA, ALIGNMENT.SEQ, ALPHABET.PT, 20, false);
-  });
-  test('SamplesFastaCsvNegativeEntry', async () => {
-    await _testNeg(readSamples(Samples.fastaCsv), 'Entry');
-  });
-  test('SamplesFastaCsvNegativeLength', async () => {
-    await _testNeg(readSamples(Samples.fastaCsv), 'Length');
-  });
-  test('SamplesFastaCsvNegativeUniProtKB', async () => {
-    await _testNeg(readSamples(Samples.fastaCsv), 'UniProtKB');
+  test('samplesFastaCsv', async () => {
+    await _testDf(readSamples(Samples.fastaCsv), {
+      'Sequence': new PosCol(NOTATION.FASTA, ALIGNMENT.SEQ, ALPHABET.PT, 20, false),
+    });
   });
 
-  test('SamplesFastaFastaPt', async () => {
-    await _testPos(readSamples(Samples.fastaFasta, readFileFasta),
-      'sequence', NOTATION.FASTA, ALIGNMENT.SEQ, ALPHABET.PT, 20, false);
+  test('samplesFastaFasta', async () => {
+    await _testDf(readSamples(Samples.fastaFasta), {
+      'sequence': new PosCol(NOTATION.FASTA, ALIGNMENT.SEQ, ALPHABET.PT, 20, false),
+    });
   });
 
   // peptidesComplex contains monomers with spaces in AlignedSequence columns, which are forbidden
   // test('samplesPeptidesComplexPositiveAlignedSequence', async () => {
   //   await _testPos(readSamples(Samples.peptidesComplex), 'AlignedSequence', 'separator:SEQ:UN', '-');
   // });
-  test('samplesPeptidesComplexNegativeID', async () => {
-    await _testNeg(readSamples(Samples.peptidesComplex), 'ID');
-  });
-  test('SamplesPeptidesComplexNegativeMeasured', async () => {
-    await _testNeg(readSamples(Samples.peptidesComplex), 'Measured');
-  });
-  test('SamplesPeptidesComplexNegativeValue', async () => {
-    await _testNeg(readSamples(Samples.peptidesComplex), 'Value');
+  test('samplesPeptidesComplex', async () => {
+    await _testDf(readSamples(Samples.peptidesComplex), {} /* no positive */);
   });
 
-  test('samplesMsaComplexUn', async () => {
-    await _testPos(readSamples(Samples.msaComplex), 'MSA',
-      NOTATION.SEPARATOR, ALIGNMENT.SEQ_MSA, ALPHABET.UN, 161, true, '/');
-  });
-  test('samplesMsaComplexNegativeActivity', async () => {
-    await _testNeg(readSamples(Samples.msaComplex), 'Activity');
+  test('samplesMsaComplex', async () => {
+    await _testDf(readSamples(Samples.msaComplex), {
+      'MSA': new PosCol(NOTATION.SEPARATOR, ALIGNMENT.SEQ_MSA, ALPHABET.UN, 161, true, '/'),
+    });
   });
 
-  test('samplesIdCsvNegativeID', async () => {
-    await _testNeg(readSamples(Samples.testIdCsv), 'ID');
+  test('samplesIdCsv', async () => {
+    await _testDf(readSamples(Samples.testIdCsv), {} /* no positive */);
   });
 
-  test('samplesSarSmallCsvNegativeSmiles', async () => {
-    await _testNeg(readSamples(Samples.testSmilesCsv), 'smiles');
+  test('samplesSarSmallCsv', async () => {
+    await _testDf(readSamples(Samples.testSmilesCsv), {} /* nopositive */);
   });
 
-  test('samplesHelmCsvHELM', async () => {
-    await _testPos(readSamples(Samples.helmCsv), 'HELM',
-      NOTATION.HELM, null, null, 160, true, null);
+  test('samplesHelmCsv', async () => {
+    await _testDf(readSamples(Samples.helmCsv), {
+      'HELM': new PosCol(NOTATION.HELM, null, null, 160, true),
+    });
   });
 
-  test('samplesHelmCsvNegativeActivity', async () => {
-    await _testNeg(readSamples(Samples.helmCsv), 'Activity');
-  });
-
-  // sample_testHelm.csb
+  // sample_testHelm.csv
   // columns: ID,Test type,HELM string,Valid?,Mol Weight,Mol Formula,SMILES
-  test('samplesTestHelmNegativeID', async () => {
-    await _testNeg(readSamples(Samples.testHelmCsv), 'ID');
-  });
-  test('samplesTestHelmNegativeTestType', async () => {
-    await _testNeg(readSamples(Samples.testHelmCsv), 'Test type');
-  });
-  test('samplesTestHelmPositiveHelmString', async () => {
-    await _testPos(readSamples(Samples.testHelmCsv), 'HELM string', NOTATION.HELM, null, null, 9, true, null);
-  });
-  test('samplesTestHelmNegativeValid', async () => {
-    await _testNeg(readSamples(Samples.testHelmCsv), 'Valid?');
-  });
-  test('samplesTestHelmNegativeMolWeight', async () => {
-    await _testNeg(readSamples(Samples.testHelmCsv), 'Mol Weight');
-  });
-  test('samplesTestHelmNegativeMolFormula', async () => {
-    await _testNeg(readSamples(Samples.testHelmCsv), 'Mol Formula');
-  });
-  test('samplesTestHelmNegativeSmiles', async () => {
-    await _testNeg(readSamples(Samples.testHelmCsv), 'Smiles');
+  test('samplesTestHelmCsv', async () => {
+    await _testDf(readSamples(Samples.testHelmCsv), {
+      'HELM string': new PosCol(NOTATION.HELM, null, null, 9, true),
+    });
   });
 
-  test('samplesTestDemogNegativeAll', async () => {
-    const dfFunc: DfReaderFunc = readSamples(Samples.testDemogCsv);
-    const df: DG.DataFrame = await dfFunc();
-
-    for (const col of df.columns.toList())
-      await _testNeg(dfFunc, col.name);
+  test('samplesTestDemogCsv', async () => {
+    await _testDf(readSamples(Samples.testDemogCsv), {} /* no positive */);
   });
 
-  test('samplesTestSmiles2NegativeSmiles', async () => {
-    await _testNeg(readSamples(Samples.testSmiles2Csv), 'SMILES');
+  test('samplesTestSmiles2Csv', async () => {
+    await _testDf(readSamples(Samples.testSmiles2Csv), {} /* no positive */);
   });
 
-  test('samplesTestSmilesShortNegativeSmiles', async () => {
-    await _testNeg(readSamples(Samples.testSmilesShort), 'SMILES');
+  test('samplesTestSmilesShort', async () => {
+    await _testDf(readSamples(Samples.testSmilesShort), {} /* no positive */);
   });
 
   test('samplesTestActivityCliffsNegativeSmiles', async () => {
-    await _testNeg(readSamples(Samples.testActivityCliffsCsv), 'smiles');
+    await _testDf(readSamples(Samples.testActivityCliffsCsv), {} /* no positive */);
   });
 
-  test('samplesFastaPtPosSequence', async () => {
-    await _testPos(readSamples(Samples.fastaPtCsv), 'sequence',
-      NOTATION.FASTA, ALIGNMENT.SEQ, ALPHABET.PT, 20, false);
+  test('samplesFastaPtCsv', async () => {
+    await _testDf(readSamples(Samples.fastaPtCsv), {
+      'sequence': new PosCol(NOTATION.FASTA, ALIGNMENT.SEQ, ALPHABET.PT, 20, false),
+    });
   });
 
-  test('samplesTestCerealNegativeCerealName', async () => {
-    await _testNeg(readSamples(Samples.testCerealCsv), 'cereal_name');
+  test('samplesTestCerealCsv', async () => {
+    await _testDf(readSamples(Samples.testCerealCsv), {} /* no positive */);
   });
 
-  test('samplesTestSpgi100NegativeStereoCategory', async () => {
-    await _testNeg(readSamples(Samples.testSpgi100), 'Stereo Category');
-  });
-  test('samplesTestSpgi100NegativeScaffoldNames', async () => {
-    await _testNeg(readSamples(Samples.testSpgi100), 'Scaffold Names');
-  });
-  test('samplesTestSpgi100NegativePrimaryScaffoldName', async () => {
-    await _testNeg(readSamples(Samples.testSpgi100), 'Primary Scaffold Name');
-  });
-  test('samplesTestSpgi100NegativeSampleName', async () => {
-    await _testNeg(readSamples(Samples.testSpgi100), 'Sample Name');
+  test('samplesTestUnichemSources', async () => {
+    await _testDf(readSamples(Samples.testUnichemSources), {} /* no positive */);
   });
 
-  test('samplesTestUnichemSourcesNegativeSrcUrl', async () => {
-    await _testNeg(readSamples(Samples.testUnichemSources), 'src_url');
-  });
-  test('samplesTestUnichemSourcesNegativeBaseIdUrl', async () => {
-    await _testNeg(readSamples(Samples.testUnichemSources), 'base_id_url');
+  test('samplesTestDmvOffices', async () => {
+    await _testDf(readSamples(Samples.testDmvOffices), {} /* no positive */);
   });
 
-  test('samplesTestDmvOfficesNegativeOfficeName', async () => {
-    await _testNeg(readSamples(Samples.testDmvOffices), 'Office Name');
-  });
-  test('samplesTestDmvOfficesNegativeCity', async () => {
-    await _testNeg(readSamples(Samples.testDmvOffices), 'City');
+  test('samplesTestAlertCollection', async () => {
+    await _testDf(readSamples(Samples.testAlertCollection), {} /* no positive */);
   });
 
-  test('samplesTestAlertCollectionNegativeSmarts', async () => {
-    await _testNeg(readSamples(Samples.testAlertCollection), 'smarts');
+  test('samplesTestSpgi', async () => {
+    await _testDf(readSamples(Samples.testSpgi), {} /* no positive */);
   });
 
-  test('samplesTestSpgiNegativeVals', async () => {
-    await _testNeg(readSamples(Samples.testSpgi), 'vals');
+  test('samplesTestSpgi100', async () => {
+    await _testDf(readSamples(Samples.testSpgi100), {} /* no positive */);
   });
 
-  test('samplesTestUrlNegativeSeq', async () => {
-    await _testNeg(readSamples(Samples.testUrl), 'url');
+  test('samplesTestUrl', async () => {
+    await _testDf(readSamples(Samples.testUrl), {} /* no positive */);
   });
 });
 
 export async function _testNeg(readDf: DfReaderFunc, colName: string) {
   const df: DG.DataFrame = await readDf();
-  const col: DG.Column = df.col(colName)!;
+  const col: DG.Column = df.getCol(colName)!;
   const semType: string = await grok.functions
     .call('Bio:detectMacromolecule', {col: col}) as unknown as string;
   if (semType)
@@ -470,4 +418,42 @@ export async function _testPos(
     expect(uh.aligned, aligned);
     expect(uh.alphabet, alphabet);
   }
+}
+
+class PosCol {
+  constructor(
+    public readonly units: string,
+    public readonly aligned: string | null,
+    public readonly alphabet: string | null,
+    public readonly alphabetSize: number,
+    public readonly alphabetIsMultichar: boolean,
+    public readonly separator?: string
+  ) { };
+};
+
+export async function _testDf(readDf: DfReaderFunc, posCols: { [colName: string]: PosCol }): Promise<void> {
+  const df: DG.DataFrame = await readDf();
+  const errList: string[] = [];
+  for (const colName of df.columns.names()) {
+    if (colName in posCols) {
+      const p = posCols[colName];
+      try {
+        await _testPos(readDf, colName, p.units, p.aligned, p.alphabet,
+          p.alphabetSize, p.alphabetIsMultichar, p.separator);
+      } catch (err: any) {
+        const errMsg: string = err.toString();
+        errList.push(`Positive col '${colName}' failed: ${errMsg}`);
+      }
+    } else {
+      try {
+        await _testNeg(readDf, colName);
+      } catch (err: any) {
+        const errMsg: string = err.toString();
+        errList.push(`Negative col '${colName}' failed: ${errMsg}`);
+      }
+    }
+  }
+
+  if (errList.length > 0)
+    throw new Error(errList.join('\n'));
 }

--- a/packages/Bio/src/tests/similarity-diversity-tests.ts
+++ b/packages/Bio/src/tests/similarity-diversity-tests.ts
@@ -31,9 +31,9 @@ category('similarity/diversity', async () => {
 
 async function _testSimilaritySearchViewer() {
   const molecules = await createTableView('tests/sample_MSA_data.csv');
-  const viewer = molecules.addViewer('SequenceSimilaritySearchViewer');
+  const viewer = molecules.addViewer('Sequence Similarity Search');
   await delay(100);
-  const similaritySearchViewer = getSearchViewer(viewer, 'SequenceSimilaritySearchViewer');
+  const similaritySearchViewer = getSearchViewer(viewer, 'Sequence Similarity Search');
   viewList.push(similaritySearchViewer);
   viewList.push(molecules);
   if (!similaritySearchViewer.molCol)
@@ -59,9 +59,9 @@ async function _testSimilaritySearchViewer() {
 
 async function _testDiversitySearchViewer() {
   const molecules = await createTableView('tests/sample_MSA_data.csv');
-  const viewer = molecules.addViewer('SequenceDiversitySearchViewer');
+  const viewer = molecules.addViewer('Sequence Diversity Search');
   await delay(10);
-  const diversitySearchviewer = getSearchViewer(viewer, 'SequenceDiversitySearchViewer');
+  const diversitySearchviewer = getSearchViewer(viewer, 'Sequence Diversity Search');
   viewList.push(diversitySearchviewer);
   viewList.push(molecules);
   if (!diversitySearchviewer.renderMolIds)

--- a/packages/Bio/tsconfig.json
+++ b/packages/Bio/tsconfig.json
@@ -1,74 +1,73 @@
 {
-    "compilerOptions": {
-      /* Visit https://aka.ms/tsconfig.json to read more about this file */
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
-      /* Basic Options */
-      // "incremental": true,                         /* Enable incremental compilation */
-      "target": "es6",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-      "module": "es2020",                             /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-      "lib": ["es2020", "dom", "ES2021.String"],      /* Specify library files to be included in the compilation. */
-      // "allowJs": true,                             /* Allow javascript files to be compiled. */
-      // "checkJs": true,                             /* Report errors in .js files. */
-      // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
-      "declaration": true,                            /* Generates corresponding '.d.ts' file. */
-      "declarationMap": true,                         /* Generates a sourcemap for each corresponding '.d.ts' file. */
-      "sourceMap": true,                              /* Generates corresponding '.map' file. */
-      // "outFile": "./",                             /* Concatenate and emit output to single file. */
-      // "outDir": "./",                              /* Redirect output structure to the directory. */
-      // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-      // "composite": true,                           /* Enable project compilation */
-      // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
-      // "removeComments": true,                      /* Do not emit comments to output. */
-      // "noEmit": true,                              /* Do not emit outputs. */
-      // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
-      // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-      // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    /* Basic Options */
+    // "incremental": true,                         /* Enable incremental compilation */
+    "target": "es6",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "es2020",                             /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "lib": ["es2020", "dom", "ES2021.String"],      /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                             /* Allow javascript files to be compiled. */
+    // "checkJs": true,                             /* Report errors in .js files. */
+    // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
+    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                              /* Generates corresponding '.map' file. */
+    // "outFile": "./",                             /* Concatenate and emit output to single file. */
+    // "outDir": "./",                              /* Redirect output structure to the directory. */
+    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                           /* Enable project compilation */
+    // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
+    // "removeComments": true,                      /* Do not emit comments to output. */
+    // "noEmit": true,                              /* Do not emit outputs. */
+    // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
-      /* Strict Type-Checking Options */
-      "strict": true,                                 /* Enable all strict type-checking options. */
-      // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
-      // "strictNullChecks": true,                    /* Enable strict null checks. */
-      // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
-      // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-      "strictPropertyInitialization": false,          /* Enable strict checking of property initialization in classes. */
-      // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
-      // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
+    /* Strict Type-Checking Options */
+    "strict": true,                                 /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                    /* Enable strict null checks. */
+    // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    "strictPropertyInitialization": false,          /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
 
-      /* Additional Checks */
-      // "noUnusedLocals": true,                      /* Report errors on unused locals. */
-      // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
-      // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
-      // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
-      // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
-      // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+    /* Additional Checks */
+    // "noUnusedLocals": true,                      /* Report errors on unused locals. */
+    // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+    // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
+    // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
-      /* Module Resolution Options */
-      "moduleResolution": "node",                     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-      // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
-      // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-      // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
-      // "typeRoots": [],                             /* List of folders to include type definitions from. */
-      // "types": [],                                 /* Type declaration files to be included in compilation. */
-      // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-      "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-      // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
-      // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
+    /* Module Resolution Options */
+    "moduleResolution": "node",                     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                             /* List of folders to include type definitions from. */
+    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
 
-      /* Source Map Options */
-      // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-      // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
-      // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
-      // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    /* Source Map Options */
+    // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
-      /* Experimental Options */
-      // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
-      // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
+    /* Experimental Options */
+    // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
 
-      /* Advanced Options */
-      "skipLibCheck": false,                          /* Skip type checking of declaration files. */
-      "forceConsistentCasingInFileNames": true,
-      /* Disallow inconsistently-cased references to the same file. */
-      //"jsx": "react"
-    }
+    /* Advanced Options */
+    "skipLibCheck": false,                          /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true,
+    /* Disallow inconsistently-cased references to the same file. */
+    //"jsx": "react"
   }
-  
+}

--- a/packages/Bio/webpack.config.js
+++ b/packages/Bio/webpack.config.js
@@ -17,15 +17,9 @@ module.exports = {
   },
   module: {
     rules: [
-      {
-        test: /\.ts(x?)$/,
-        use: 'ts-loader',
-        exclude: /node_modules/,
-      },
-      {
-        test: /\.css$/,
-        use: ['style-loader', 'css-loader'],
-      },
+      {test: /\.js$/, enforce: 'pre', use: ['source-map-loader']},
+      {test: /\.ts(x?)$/, use: 'ts-loader', exclude: /node_modules/},
+      {test: /\.css$/, use: ['style-loader', 'css-loader']},
     ],
   },
   devtool: 'source-map',


### PR DESCRIPTION
The detectMacromolecule is too aggressive.

The Detector will not recognize the notation ‘fasta’ with the alphabet 'UN' non-multichar, because words of the natural language are too similar to oligomers (notation fasta with alphabet UN non-multichar).

Tests for detectMacromolecule require a fix to test all available non-positive columns for false positive results.

Enable the use of required column name parts.
