### PR TITLE
GROK-13754: Help docs github workflow: Reorganized and improved

### DIFF
--- a/help/develop/help-pages/github-workflow.mdx
+++ b/help/develop/help-pages/github-workflow.mdx
@@ -8,133 +8,32 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 ```
 
-## GitHub Actions Docusaurus workflow
-
-[GitHub Actions Docusaurus workflow](https://github.com/datagrok-ai/public/actions/workflows/docusaurus.yaml) includes:
-
-* Lint checks using [markdownlint](https://github.com/DavidAnson/markdownlint-cli2) linter.
-* If the checks are finished successfully, GitHub will convert the markdown files to HTML
-  using [Docusaurus](https://docusaurus.io/)
-  * The result HTML help pages are also available as GitHub Actions artifact: `docusaurus`
-* Then [Hyperlink](https://github.com/untitaker/hyperlink) checks the result HTML files.
-* If the checks are finished successfully and the changes are in the master branch,  GitHub Actions will deploy the documentation to the server.
-  * 'Deploy to server' step contains detailed information about changes that are made on the server.
-* Finally, GitHub Actions performs Typesense DocSearch Scrape to update indexes for search in the wiki
-
-If any error occurs during checks, the deployment to the server will be canceled. Check for errors in the GitHub Actions log or in GitHub Actions run summary.
-
-More information about flow can be found on Docusaurus Help tab in [public repository CI/CD flows](../../deploy/releases/ci-flow.mdx#public-repository-cicd-flows).
-
-### Trigger GitHub Actions manually
-
-If an error occurred for the action triggered by the commit, it is possible to trigger the action manually.
-
-1. Use [Docusaurus workflow](https://github.com/datagrok-ai/public/actions/workflows/docusaurus.yaml).
-2. Press `run workflow`. Choose the target branch. Then `Run workflow`. Note that deployment to the server is executed for the master branch only.
-3. Check that the GitHub Actions workflow finished successfully.
-
-## Run docusaurus locally
+## Install Docusaurus and linting tools
 
 [Docusaurus](https://docusaurus.io/) is an optimized site generator. Docusaurus
 is a project for building, deploying, and maintaining open source project
 websites easily.
 
-### Requirements
+### 1. Install the latest stable NodeJS
 
-1. Install Node JS [v18.12.x](https://nodejs.org/dist/v18.12.0/)
-2. Upgrade npm to `v9.x.x`:
+Use instructions from the official
+[Node JS](https://nodejs.org/en/download) installation page.
+After installation check that the npm version is at least `v9.x.x`:
 
-    ```shell
-    npm install -g npm@9.x.x
-    ```
+```shell
+npm --version
+```
 
-### Local setup
+### 2. Install hyperlink checker and commit linting tools
 
-1. Open the terminal and change the current directory to the directory with docusaurus code:
+To check for incorrect hyperlinks, we use the hyperlink checker:
 
-    ```shell
-    cd docusaurus
-    ```
+```shell
+npm install --global @untitaker/hyperlink
+```
 
-2. Install package dependencies:
-
-    ```shell
-    npm install
-    ```
-
-3. As we use docusaurus to generate the API documentation, you need to repeat these installation steps in the `js-api` folder:
-
-   ```mdx-code-block
-   <Tabs>
-   <TabItem value="win" label="Windows">
-   ```
-
-    ```cmd
-    cd ..\js-api
-    npm install
-    ```
-
-   ```mdx-code-block
-   </TabItem>
-   <TabItem value="bash" label="Linux/MacOS" default>
-   ```
-
-    ```shell
-    cd ../js-api
-    npm install
-    ```
-
-   ```mdx-code-block
-   </TabItem>
-   </Tabs>
-   ```
-
-4. To run docusaurus locally and test the changes, run the following command:
-
-   ```mdx-code-block
-   <Tabs>
-   <TabItem value="win" label="Windows">
-   ```
-
-    ```cmd
-    cd ..\docusaurus
-    npm run start-debug
-    ```
-
-   ```mdx-code-block
-   </TabItem>
-   <TabItem value="bash" label="Linux/MacOS" default>
-   ```
-
-    ```shell
-    cd ../docusaurus
-    npm run start-debug
-    ```
-
-   ```mdx-code-block
-   </TabItem>
-   </Tabs>
-   ```
-
-    It will start the server and recompile the client
-    on every change you make. If the command does not work use `docusaurus start --config docusaurus-debug.config.js`.
-
-5. Docusaurus will be available at [http://localhost:3000](http://localhost:3000). If you don't see your changes immediately, reload the page.
-6. When you think the development is over and you want to commit the code, run the following command to check that the project builds without errors. Note that the build step will take some time.
-
-    ```shell
-    npm run build
-    ```
-
-   If the command does not work use `docusaurus build`.
-
-7. Now you can commit and push your changes to the repository.
-
-## Run linter locally
-
-### Markdown linter
-
-To lint and flag style issues in markdown files we use [markdownlint](https://github.com/DavidAnson/markdownlint).
+To lint and flag style issues in markdown files
+we use [markdownlint](https://github.com/DavidAnson/markdownlint).
 
 ```mdx-code-block
 <Tabs>
@@ -144,13 +43,14 @@ To lint and flag style issues in markdown files we use [markdownlint](https://gi
 1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2#install)
 
    ```bash
-   npm install markdownlint-cli2 --global
+   npm install --global markdownlint-cli2
    ```
 
-2. [Install](https://github.com/DavidAnson/vscode-markdownlint#install) Markdownlint [VSCode plugin](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
+2. [Install](https://github.com/DavidAnson/vscode-markdownlint#install)
+   Markdownlint [VSCode plugin](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
 
 3. [Configure autofix for issues](https://github.com/DavidAnson/vscode-markdownlint#fix)
-4. Show markdownlint warnings using shortcut: `Ctrl+Shift+M`/`Ctrl+Shift+M`/`⇧⌘M`
+4. Show markdownlint warnings using the shortcut: `Ctrl+Shift+M`/`Ctrl+Shift+M`/`⇧⌘M`
 
 ```mdx-code-block
 </TabItem>
@@ -160,7 +60,7 @@ To lint and flag style issues in markdown files we use [markdownlint](https://gi
 1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2#install)
 
    ```bash
-   npm install markdownlint-cli2 --global
+   npm install --global markdownlint-cli2
    ```
 
 2. Add MarkdownLint as [External Tool](https://www.jetbrains.com/help/idea/configuring-third-party-tools.html#local-ext-tools). `Preferences > Tools > External Tools > + (Add)`
@@ -176,9 +76,13 @@ To lint and flag style issues in markdown files we use [markdownlint](https://gi
 
 3. Now, to run MarkdownLint on the current file, you can click `Tools > External Tools > MarkdownLint`.
 
-4. _(Optional)_ To run MarkdownLint easier you can [add an icon to the toolbar](https://www.jetbrains.com/help/idea/customize-actions-menus-and-toolbars.html#customize-menus-and-toolbars). `Preferences > Appearance & Behavior > Menus and Toolbars > Main Toolbar > Toolbar Run Actions > + > Add Action... > External Tools > External Tools > MarkdownLint > OK`. Now, you can run Markdownlint from toolbar using icon.
+4. _(Optional)_ To run MarkdownLint easier you can [add an icon to the toolbar](https://www.jetbrains.com/help/idea/customize-actions-menus-and-toolbars.html#customize-menus-and-toolbars). 
+   `Preferences > Appearance & Behavior > Menus and Toolbars > Main Toolbar > Toolbar Run Actions > + > Add Action... > External Tools > External Tools > MarkdownLint > OK`. 
+   Now, you can run Markdownlint from the toolbar using the icon.
 
-5. _(Optional)_ To run MarkdownLint easier you can [add a shortcut](https://www.jetbrains.com/help/idea/configuring-keyboard-and-mouse-shortcuts.html). `Preferences > Keymap > External Tools > MarkdownLint > Right click > Add Keyboard Shortcut > Set the shortcut you like, for example, Ctrl+Shift+M/⌘⇧M`. Now, you can run Markdownlint using shortcut.
+5. _(Optional)_ To run MarkdownLint easier you can [add a shortcut](https://www.jetbrains.com/help/idea/configuring-keyboard-and-mouse-shortcuts.html). 
+   `Preferences > Keymap > External Tools > MarkdownLint > Right click > Add Keyboard Shortcut > Set the shortcut you like, for example, Ctrl+Shift+M/⌘⇧M`. 
+   Now, you can run Markdownlint using the shortcut.
 
 ```mdx-code-block
 </TabItem>
@@ -188,7 +92,7 @@ To lint and flag style issues in markdown files we use [markdownlint](https://gi
 1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2#install)
 
    ```bash
-   npm install markdownlint-cli2 --global
+   npm install --global markdownlint-cli2
    ```
 
 2. Run MarkdownLint using the following command
@@ -238,49 +142,172 @@ To lint and flag style issues in markdown files we use [markdownlint](https://gi
 </Tabs>
 ```
 
-### Links and anchors check
+### 3. Prepare Datagrok repository and Docusaurus
 
-Internal links and anchors are checked after the help package convert to HTML. To test it locally wou should convert markdown to HTML using [Docusaurus](https://docusaurus.io/) and then check all links using [hyperlink](https://github.com/untitaker/hyperlink).
+The source code and READMEs are located in our
+[public repository on GitHub](https://github.com/datagrok-ai/public/tree/master).
+This section helps you to set up this repository and install all required packages.
+
+1. Install commit linting tools as described in the [Git policy](../advanced/git-policy#commit-linting)
+
+1. Open the Docusaurus folder in the _Datagrok public_ repository:
+
+    ```shell
+    cd public/docusaurus
+    ```
+
+1. Install package dependencies:
+
+    ```shell
+    npm install
+    ```
+
+1. As we use Docusaurus to generate the API documentation,
+you need to repeat the npm installation steps in the `js-api` folder:
 
 ```mdx-code-block
 <Tabs>
-<TabItem value="cli" label="CLI" default>
+<TabItem value="win" label="Windows">
 ```
 
-   ```mdx-code-block
-   <Tabs>
-   <TabItem value="win" label="Windows">
-   ```
+```cmd
+cd ..\js-api
+npm install
+```
 
-   ```cmd
-   cd docusaurus
-   npm install
-   npm run build
+```mdx-code-block
+</TabItem>
+<TabItem value="bash" label="Linux/MacOS" default>
+```
 
-   npm install @untitaker/hyperlink --global
-   hyperlink --check-anchors build --sources ..\help
-   ```
-
-   ```mdx-code-block
-   </TabItem>
-   <TabItem value="bash" label="Linux/MacOS" default>
-   ```
-
-   ```bash
-   cd docusaurus
-   npm install
-   npm run build
-
-   npm install @untitaker/hyperlink --global
-   hyperlink --check-anchors build/ --sources ../help/
-   ```
-
-   ```mdx-code-block
-   </TabItem>
-   </Tabs>
-   ```
+```shell
+cd ../js-api
+npm install
+```
 
 ```mdx-code-block
 </TabItem>
 </Tabs>
 ```
+
+## Make changes
+
+### 1. Create the branch
+
+Create the branch for your changes following the [General flow](../advanced/git-policy#general-flow) 
+from the Git policy.
+
+### 2. Run Docusaurus locally
+
+```mdx-code-block
+<Tabs>
+<TabItem value="win" label="Windows">
+```
+
+```cmd
+cd ..\docusaurus
+npm run start-debug
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="bash" label="Linux/MacOS" default>
+```
+
+```shell
+cd ../docusaurus
+npm run start-debug
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+If the command does not work use `docusaurus start --config docusaurus-debug.config.js`.
+Docusaurus will be available at [http://localhost:3000](http://localhost:3000).
+
+### 3. Make changes
+
+Now you can proceed with the documentation editing.
+Docusaurus will recompile the documentation on every change you make,
+so you will instantly see all the improvements you have made to the documentation.
+If you don't see your changes immediately, reload the page.
+
+### 4. Lint your changes
+
+Before making a commit, check that the documentation builds without errors.
+
+1. Run the markdown linter for all changed files from your IDE or via the command line:
+
+    ```shell
+    markdownlint-cli2-fix changed-documentation-file.md
+    ```
+
+1. To test internal links and anchors, convert markdown to HTML using [Docusaurus](https://docusaurus.io/)
+and then check all links using [hyperlink](https://github.com/untitaker/hyperlink).
+Stop Docusaurus by pressing `Ctrl+C` and run the following commands to build and check your documentation.
+Note that the build step will take some time.
+
+```mdx-code-block
+<Tabs>
+<TabItem value="win" label="Windows">
+```
+
+```cmd
+cd docusaurus
+npm run build
+
+hyperlink --check-anchors build --sources ..\help
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="bash" label="Linux/MacOS" default>
+```
+
+```bash
+cd docusaurus
+npm run build
+
+hyperlink --check-anchors build/ --sources ../help/
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+If the command `npm run build` does not work use `docusaurus build`.
+
+### 7. Commit and push your changes
+
+Make and push a commit, following the [Commit message policy](../advanced/git-policy#commit-message-policy)
+to choose the correct commit naming.
+
+Finally, create a pull request to merge your changes to the master branch.
+
+## GitHub Actions Docusaurus workflow
+
+[GitHub Actions Docusaurus workflow](https://github.com/datagrok-ai/public/actions/workflows/docusaurus.yaml) includes:
+
+* Lint checks using [markdownlint](https://github.com/DavidAnson/markdownlint-cli2) linter.
+* If the checks are finished successfully, GitHub will convert the markdown files to HTML
+  using [Docusaurus](https://docusaurus.io/)
+  * The result HTML help pages are also available as GitHub Actions artifact: `docusaurus`
+* Then [Hyperlink](https://github.com/untitaker/hyperlink) checks the result HTML files.
+* If the checks are finished successfully and the changes are in the master branch,  GitHub Actions will deploy the documentation to the server.
+  * 'Deploy to server' step contains detailed information about changes that are made on the server.
+* Finally, GitHub Actions performs Typesense DocSearch Scrape to update indexes for search in the wiki
+
+If any error occurs during checks, the deployment to the server will be canceled. Check for errors in the GitHub Actions log or in GitHub Actions run summary.
+
+More information about flow can be found on the Docusaurus Help tab in [public repository CI/CD flows](../../deploy/releases/ci-flow.mdx#public-repository-cicd-flows).
+
+### Trigger GitHub Actions manually
+
+If an error occurs for the action triggered by the commit, it is possible to trigger the action manually.
+
+1. Use [Docusaurus workflow](https://github.com/datagrok-ai/public/actions/workflows/docusaurus.yaml).
+2. Press `run workflow`. Choose the target branch. Then `Run workflow`. Note that deployment to the server is executed for the master branch only.
+3. Check that the GitHub Actions workflow finished successfully.

--- a/help/develop/help-pages/github-workflow.mdx
+++ b/help/develop/help-pages/github-workflow.mdx
@@ -12,13 +12,13 @@ import TabItem from '@theme/TabItem';
 
 [Docusaurus](https://docusaurus.io/) is an optimized site generator. Docusaurus
 is a project for building, deploying, and maintaining open source project
-websites easily.
+websites.
 
 ### 1. Install the latest stable NodeJS
 
 Use instructions from the official
 [Node JS](https://nodejs.org/en/download) installation page.
-After installation check that the npm version is at least `v9.x.x`:
+After installation, check that the npm version is at least `v9.x.x`:
 
 ```shell
 npm --version
@@ -50,7 +50,7 @@ we use [markdownlint](https://github.com/DavidAnson/markdownlint).
    Markdownlint [VSCode plugin](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
 
 3. [Configure autofix for issues](https://github.com/DavidAnson/vscode-markdownlint#fix)
-4. Show markdownlint warnings using the shortcut: `Ctrl+Shift+M`/`Ctrl+Shift+M`/`⇧⌘M`
+4. Show markdownlint warnings using the shortcut: `Ctrl+Shift+M`/`⇧⌘M`
 
 ```mdx-code-block
 </TabItem>
@@ -65,7 +65,7 @@ we use [markdownlint](https://github.com/DavidAnson/markdownlint).
 
 2. Add MarkdownLint as [External Tool](https://www.jetbrains.com/help/idea/configuring-third-party-tools.html#local-ext-tools). `Preferences > Tools > External Tools > + (Add)`
    1. Name: `MarkdownLint`
-   2. Description: `MarkdownLint CLI with enabled fix`
+   2. Description: `MarkdownLint CLI with the enabled fix.`
    3. Program: `markdownlint-cli2-fix`
    4. Arguments: `$FilePath$`
    5. Working Directory: `$Projectpath$`
@@ -74,15 +74,13 @@ we use [markdownlint](https://github.com/DavidAnson/markdownlint).
 
    ![idea-markdownlint.png](idea-markdownlint.png)
 
-3. Now, to run MarkdownLint on the current file, you can click `Tools > External Tools > MarkdownLint`.
+3. To run MarkdownLint on the current file, click `Tools > External Tools > MarkdownLint`.
 
-4. _(Optional)_ To run MarkdownLint easier you can [add an icon to the toolbar](https://www.jetbrains.com/help/idea/customize-actions-menus-and-toolbars.html#customize-menus-and-toolbars). 
-   `Preferences > Appearance & Behavior > Menus and Toolbars > Main Toolbar > Toolbar Run Actions > + > Add Action... > External Tools > External Tools > MarkdownLint > OK`. 
-   Now, you can run Markdownlint from the toolbar using the icon.
+4. _(Optional)_ To run MarkdownLint easier, [add an icon to the toolbar](https://www.jetbrains.com/help/idea/customize-actions-menus-and-toolbars.html#customize-menus-and-toolbars). 
+   `Preferences > Appearance & Behavior > Menus and Toolbars > Main Toolbar > Toolbar Run Actions > + > Add Action... > External Tools > External Tools > MarkdownLint > OK`.    
 
-5. _(Optional)_ To run MarkdownLint easier you can [add a shortcut](https://www.jetbrains.com/help/idea/configuring-keyboard-and-mouse-shortcuts.html). 
-   `Preferences > Keymap > External Tools > MarkdownLint > Right click > Add Keyboard Shortcut > Set the shortcut you like, for example, Ctrl+Shift+M/⌘⇧M`. 
-   Now, you can run Markdownlint using the shortcut.
+5. _(Optional)_ To run MarkdownLint easier, [add a shortcut](https://www.jetbrains.com/help/idea/configuring-keyboard-and-mouse-shortcuts.html). 
+   `Preferences > Keymap > External Tools > MarkdownLint > Right click > Add Keyboard Shortcut > Set the shortcut you like, for example, Ctrl+Shift+M/⌘⇧M`.    
 
 ```mdx-code-block
 </TabItem>
@@ -224,12 +222,12 @@ npm run start-debug
 </Tabs>
 ```
 
-If the command does not work use `docusaurus start --config docusaurus-debug.config.js`.
+If the command does not work, use `docusaurus start --config docusaurus-debug.config.js`.
 Docusaurus will be available at [http://localhost:3000](http://localhost:3000).
 
 ### 3. Make changes
 
-Now you can proceed with the documentation editing.
+Now, you can proceed with the documentation editing.
 Docusaurus will recompile the documentation on every change you make,
 so you will instantly see all the improvements you have made to the documentation.
 If you don't see your changes immediately, reload the page.
@@ -278,7 +276,7 @@ hyperlink --check-anchors build/ --sources ../help/
 </Tabs>
 ```
 
-If the command `npm run build` does not work use `docusaurus build`.
+If the command `npm run build` does not work, use `docusaurus build`.
 
 ### 7. Commit and push your changes
 
@@ -296,7 +294,7 @@ Finally, create a pull request to merge your changes to the master branch.
   using [Docusaurus](https://docusaurus.io/)
   * The result HTML help pages are also available as GitHub Actions artifact: `docusaurus`
 * Then [Hyperlink](https://github.com/untitaker/hyperlink) checks the result HTML files.
-* If the checks are finished successfully and the changes are in the master branch,  GitHub Actions will deploy the documentation to the server.
+* If the checks are finished successfully, and the changes are in the master branch,  GitHub Actions will deploy the documentation to the server.
   * 'Deploy to server' step contains detailed information about changes that are made on the server.
 * Finally, GitHub Actions performs Typesense DocSearch Scrape to update indexes for search in the wiki
 


### PR DESCRIPTION
Reorganized the Helop docs contribution pages.

- Moved installation instructions to a separate section
- Added links to GitHub policy for commit and branch naming