### PR TITLE
GROK-14124: EDA | ANOVA: Naming upd

### DIFF
--- a/packages/EDA/CHANGELOG.md
+++ b/packages/EDA/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EDA changelog
 
+## 1.1.5 (2023-10-23)
+
+Anova top-menu item is improved.
+
 ## 1.1.4 (2023-10-11)
 
 Implemented ANOVA.

--- a/packages/EDA/package.json
+++ b/packages/EDA/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@datagrok/eda",
   "friendlyName": "EDA",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Exploratory Data Analysis Tools",
   "dependencies": {
     "@datagrok-libraries/ml": "^6.3.39",

--- a/packages/EDA/src/package.ts
+++ b/packages/EDA/src/package.ts
@@ -321,7 +321,7 @@ export async function applySigmoidKernelSVM(df: DG.DataFrame, model: any): Promi
   return await getPrediction(df, model); 
 }
 
-//top-menu: ML | Analysis of Variances (ANOVA)...
+//top-menu: ML | Analyze | ANOVA...
 //name: One-way ANOVA
 //description: One-way analysis of variances (ANOVA) determines whether the examined factor has a significant impact on the studied feature.
 //input: dataframe table


### PR DESCRIPTION
The method is moved to top-menu ML | Analyze and renamed to just _ANOVA_ instead _Analysis of variances (ANOVA)_.