### PR TITLE
Fix has coords regression

### DIFF
--- a/libraries/chem-meta/src/rdkit-api.ts
+++ b/libraries/chem-meta/src/rdkit-api.ts
@@ -45,7 +45,7 @@ export interface RDMol {
   get_morgan_fp_as_uint8array(radius: number, fplen: number): Uint8Array;
 
   is_valid(): boolean;
-  has_coords(): boolean;
+  has_coords(): number;
 
   get_stereo_tags(): string;
   get_aromatic_form(): string;

--- a/packages/Chem/src/rendering/rdkit-cell-renderer.ts
+++ b/packages/Chem/src/rendering/rdkit-cell-renderer.ts
@@ -105,7 +105,7 @@ M  END
     if (mol !== null) {
       try {
         if (mol.is_valid()) {
-          let molHasOwnCoords = mol.has_coords();
+          let molHasOwnCoords = !!mol.has_coords();
           const scaffoldIsMolBlock = DG.chem.isMolBlock(scaffoldMolString);
           if (scaffoldIsMolBlock) {
             const rdKitScaffoldMolCtx = this._fetchMol(scaffoldMolString, '', molRegenerateCoords, false, {mergeQueryHs: true, isSubstructure: true}).molCtx;

--- a/packages/Chem/src/utils/chem-common-rdkit.ts
+++ b/packages/Chem/src/utils/chem-common-rdkit.ts
@@ -27,7 +27,7 @@ const RDKIT_COMMON_RENDER_OPTS: {[key: string]: any} = {
   minFontSize: -1,
   maxFontSize: -1,
   annotationFontScale: 0.7,
-  highlightBondWidthMultiplier: 12,
+  highlightBondWidthMultiplier: 20,
   dummyIsotopeLabels: false,
   atomColourPalette: {
     0: [0.1, 0.1, 0.1],
@@ -42,6 +42,7 @@ const RDKIT_COMMON_RENDER_OPTS: {[key: string]: any} = {
     35: [0.0, 0.498, 0.0],
     53: [0.247, 0.0, 0.498],
   },
+  highlightColour: [1.0, 0.7, 0.7, 1.0],
   backgroundColour: [1, 1, 1, 1],
   queryColour: [0, 0, 0, 1],
 };

--- a/packages/Chem/src/utils/mol-creation_rdkit.ts
+++ b/packages/Chem/src/utils/mol-creation_rdkit.ts
@@ -62,12 +62,12 @@ export function getMolSafe(molString: string, details: object = {}, rdKitModule:
       return { mol, kekulize, isQMol, useMolBlockWedging };
     }
     if (mol.is_valid()) {
-      useMolBlockWedging = mol.has_coords();
+      useMolBlockWedging = (mol.has_coords() === 2);
     }
     return { mol, kekulize, isQMol, useMolBlockWedging };
   }
   if (mol.is_valid()) {
-    useMolBlockWedging = mol.has_coords();
+    useMolBlockWedging = (mol.has_coords() === 2);
   } else {
     mol?.delete()
     mol = null;


### PR DESCRIPTION
This PR fixes a regression that I have just noticed (i.e., fonts getting noticeably larger when molecules are aligned to a scaffold) caused by the fact that `JSMol.has_coords()` does not return a `boolean` anymore, but a `number`, so code needs to be updated accordingly in a few places.
makes the highlighting halo around scaffold atoms a bit thicker and a bit lighter to improve visibility.

@StLeonidas @MariaDolotova this is an important one; could you please it is merged into `Chem` ASAP? Many thanks in advance.