### PR TITLE
Moved composition-table to library, bump bio

### DIFF
--- a/libraries/bio/package-lock.json
+++ b/libraries/bio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datagrok-libraries/bio",
-  "version": "5.53.3",
+  "version": "5.53.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datagrok-libraries/bio",
-      "version": "5.53.3",
+      "version": "5.53.4",
       "dependencies": {
         "@datagrok-libraries/chem-meta": "^1.2.7",
         "@datagrok-libraries/gridext": "^1.4.0",

--- a/libraries/bio/package.json
+++ b/libraries/bio/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "friendlyName": "Datagrok bio library",
-  "version": "5.53.3",
+  "version": "5.53.4",
   "description": "Bio utilities, types supporting Macromolecule, Molecule3D data",
   "dependencies": {
     "@datagrok-libraries/chem-meta": "^1.2.7",

--- a/libraries/bio/src/utils/composition-table.ts
+++ b/libraries/bio/src/utils/composition-table.ts
@@ -1,0 +1,53 @@
+import * as grok from 'datagrok-api/grok';
+import * as ui from 'datagrok-api/ui';
+import * as DG from 'datagrok-api/dg';
+import {TAGS as bioTAGS, ALPHABET} from './macromolecule';
+import {GAP_SYMBOL} from './macromolecule/consts';
+import {IMonomerLibBase} from './../types';
+import {HelmType} from './../helm/types';
+
+export function buildCompositionTable(
+  counts: { [m: string]: number }, biotype: HelmType, monomerLib: IMonomerLibBase
+): HTMLTableElement {
+  let sumValue: number = 0;
+  let maxValue: number | null = null;
+  for (const value of Object.values(counts)) {
+    sumValue = sumValue + value;
+    maxValue = maxValue === null ? value : Math.max(maxValue, value);
+  }
+  const maxRatio = maxValue! / sumValue;
+  const elMap: { [m: string]: HTMLElement } = Object.assign({}, ...Array.from(Object.entries(counts))
+    .sort((a, b) => b[1] - a[1])
+    .map(([cm, value]) => {
+      const ratio = value / sumValue;
+      let color: string;
+      try {
+        const colors = monomerLib.getMonomerColors(biotype, cm);
+        color = colors?.backgroundcolor || '#CCCCCC';
+      } catch (error) {
+        console.warn(`Failed to get colors for monomer ${cm}:`, error);
+        color = '#CCCCCC';
+      }
+
+      const barDiv = ui.div('', {classes: 'macromolecule-cell-comp-analysis-bar'});
+      barDiv.style.width = `${50 * ratio / maxRatio}px`;
+      barDiv.style.backgroundColor = color;
+      if (GAP_SYMBOL === cm) {
+        barDiv.style.borderWidth = '1px';
+        barDiv.style.borderStyle = 'solid';
+        barDiv.style.borderColor = DG.Color.toHtml(DG.Color.lightGray);
+      }
+      const displayMonomer: string = GAP_SYMBOL === cm ? '-' : cm;
+      const valueDiv = ui.div(`${(100 * ratio).toFixed(2)}%`);
+      const el = ui.div([barDiv, valueDiv], {classes: 'macromolecule-cell-comp-analysis-value'});
+      return ({[displayMonomer]: el});
+    }));
+
+  const table = ui.tableFromMap(elMap);
+  Array.from(table.rows).forEach((row) => {
+    const barCol = (row.getElementsByClassName('macromolecule-cell-comp-analysis-bar')[0] as HTMLDivElement)
+      .style.backgroundColor;
+    row.cells[0].style.color = barCol;
+  });
+  return table;
+}

--- a/libraries/bio/src/utils/sequence-position-scroller.ts
+++ b/libraries/bio/src/utils/sequence-position-scroller.ts
@@ -14,6 +14,8 @@ import {ISeqHandler} from './macromolecule/seq-handler';
 import {HelmType} from '../helm/types';
 import {HelmTypes} from '../helm/consts';
 import {buildCompositionTable} from './composition-table';
+import {BioType} from '@datagrok-libraries/js-draw-lite/src/types/jsdraw2';
+import {IMonomerLib} from '../types';
 
 
 // WebLogo Constants
@@ -113,7 +115,7 @@ export abstract class MSAHeaderTrack {
   protected defaultHeight: number;
   protected title: string = '';
   protected tooltipEnabled: boolean = false;
-  protected tooltipContent: ((position: number, data: any) => HTMLElement) | null = null;
+  protected tooltipContent: ((position: number, monomer: string | null, data: Map<string, number>) => HTMLElement) | null = null;
 
   constructor(height: number = LAYOUT_CONSTANTS.DEFAULT_TRACK_HEIGHT,
     minHeight: number = LAYOUT_CONSTANTS.MIN_TRACK_HEIGHT,
@@ -131,7 +133,7 @@ export abstract class MSAHeaderTrack {
     this.ctx = ctx;
   }
 
-  public getMonomerAt(x: number, y: number, position: number): string | null {
+  public getMonomerAt(_x: number, _y: number, _position: number): string | null {
     return null;
   }
 
@@ -139,20 +141,20 @@ export abstract class MSAHeaderTrack {
     this.tooltipEnabled = enabled;
   }
 
-  public setTooltipContentGenerator(contentGenerator: (position: number, data: any) => HTMLElement): void {
+  public setTooltipContentGenerator(contentGenerator: (position: number, monomer: string | null, data: Map<string, number>) => HTMLElement): void {
     this.tooltipContent = contentGenerator;
   }
 
-  public getTooltipContent(position: number): HTMLElement | null {
+  public getTooltipContent(position: number, monomer: string | null): HTMLElement | null {
     if (!this.tooltipEnabled || !this.tooltipContent) return null;
-    const positionData = this.getPositionData(position);
-    return this.tooltipContent(position, positionData);
+    const positionData = this.getPositionData(position) ?? new Map();
+    return this.tooltipContent(position, monomer, positionData);
   }
 
   /**
    * Get data for a specific position (to be implemented by subclasses)
    */
-  protected getPositionData(position: number): any {
+  protected getPositionData(position: number): Map<string, number> | null {
     return null;
   }
 
@@ -203,8 +205,8 @@ export abstract class MSAHeaderTrack {
 
 export class WebLogoTrack extends MSAHeaderTrack {
   private data: Map<number, Map<string, number>> = new Map();
-  private monomerLib: any = null;
-  private biotype: string = 'PEPTIDE';
+  private monomerLib: IMonomerLib | null = null;
+  private biotype: HelmType = 'HELM_AA';
   private hoveredPosition: number = -1;
   private hoveredMonomer: string | null = null;
 
@@ -228,8 +230,8 @@ export class WebLogoTrack extends MSAHeaderTrack {
 
   public setupDefaultTooltip(): void {
     this.enableTooltip(true);
-    this.setTooltipContentGenerator((position: number, data: Map<string, number>) => {
-      return this.createTooltipContent(position, data);
+    this.setTooltipContentGenerator((position: number, monomer: string | null, data: Map<string, number>) => {
+      return this.createTooltipContent(position, monomer, data);
     });
   }
 
@@ -237,15 +239,16 @@ export class WebLogoTrack extends MSAHeaderTrack {
   private createFrequencyTable(data: Map<string, number>): HTMLElement {
     let helmType: HelmType;
     switch (this.biotype) {
-    case 'DNA':
-    case 'RNA':
-    case 'NUCLEOTIDE':
+    case 'HELM_BASE':
+    case 'HELM_SUGAR':
+    case 'HELM_NUCLETIDE':
       helmType = HelmTypes.NUCLEOTIDE;
-    case 'PEPTIDE':
-    case 'PROTEIN':
-    case 'AA':
+      break;
+    case 'HELM_AA':
+    case 'HELM_LINKER':
     default:
       helmType = HelmTypes.AA;
+      break;
     }
     const totalFrequency = Array.from(data.values()).reduce((sum, freq) => sum + freq, 0);
     const displayTotal = 100;
@@ -255,7 +258,7 @@ export class WebLogoTrack extends MSAHeaderTrack {
       counts[monomer] = Math.max(1, Math.round((frequency / totalFrequency) * displayTotal));
 
 
-    const table = buildCompositionTable(counts, helmType, this.monomerLib);
+    const table = buildCompositionTable(counts, helmType, this.monomerLib!);
     table.style.fontSize = '11px';
     table.style.marginTop = '4px';
 
@@ -263,12 +266,23 @@ export class WebLogoTrack extends MSAHeaderTrack {
   }
 
 
-  private createTooltipContent(position: number, data: Map<string, number>): HTMLElement {
+  private createTooltipContent(position: number, monomer: string | null, data: Map<string, number>): HTMLElement {
     const tooltipRows: HTMLElement[] = [];
 
     tooltipRows.push(ui.divText(`Position: ${position + 1}`, {
       style: {fontWeight: 'bold', marginBottom: '6px', fontSize: '13px'}
     }));
+
+    if (monomer) {
+      tooltipRows.push(ui.divText(`Monomer: ${monomer}`, {
+        style: {marginBottom: '6px', fontSize: '13px'}
+      }));
+      if (data.has(monomer)) {
+        tooltipRows.push(ui.divText(`${(data.get(monomer)! * 100).toFixed(2)}%`, {
+          style: {marginBottom: '6px', fontSize: '13px'}
+        }));
+      }
+    }
 
     if (data && data.size > 0) {
       // Use the datagrok buildCompositionTable
@@ -286,11 +300,11 @@ export class WebLogoTrack extends MSAHeaderTrack {
   }
 
 
-  setMonomerLib(monomerLib: any): void {
+  setMonomerLib(monomerLib: IMonomerLib): void {
     this.monomerLib = monomerLib;
   }
 
-  setBiotype(biotype: string): void {
+  setBiotype(biotype: HelmType): void {
     this.biotype = biotype;
   }
 
@@ -614,6 +628,7 @@ export class MSAScrollingHeader {
   // Tooltip and hover state
   private currentHoverPosition: number = -1;
   private currentHoverTrack: string | null = null;
+  private currentHoverMonomer: string | null = null;
   private previousHoverPosition: number = -1;
   private previousHoverTrack: string | null = null;
   private previousHoverMonomer: string | null = null;
@@ -890,7 +905,7 @@ export class MSAScrollingHeader {
     );
   }
 
-  public setSelectionData(dataFrame: DG.DataFrame, seqColumn: DG.Column<string>, seqHandler: any,
+  public setSelectionData(dataFrame: DG.DataFrame, seqColumn: DG.Column<string>, seqHandler: ISeqHandler,
     callback?: (position: number, monomer: string) => void): void {
     this.dataFrame = dataFrame;
     this.seqColumn = seqColumn;
@@ -988,14 +1003,14 @@ export class MSAScrollingHeader {
     }
 
     // Handle tooltips
-    if (hoveredPosition !== this.currentHoverPosition || hoveredTrackId !== this.currentHoverTrack) {
+    if (hoveredPosition !== this.currentHoverPosition || hoveredTrackId !== this.currentHoverTrack || currentHoverMonomer !== this.currentHoverMonomer) {
       this.currentHoverPosition = hoveredPosition;
       this.currentHoverTrack = hoveredTrackId;
-
+      this.currentHoverMonomer = currentHoverMonomer;
       if (hoveredTrackId) {
         const track = this.tracks.get(hoveredTrackId);
         if (track) {
-          const tooltipContent = track.getTooltipContent(hoveredPosition);
+          const tooltipContent = track.getTooltipContent(hoveredPosition, currentHoverMonomer);
           if (tooltipContent) {
             ui.tooltip.show(tooltipContent, e.clientX + 16, e.clientY + 16);
             return;

--- a/libraries/bio/src/utils/sequence-position-scroller.ts
+++ b/libraries/bio/src/utils/sequence-position-scroller.ts
@@ -11,19 +11,10 @@ import * as ui from 'datagrok-api/ui';
 import * as DG from 'datagrok-api/dg';
 import * as grok from 'datagrok-api/grok';
 import {ISeqHandler} from './macromolecule/seq-handler';
+import {HelmType} from '../helm/types';
+import {HelmTypes} from '../helm/consts';
+import {buildCompositionTable} from './composition-table';
 
-// Layout Constants
-// const LAYOUT_CONSTANTS = {
-//   TITLE_HEIGHT: 16,
-//   TRACK_GAP: 4,
-//   DOTTED_CELL_HEIGHT: 30,
-//   SLIDER_HEIGHT: 8,
-//   TOP_PADDING: 5,
-//   DEFAULT_TRACK_HEIGHT: 45,
-//   MIN_TRACK_HEIGHT: 35,
-//   TRACK_SELECTOR_SIZE: 20,
-//   TRACK_SELECTOR_MARGIN: 5
-// } as const;
 
 // WebLogo Constants
 const WEBLOGO_CONSTANTS = {
@@ -241,51 +232,36 @@ export class WebLogoTrack extends MSAHeaderTrack {
       return this.createTooltipContent(position, data);
     });
   }
+
+
   private createFrequencyTable(data: Map<string, number>): HTMLElement {
-    const sortedResidues = Array.from(data.entries()).sort((a, b) => b[1] - a[1]);
-
-    const table = document.createElement('table');
-    table.style.borderCollapse = 'collapse';
-    table.style.marginTop = '4px';
-    table.style.fontSize = '11px';
-
-    // Create header
-    const headerRow = table.insertRow();
-    const headerCell1 = headerRow.insertCell();
-    const headerCell2 = headerRow.insertCell();
-    headerCell1.textContent = 'Residue';
-    headerCell2.textContent = 'Frequency';
-    headerCell1.style.fontWeight = 'bold';
-    headerCell2.style.fontWeight = 'bold';
-    headerCell1.style.padding = '4px 8px';
-    headerCell2.style.padding = '4px 8px';
-    headerCell1.style.borderBottom = '1px solid #ccc';
-    headerCell2.style.borderBottom = '1px solid #ccc';
-
-    for (const [residue, freq] of sortedResidues) {
-      const row = table.insertRow();
-      const cell1 = row.insertCell();
-      const cell2 = row.insertCell();
-
-      const backgroundColor = this.getMonomerBackgroundColor(residue);
-      const textColor = this.getMonomerTextColor(residue);
-
-      cell1.textContent = residue;
-      cell1.style.backgroundColor = backgroundColor;
-      cell1.style.color = textColor;
-      cell1.style.textAlign = 'center';
-      cell1.style.fontWeight = 'bold';
-      cell1.style.padding = '4px 8px';
-      cell1.style.border = '1px solid rgba(0,0,0,0.1)';
-
-      cell2.textContent = `${(freq * 100).toFixed(0)}%`;
-      cell2.style.textAlign = 'right';
-      cell2.style.padding = '4px 8px';
-      cell2.style.border = '1px solid rgba(0,0,0,0.1)';
+    let helmType: HelmType;
+    switch (this.biotype) {
+    case 'DNA':
+    case 'RNA':
+    case 'NUCLEOTIDE':
+      helmType = HelmTypes.NUCLEOTIDE;
+    case 'PEPTIDE':
+    case 'PROTEIN':
+    case 'AA':
+    default:
+      helmType = HelmTypes.AA;
     }
+    const totalFrequency = Array.from(data.values()).reduce((sum, freq) => sum + freq, 0);
+    const displayTotal = 100;
+    const counts: { [m: string]: number } = {};
+
+    for (const [monomer, frequency] of data.entries())
+      counts[monomer] = Math.max(1, Math.round((frequency / totalFrequency) * displayTotal));
+
+
+    const table = buildCompositionTable(counts, helmType, this.monomerLib);
+    table.style.fontSize = '11px';
+    table.style.marginTop = '4px';
 
     return table;
   }
+
 
   private createTooltipContent(position: number, data: Map<string, number>): HTMLElement {
     const tooltipRows: HTMLElement[] = [];
@@ -295,6 +271,7 @@ export class WebLogoTrack extends MSAHeaderTrack {
     }));
 
     if (data && data.size > 0) {
+      // Use the datagrok buildCompositionTable
       const freqTable = this.createFrequencyTable(data);
       tooltipRows.push(freqTable);
     } else {
@@ -303,10 +280,8 @@ export class WebLogoTrack extends MSAHeaderTrack {
       }));
     }
 
-    // Use the standard tooltip container approach
     const tooltipEl = ui.divV(tooltipRows);
     tooltipEl.style.maxHeight = '80vh';
-
     return tooltipEl;
   }
 

--- a/packages/Bio/src/viewers/web-logo-viewer.ts
+++ b/packages/Bio/src/viewers/web-logo-viewer.ts
@@ -30,10 +30,10 @@ import {HelmType} from '@datagrok-libraries/bio/src/helm/types';
 import {undefinedColor} from '@datagrok-libraries/bio/src/utils/cell-renderer-monomer-placer';
 
 import {AggFunc, getAgg} from '../utils/agg';
-import {buildCompositionTable} from '../widgets/composition-analysis-widget';
 
 import {_package, getMonomerLibHelper} from '../package';
 import {numbersWithinMaxDiff} from './utils';
+import {buildCompositionTable} from '@datagrok-libraries/bio/src/utils/composition-table';
 
 declare global {
   interface HTMLCanvasElement {

--- a/packages/Bio/src/widgets/composition-analysis-widget.ts
+++ b/packages/Bio/src/widgets/composition-analysis-widget.ts
@@ -12,6 +12,7 @@ import {HelmTypes} from '@datagrok-libraries/bio/src/helm/consts';
 
 import '../../css/composition-analysis.css';
 import {ISeqHelper} from '@datagrok-libraries/bio/src/utils/seq-helper';
+import {buildCompositionTable} from '@datagrok-libraries/bio/src/utils/composition-table';
 
 export function getCompositionAnalysisWidget(
   val: DG.SemanticValue, monomerLib: IMonomerLibBase, seqHelper: ISeqHelper
@@ -43,41 +44,3 @@ export function getCompositionAnalysisWidget(
   return new DG.Widget(host);
 }
 
-export function buildCompositionTable(
-  counts: { [m: string]: number }, biotype: HelmType, monomerLib: IMonomerLibBase
-): HTMLTableElement {
-  let sumValue: number = 0;
-  let maxValue: number | null = null;
-  for (const value of Object.values(counts)) {
-    sumValue = sumValue + value;
-    maxValue = maxValue === null ? value : Math.max(maxValue, value);
-  }
-  const maxRatio = maxValue! / sumValue;
-  const elMap: { [m: string]: HTMLElement } = Object.assign({}, ...Array.from(Object.entries(counts))
-    .sort((a, b) => b[1] - a[1])
-    .map(([cm, value]) => {
-      const ratio = value / sumValue;
-      const wem = monomerLib.getWebEditorMonomer(biotype, cm)!;
-      const color = wem.backgroundcolor!;
-      const barDiv = ui.div('', {classes: 'macromolecule-cell-comp-analysis-bar'});
-      barDiv.style.width = `${50 * ratio / maxRatio}px`;
-      barDiv.style.backgroundColor = color;
-      if (GAP_SYMBOL === cm) {
-        barDiv.style.borderWidth = '1px';
-        barDiv.style.borderStyle = 'solid';
-        barDiv.style.borderColor = DG.Color.toHtml(DG.Color.lightGray);
-      }
-      const displayMonomer: string = GAP_SYMBOL === cm ? '-' : cm;
-      const valueDiv = ui.div(`${(100 * ratio).toFixed(2)}%`);
-      const el = ui.div([barDiv, valueDiv], {classes: 'macromolecule-cell-comp-analysis-value'});
-      return ({[displayMonomer]: el});
-    }));
-
-  const table = ui.tableFromMap(elMap);
-  Array.from(table.rows).forEach((row) => {
-    const barCol = (row.getElementsByClassName('macromolecule-cell-comp-analysis-bar')[0] as HTMLDivElement)
-      .style.backgroundColor;
-    row.cells[0].style.color = barCol;
-  });
-  return table;
-}


### PR DESCRIPTION
Moved `buildCompositionTable` out of `packages/Bio/.../composition-analysis-widget` to `libraries/bio/utils/composition-table`. 
- Note, i left `getCompositionAnalysisWidget` in that same file. Is that right?

Also bumped the library's `package.json` version as @drizhina showed on a call for it to be gh-action propagated to npm. Hopefully got that right as well? 