### PR TITLE
GROK-12827: Dendrogram: Add option to reset view

### DIFF
--- a/packages/Dendrogram/package.json
+++ b/packages/Dendrogram/package.json
@@ -5,7 +5,7 @@
     "name": "Aleksandr Tanas",
     "email": "atanas@datagrok.ai"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Computation and visualization of hierarchical data clustering. [Learn more](https://github.com/datagrok-ai/public/blob/master/packages/Dendrogram/README.md)",
   "dependencies": {
     "@datagrok-libraries/bio": "^5.26.0",

--- a/packages/Dendrogram/src/viewers/dendrogram.ts
+++ b/packages/Dendrogram/src/viewers/dendrogram.ts
@@ -387,8 +387,15 @@ export class Dendrogram extends DG.JsViewer implements IDendrogram {
     this.viewSubs.push(this.dataFrame.onSelectionChanged.subscribe(this.dataFrameOnSelectionChanged.bind(this)));
     this.viewSubs.push(this.dataFrame.onCurrentRowChanged.subscribe(this.dataFrameOnCurrentRowChanged.bind(this)));
     this.viewSubs.push(this.dataFrame.onMouseOverRowChanged.subscribe(this.dataFrameOnMouseOverRowChanged.bind(this)));
+
+    this.viewSubs.push(this.onContextMenu.subscribe(this.onContextMenuHandler.bind(this)));
   }
 
+  private onContextMenuHandler(menu: DG.Menu): void {
+    menu.item('Reset view', () =>{
+      this._renderer?.onResetZoom();
+    });
+  }
   // -- Handle controls events --
 
   private rootOnSizeChanged(): void {

--- a/packages/Dendrogram/src/viewers/tree-renderers/canvas-tree-renderer.ts
+++ b/packages/Dendrogram/src/viewers/tree-renderers/canvas-tree-renderer.ts
@@ -354,16 +354,15 @@ export class CanvasTreeRenderer<TNode extends MarkupNodeType>
 
           this.selections = selections;
         }
-      } else 
-        this.current = this.mouseOver;
+      } else this.current = this.mouseOver; 
 
       if (!this.current) {
-        this.clickCounter +=1;
+        this.clickCounter += 1;
         if (this.clickCounter === 2) {
           this.clickCounter = 0;
           this.onResetZoom();
         }
-        setTimeout(() =>{
+        setTimeout(() => {
           this.clickCounter = 0;
         }, 300);
       }

--- a/packages/Dendrogram/src/viewers/tree-renderers/canvas-tree-renderer.ts
+++ b/packages/Dendrogram/src/viewers/tree-renderers/canvas-tree-renderer.ts
@@ -42,7 +42,9 @@ export class CanvasTreeRenderer<TNode extends MarkupNodeType>
   protected _mainStyler: ITreeStyler<TNode>;
   protected _mainStylerOnChangedSub!: rxjs.Unsubscribable;
 
-  get mainStyler(): ITreeStyler<TNode> { return this._mainStyler; }
+  get mainStyler(): ITreeStyler<TNode> {
+    return this._mainStyler;
+  }
 
   set mainStyler(value: ITreeStyler<TNode>) {
     if (this.view)
@@ -130,7 +132,9 @@ export class CanvasTreeRenderer<TNode extends MarkupNodeType>
       if (this.treeRoot) {
         const styler: ITreeStyler<TNode> = !this.mouseOver ? this._mainStyler : this.lightStyler;
         const selectionTraceList: TraceTargetType<TNode>[] = this.selections.map(
-          (sel) => { return {target: sel.node, styler: this.selectionStyler}; });
+          (sel) => {
+            return {target: sel.node, styler: this.selectionStyler};
+          });
         renderNode(
           {
             ctx: ctx, firstRowIndex: this.placer.top, lastRowIndex: this.placer.bottom,
@@ -311,14 +315,16 @@ export class CanvasTreeRenderer<TNode extends MarkupNodeType>
       // console.debug('CanvasTreeRender.onMouseMove() --- getNode() ---');
       this.mouseOver = !this.treeRoot ? null : this.placer.getNode(
         this.treeRoot, canvasPoint, this._mainStyler.lineWidth, this._mainStyler.nodeSize,
-        (canvasP: DG.Point): DG.Point => { return treeToCanvasPoint(canvasP, this.canvas!, this.placer); });
+        (canvasP: DG.Point): DG.Point => {
+          return treeToCanvasPoint(canvasP, this.canvas!, this.placer);
+        });
 
       this._mainStyler.fireTooltipShow(this.mouseOver ? this.mouseOver.node : null, e);
     }
   }
 
   //used for double click detection
-  protected clickCounter:number = 0;
+  protected clickCounter: number = 0;
 
   protected canvasOnClick(e: MouseEvent): void {
     if (e.button == 0) {
@@ -348,12 +354,12 @@ export class CanvasTreeRenderer<TNode extends MarkupNodeType>
 
           this.selections = selections;
         }
-      } else {
+      } else 
         this.current = this.mouseOver;
-      }
+
       if (!this.current) {
         this.clickCounter +=1;
-        if (this.clickCounter == 2) {
+        if (this.clickCounter === 2) {
           this.clickCounter = 0;
           this.onResetZoom();
         }


### PR DESCRIPTION
Add context menu option to dendrogram for resetting the view back to default (after moving around and zooming).
Same reset happens when user double-clicks on 'white space'
