### PR TITLE
Only generate coordinates when needed

### DIFF
--- a/packages/Chem/src/rendering/rdkit-cell-renderer.ts
+++ b/packages/Chem/src/rendering/rdkit-cell-renderer.ts
@@ -148,7 +148,6 @@ M  END
     if (mol !== null) {
       try {
         let molHasOwnCoords = (mol.has_coords() > 0);
-        let doNotUseMolblockWedging = false;
         const scaffoldIsMolBlock = scaffolds.length ? DG.chem.isMolBlock(scaffolds[0].molecule) : null;
         const alignedByFirstSubstr = scaffoldIsMolBlock && alignByFirstSubstr;
         const { haveReferenceSmarts, parentMolScaffoldMolString } = (details as any);
@@ -161,13 +160,11 @@ M  END
             rdKitScaffoldMol.normalize_depiction(0);
             if (molHasOwnCoords)
               mol.normalize_depiction(0);
-            else {
-              //need the following 4 rows for smiles with highlights to be rendered in adequate coordinates
+            else if (scaffolds[0].isSuperstructure) {
+              //need the following 3 rows for smiles with highlights to be rendered in adequate coordinates
               mol.set_new_coords();
               mol.normalize_depiction(1);
               mol.straighten_depiction(false);
-              molHasOwnCoords = true;
-              doNotUseMolblockWedging = true;
             }
             let substructString = '';
             let useCoordGen = (details as any).useCoordGen;
@@ -227,7 +224,7 @@ M  END
             }
           }
         }
-        molCtx.useMolBlockWedging = molHasOwnCoords && !doNotUseMolblockWedging;;
+        molCtx.useMolBlockWedging = molHasOwnCoords;
         if (mol.has_coords() === 0 || molRegenerateCoords) {
           mol.set_new_coords(molRegenerateCoords);
           mol.normalize_depiction(1);


### PR DESCRIPTION
@MariaDolotova @StLeonidas 

This code was already part of #2493, but it has been reverted in a subsequent commit:

```
commit 5f02c369b64d228db117bed980fd5ca05456925b
Author: Maria Dolotova <maria.dolotova@softwarecountry.com>
Date:   Mon Nov 13 17:07:22 2023 +0300

    Chem: Fixing coordinates for smiles
```

As a consequence, R-group and R-series alignment is now broken in `Chem 1.8.5`.

This PR restores the change in #2493 and maintains the rebuilding only for SMILES scaffolds.

- do not generate unaligned coordinates before generating aligned coordinates as it is a waste of time
- do not set `molHasOwnCoords` after generating coordinates from SMILES: that flag is reserved to molecules having original, own coordinates (e.g., from molblock or CXSMILES input)