### PR TITLE
rename set_aromatic_form to convert_to_aromatic_form

### DIFF
--- a/libraries/chem-meta/src/rdkit-api.ts
+++ b/libraries/chem-meta/src/rdkit-api.ts
@@ -70,9 +70,9 @@ export interface RDMol {
 
   get_stereo_tags(): string;
   get_aromatic_form(): string;
-  set_aromatic_form(): void;
+  convert_to_aromatic_form(): void;
   get_kekule_form(): string;
-  set_kekule_form(): void;
+  convert_to_kekule_form(): void;
   get_new_coords(useCoordGen?: boolean): string;
   set_new_coords(useCoordGen?: boolean): boolean;
   has_prop(key: string): boolean;

--- a/packages/Chem/src/rdkit-service/rdkit-service-worker-substructure.ts
+++ b/packages/Chem/src/rdkit-service/rdkit-service-worker-substructure.ts
@@ -61,7 +61,7 @@ export class RdKitServiceWorkerSubstructure extends RdKitServiceWorkerSimilarity
       else {
         try {
           queryMol = this._rdKitModule.get_qmol(queryMolString);
-          queryMol.set_aromatic_form();
+          queryMol.convert_to_aromatic_form();
         } catch (e) {
           if (queryMol) {
             queryMol.delete();

--- a/packages/Chem/src/rendering/rdkit-cell-renderer.ts
+++ b/packages/Chem/src/rendering/rdkit-cell-renderer.ts
@@ -92,7 +92,7 @@ M  END
       } else {
         try {
           mol = this.rdKitModule.get_qmol(molString);
-          mol.set_aromatic_form();
+          mol.convert_to_aromatic_form();
         } catch (e) {
           if (mol) {
             mol.delete();

--- a/packages/Chem/src/widgets/scaffold-tree.ts
+++ b/packages/Chem/src/widgets/scaffold-tree.ts
@@ -878,7 +878,7 @@ export class ScaffoldTreeViewer extends DG.JsViewer {
         let molArom;
         try {
           molArom = _rdKitModule.get_qmol(molStr);
-          molArom.set_aromatic_form();
+          molArom.convert_to_aromatic_form();
           this.molColumn.temp['chem-scaffold-filter'] = molArom.get_molblock();
         } catch (e) {
         } finally {


### PR DESCRIPTION
The `Chem` package is currently broken as the `1.2.8` version of MinimalLib features this API change compared to the previous version.
@MariaDolotova @StLeonidas Could you please apply this fix ASAP to avoid building a broken `Chem` package?
Thanks in advance!