### PR TITLE
Fixes major regression in SMILES stereochemistry depiction

### DIFF
--- a/packages/Chem/src/rendering/rdkit-cell-renderer.ts
+++ b/packages/Chem/src/rendering/rdkit-cell-renderer.ts
@@ -200,6 +200,7 @@ M  END
             }
           }
         }
+        molCtx.useMolBlockWedging = (mol.has_coords() === 2);
         if (mol.has_coords() === 0 || molRegenerateCoords) {
           mol.set_new_coords(molRegenerateCoords);
           molHasOwnCoords = false;
@@ -209,8 +210,6 @@ M  END
           mol.straighten_depiction(molHasOwnCoords);
         } else if (!molHasOwnCoords)
           mol.normalize_depiction(0);
-
-        molCtx.useMolBlockWedging = (mol.has_coords() === 2);
       } catch (e) {
         console.error(
           'In _fetchMolGetOrCreate: RDKit crashed, possibly a malformed molString molecule: `' + molString + '`');


### PR DESCRIPTION
@MariaDolotova @StLeonidas
This PR fixes a major regression that caused **ALL** molecules rendered from SMILES to have no stereochemistry.
Molecules were being tested for the presence of pre-existing 2D coordinates _after_ coordinates had been generated, so the check was always true.