### PR TITLE
JS API: Fixed FuncCall params typing

### DIFF
--- a/js-api/src/functions.ts
+++ b/js-api/src/functions.ts
@@ -210,6 +210,13 @@ export class Context {
   }
 }
 
+class FuncCallParams {
+  [name: string]: FuncCallParam,
+
+  //@ts-ignore
+  public values(): FuncCallParam[];
+}
+
 /** Represents a function call
  * {@link https://datagrok.ai/help/datagrok/functions/function-call*}
  * */
@@ -217,16 +224,16 @@ export class FuncCall extends Entity {
   public readonly dart: any;
 
   /** Named input values. See {@link inputParams} for parameter metadata. */
-  public inputs: {[name: string]: FuncCallParam};
+  public inputs: {[name: string]: any};
 
   /** Named output values. See {@link outputParams} for parameter metadata. */
-  public outputs: {[name: string]: FuncCallParam};
+  public outputs: {[name: string]: any};
 
   /** Input parameter metadata. See {@link inputs} for parameter values. */
-  public inputParams: {[name: string]: FuncCallParam};
+  public inputParams: FuncCallParams;
 
   /** Output parameter metadata. See {@link outputs} for parameter values. */
-  public outputParams: {[name: string]: FuncCallParam};
+  public outputParams: FuncCallParams;
 
   public aux: any;
   public options: any;


### PR DESCRIPTION
Checked typing by compiling `compute-utils` and `ApiTests`