### PR TITLE
Fix #1829

### DIFF
--- a/packages/Chem/src/utils/chem-common-rdkit.ts
+++ b/packages/Chem/src/utils/chem-common-rdkit.ts
@@ -113,7 +113,7 @@ export function drawRdKitMoleculeToOffscreenCanvas(
     return;
   }
 
-  const opts = createRenderingOpts({width: Math.ceil(w), height: Math.ceil(h)});
+  const opts = createRenderingOpts({width: Math.floor(w), height: Math.floor(h)});
 
   g?.clearRect(0,0, w, h);
   if (substruct)
@@ -148,6 +148,11 @@ export function drawRdKitReactionToOffscreenCanvas(
 export function drawMoleculeToCanvas(x: number, y: number, w: number, h: number,
   onscreenCanvas: HTMLCanvasElement, molString: string, scaffoldMolString: string | null = null,
   options = {normalizeDepiction: true, straightenDepiction: true}) {
+
+  if (!w || !h) {
+    console.error('Width and height cannot be zero.');
+    return;
+  }
 
   $(onscreenCanvas).addClass('chem-canvas');
   const r = window.devicePixelRatio;


### PR DESCRIPTION
@MariaDolotova this is my proposal to fix #1829: `drawMoleculeToCanvas` should do nothing and print an error message to console if width or height are 0.

- reverted `ceil` to `floor`
- if width or height are 0, `drawMoleculeToCanvas` should be a no-op
