### PR TITLE
Make the invalidated column key unique on table name

### DIFF
--- a/packages/Chem/src/chem-searches.ts
+++ b/packages/Chem/src/chem-searches.ts
@@ -81,8 +81,12 @@ function _chemGetDiversities(limit: number, molStringsColumn: DG.Column, fingerp
   return diversities;
 }
 
+function invalidatedColumnKey(col: DG.Column): string {
+  return col.dataFrame.name + '.' + col.name;
+}
+
 function colInvalidated(col: DG.Column, createMols: boolean): Boolean {
-  return (lastColumnInvalidated == col.name &&
+  return (lastColumnInvalidated == invalidatedColumnKey(col) &&
     col.getTag(FING_COL_TAGS.invalidatedForVersion) == String(col.version) &&
     (!createMols || col.getTag(FING_COL_TAGS.molsCreatedForVersion) == String(col.version)));
 }
@@ -93,7 +97,7 @@ async function _invalidate(molCol: DG.Column, createMols: boolean) {
       await (await getRdKitService()).initMoleculesStructures(molCol.toList());
       molCol.setTag(FING_COL_TAGS.molsCreatedForVersion, String(molCol.version + 2));
     }
-    lastColumnInvalidated = molCol.name;
+    lastColumnInvalidated = invalidatedColumnKey(molCol);
     molCol.setTag(FING_COL_TAGS.invalidatedForVersion, String(molCol.version + 1));
   }
 }


### PR DESCRIPTION
@StLeonidas @MariaDolotova This PR fixes a major bug which causes exceptions and misbehavior of the structure filter whenever there are multiple tables featuring molecule columns with the same name (e.g., `Structure`).
In such cases `lastColumnInvalidated` does not work as it should, and stale cache actually referring to a different column (but with the same name) is not invalidated, thus causing multiple problems (bogus results returned from structure filter) and exceptions thrown such as:
![image](https://github.com/datagrok-ai/public/assets/5244385/5b69672a-ceee-471f-935a-3495ab631224)

The fix is very simple: make the cache key unique on dataframe name _and_ column name.