### PR TITLE
fix(DDIS-6462): Fonts are too large compared to the scaffold size

### DIFF
--- a/packages/Chem/src/widgets/scaffold-tree.ts
+++ b/packages/Chem/src/widgets/scaffold-tree.ts
@@ -2003,7 +2003,8 @@ class SketcherDialogWrapper {
     validLabel.innerText = errorMsg ?? '';
 
     this.sketcher.onChanged.subscribe(() => {
-      const molStr = thisWrapper.sketcher.getMolFile();
+      const molStr = this.normalizeMolStr(thisWrapper.sketcher.getMolFile());
+
       errorMsg = validate(molStr, thisWrapper.node);
       valid = errorMsg === null;
       validLabel.style.color = SketcherDialogWrapper.validationColor(valid);
@@ -2019,7 +2020,7 @@ class SketcherDialogWrapper {
       thisWrapper.isMolBlock ? thisWrapper.sketcher.setMolFile(molStr) : thisWrapper.sketcher.setSmiles(molStr);
     });
     this.dialog.addButton(actionName, () => {
-      const molStr = thisWrapper.sketcher.getMolFile();
+      const molStr = this.normalizeMolStr(thisWrapper.sketcher.getMolFile());
       action(molStr, thisWrapper.node, errorMsg);
     });
 
@@ -2028,6 +2029,24 @@ class SketcherDialogWrapper {
 
     if (onClose != null)
       this.dialog.onCancel(onClose);
+  }
+
+  normalizeMolStr(molStr: string): string {
+    let mol;
+    try {
+      mol = _rdKitModule.get_mol(molStr);
+      if (mol.has_coords() === 2) {
+        mol.normalize_depiction(0);
+        molStr = mol.get_molblock();
+      }
+    } catch {
+      // do nothing
+    } finally {
+      if (mol) {
+        mol.delete();
+      }
+    }
+    return molStr;
   }
 
   set node(node: DG.TreeViewGroup) {


### PR DESCRIPTION
@MariaDolotova @StLeonidas This small PR is to normalize the scale of scaffolds retrieved from the sketcher, such that their bond length is the same that RDKit expects. This avoids downstream issues such as:
1. heteroatom fonts being too large compared to the size of the scaffold
2. possible distortions upon attempting to align molecules to such scaffolds

For instance, fonts that previously looked like this
![image](https://github.com/datagrok-ai/public/assets/5244385/3a4ee94d-ff4f-44ec-8a05-0adbaad6d8ef)

are now properly scaled:
![image](https://github.com/datagrok-ai/public/assets/5244385/0e6334ba-c17f-4d0a-8991-fff9dd7b293d)
