### PR TITLE
Do not overwrite col.temp entirely while updating version and molIds

### DIFF
--- a/packages/Chem/src/package.ts
+++ b/packages/Chem/src/package.ts
@@ -150,10 +150,10 @@ export async function chemTooltip(col: DG.Column): Promise<DG.Widget | undefined
     const molIds = await chemDiversitySearch(
       col, similarityMetric['Tanimoto'], 9, 'Morgan' as Fingerprint, true);
 
-    col.temp = {
+    Object.assign(col.temp, {
       'version': version,
       'molIds': molIds
-    }
+    });
   }
 
   const molIdsCached = col.temp['molIds'];


### PR DESCRIPTION
This PR fixes a major regression in the `Chem` package where molecules fail to align to scaffolds after a tooltip is displayed.
@StLeonidas @MariaDolotova It would be great if this could be merged ASAP. Thanks in advance!