### PR TITLE
Sequence similarity improvements

### DIFF
--- a/packages/Bio/src/analysis/sequence-diversity-viewer.ts
+++ b/packages/Bio/src/analysis/sequence-diversity-viewer.ts
@@ -1,3 +1,4 @@
+
 import * as ui from 'datagrok-api/ui';
 import * as DG from 'datagrok-api/dg';
 import * as grok from 'datagrok-api/grok';
@@ -12,17 +13,19 @@ import {getEncodedSeqSpaceCol} from './sequence-space';
 import {MmDistanceFunctionsNames} from '@datagrok-libraries/ml/src/macromolecule-distance-functions';
 import {DistanceMatrixService, dmLinearIndex} from '@datagrok-libraries/ml/src/distance-matrix';
 import {MmcrTemps} from '@datagrok-libraries/bio/src/utils/cell-renderer-consts';
+import {_package} from '../package';
+import {getMonomerSubstitutionMatrix} from '@datagrok-libraries/bio/src/monomer-works/monomer-utils';
 
-const MAX_SAMPLE_SIZE = 10000; // Maximum size for sampling
+const MAX_SAMPLE_SIZE = 10000;
+
 
 export class SequenceDiversityViewer extends SequenceSearchBaseViewer {
-  diverseColumnLabel: string | null; // Use postfix Label to prevent activating table column selection editor
+  diverseColumnLabel: string | null;
 
   renderMolIds: number[] | null = null;
   columnNames = [];
   computeCompleted = new Subject<boolean>();
 
-  // Store the original indices when sampling is used
   private sampledIndices: number[] | null = null;
 
   constructor(
@@ -64,65 +67,45 @@ export class SequenceDiversityViewer extends SequenceSearchBaseViewer {
   private async computeByMM() {
     const totalLength = this.targetColumn!.length;
     let workingIndices: number[];
-    let workingColumn: DG.Column;
 
     // Determine if we need to sample the data
     if (this.requiresSampling && totalLength > MAX_SAMPLE_SIZE) {
-      // Create a random sample of indices
       workingIndices = this.createRandomSample(totalLength, MAX_SAMPLE_SIZE);
       this.sampledIndices = workingIndices;
-
-      // Create a new column with only the sampled sequences
-      workingColumn = DG.Column.string(`${this.targetColumn!.name}_sampled`, workingIndices.length)
-        .init((i) => this.targetColumn!.get(workingIndices[i]));
-      workingColumn.semType = this.targetColumn!.semType;
-
-      // Copy all relevant tags
-      this.tags.forEach((tag) => {
-        if (this.targetColumn!.getTag(tag))
-          workingColumn.setTag(tag, this.targetColumn!.getTag(tag));
-      });
-
       grok.shell.info(`Sampled ${workingIndices.length} sequences from ${totalLength} for diversity calculation.`);
     } else {
       // Use the full dataset
       workingIndices = Array.from({length: totalLength}, (_, i) => i);
-      workingColumn = this.targetColumn!;
       this.sampledIndices = null;
     }
 
-    // Get the selected distance function and its options
     const distanceFunction = this.distanceMetric as MmDistanceFunctionsNames;
-    const distanceFunctionOptions = this.getDistanceFunctionOptions();
+    const params = this.getDistanceFunctionParams();
 
-    // Encode sequences using the selected distance function
-    // Note: getEncodedSeqSpaceCol only needs the fingerprint type, not full options
-    const fingerprintType = distanceFunctionOptions.fingerprintType || 'Morgan';
-    const encodedSequences = (await getEncodedSeqSpaceCol(
-      workingColumn,
-      distanceFunction,
-      fingerprintType
-    )).seqList;
+    const encodedResult = await getEncodedSeqSpaceCol(this.targetColumn!, distanceFunction, params);
+    const fullEncodedSequences = encodedResult.seqList;
+    const options = encodedResult.options;
 
-    // Calculate distance matrix for the working dataset
+    // Extract only the sequences we need for the working set
+    const workingEncodedSequences = workingIndices.map((idx) => fullEncodedSequences[idx]);
+
     const distanceMatrixService = new DistanceMatrixService(true, false);
     const distanceMatrixData = await distanceMatrixService.calc(
-      encodedSequences,
+      workingEncodedSequences,
       distanceFunction,
       true, // normalize
-      distanceFunctionOptions
+      options
     );
     distanceMatrixService.terminate();
 
-    const workingLength = workingColumn.length;
+    const workingLength = workingIndices.length;
     const linearizeFunc = dmLinearIndex(workingLength);
 
-    // Apply diversity selection on the working dataset
     const diverseIndicesInWorkingSet = getDiverseSubset(
       workingLength,
       Math.min(workingLength, this.limit),
       (i1: number, i2: number) => {
-        return workingColumn.isNone(i1) || workingColumn.isNone(i2) ? 0 :
+        return this.targetColumn!.isNone(workingIndices[i1]) || this.targetColumn!.isNone(workingIndices[i2]) ? 0 :
           distanceMatrixData[linearizeFunc(i1, i2)];
       }
     );
@@ -132,36 +115,38 @@ export class SequenceDiversityViewer extends SequenceSearchBaseViewer {
   }
 
   private createRandomSample(totalLength: number, sampleSize: number): number[] {
-    // Create array of all indices
-    const allIndices = Array.from({length: totalLength}, (_, i) => i);
-
-    // Filter out indices with missing values to avoid wasting sample space
-    const validIndices = allIndices.filter((i) => !this.targetColumn!.isNone(i));
+    const validIndices: number[] = [];
+    for (let i = 0; i < totalLength; i++) {
+      if (!this.targetColumn!.isNone(i))
+        validIndices.push(i);
+    }
 
     if (validIndices.length <= sampleSize)
       return validIndices;
 
-
-    // Fisher-Yates shuffle to get random sample
-    const shuffled = [...validIndices];
-    for (let i = shuffled.length - 1; i > 0; i--) {
+    for (let i = validIndices.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
-      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+      const temp = validIndices[i];
+      validIndices[i] = validIndices[j];
+      validIndices[j] = temp;
     }
 
-    return shuffled.slice(0, sampleSize).sort((a, b) => a - b);
+    // Return first sampleSize elements, sorted for better cache performance
+    const result = validIndices.slice(0, sampleSize);
+    result.sort((a, b) => a - b);
+    return result;
   }
 
-  // Helper method to get information about sampling (useful for debugging/info)
-  getSamplingInfo(): {isSampled: boolean, originalSize?: number, sampleSize?: number, sampledIndices?: number[]} {
-    if (this.sampledIndices) {
-      return {
-        isSampled: true,
-        originalSize: this.targetColumn?.length,
-        sampleSize: this.sampledIndices.length,
-        sampledIndices: this.sampledIndices
-      };
-    }
-    return {isSampled: false};
-  }
+  // // Helper method to get information about sampling (useful for debugging/info)
+  // getSamplingInfo(): {isSampled: boolean, originalSize?: number, sampleSize?: number, sampledIndices?: number[]} {
+  //   if (this.sampledIndices) {
+  //     return {
+  //       isSampled: true,
+  //       originalSize: this.targetColumn?.length,
+  //       sampleSize: this.sampledIndices.length,
+  //       sampledIndices: this.sampledIndices
+  //     };
+  //   }
+  //   return {isSampled: false};
+  // }
 }

--- a/packages/Bio/src/analysis/sequence-diversity-viewer.ts
+++ b/packages/Bio/src/analysis/sequence-diversity-viewer.ts
@@ -13,12 +13,17 @@ import {MmDistanceFunctionsNames} from '@datagrok-libraries/ml/src/macromolecule
 import {DistanceMatrixService, dmLinearIndex} from '@datagrok-libraries/ml/src/distance-matrix';
 import {MmcrTemps} from '@datagrok-libraries/bio/src/utils/cell-renderer-consts';
 
+const MAX_SAMPLE_SIZE = 10000; // Maximum size for sampling
+
 export class SequenceDiversityViewer extends SequenceSearchBaseViewer {
   diverseColumnLabel: string | null; // Use postfix Label to prevent activating table column selection editor
 
   renderMolIds: number[] | null = null;
   columnNames = [];
   computeCompleted = new Subject<boolean>();
+
+  // Store the original indices when sampling is used
+  private sampledIndices: number[] | null = null;
 
   constructor(
     private readonly seqHelper: ISeqHelper,
@@ -57,17 +62,106 @@ export class SequenceDiversityViewer extends SequenceSearchBaseViewer {
   }
 
   private async computeByMM() {
-    const encodedSequences =
-      (await getEncodedSeqSpaceCol(this.targetColumn!, MmDistanceFunctionsNames.LEVENSHTEIN)).seqList;
-    const distanceMatrixService = new DistanceMatrixService(true, false);
-    const distanceMatrixData = await distanceMatrixService.calc(encodedSequences, MmDistanceFunctionsNames.LEVENSHTEIN);
-    distanceMatrixService.terminate();
-    const len = this.targetColumn!.length;
-    const linearizeFunc = dmLinearIndex(len);
-    this.renderMolIds = getDiverseSubset(len, Math.min(len, this.limit),
-      (i1: number, i2: number) => {
-        return this.targetColumn!.isNone(i1) || this.targetColumn!.isNone(i2) ? 0 :
-          distanceMatrixData[linearizeFunc(i1, i2)];
+    const totalLength = this.targetColumn!.length;
+    let workingIndices: number[];
+    let workingColumn: DG.Column;
+
+    // Determine if we need to sample the data
+    if (this.requiresSampling && totalLength > MAX_SAMPLE_SIZE) {
+      // Create a random sample of indices
+      workingIndices = this.createRandomSample(totalLength, MAX_SAMPLE_SIZE);
+      this.sampledIndices = workingIndices;
+
+      // Create a new column with only the sampled sequences
+      workingColumn = DG.Column.string(`${this.targetColumn!.name}_sampled`, workingIndices.length)
+        .init((i) => this.targetColumn!.get(workingIndices[i]));
+      workingColumn.semType = this.targetColumn!.semType;
+
+      // Copy all relevant tags
+      this.tags.forEach((tag) => {
+        if (this.targetColumn!.getTag(tag))
+          workingColumn.setTag(tag, this.targetColumn!.getTag(tag));
       });
+
+      grok.shell.info(`Sampled ${workingIndices.length} sequences from ${totalLength} for diversity calculation.`);
+    } else {
+      // Use the full dataset
+      workingIndices = Array.from({length: totalLength}, (_, i) => i);
+      workingColumn = this.targetColumn!;
+      this.sampledIndices = null;
+    }
+
+    // Get the selected distance function and its options
+    const distanceFunction = this.distanceMetric as MmDistanceFunctionsNames;
+    const distanceFunctionOptions = this.getDistanceFunctionOptions();
+
+    // Encode sequences using the selected distance function
+    // Note: getEncodedSeqSpaceCol only needs the fingerprint type, not full options
+    const fingerprintType = distanceFunctionOptions.fingerprintType || 'Morgan';
+    const encodedSequences = (await getEncodedSeqSpaceCol(
+      workingColumn,
+      distanceFunction,
+      fingerprintType
+    )).seqList;
+
+    // Calculate distance matrix for the working dataset
+    const distanceMatrixService = new DistanceMatrixService(true, false);
+    const distanceMatrixData = await distanceMatrixService.calc(
+      encodedSequences,
+      distanceFunction,
+      true, // normalize
+      distanceFunctionOptions
+    );
+    distanceMatrixService.terminate();
+
+    const workingLength = workingColumn.length;
+    const linearizeFunc = dmLinearIndex(workingLength);
+
+    // Apply diversity selection on the working dataset
+    const diverseIndicesInWorkingSet = getDiverseSubset(
+      workingLength,
+      Math.min(workingLength, this.limit),
+      (i1: number, i2: number) => {
+        return workingColumn.isNone(i1) || workingColumn.isNone(i2) ? 0 :
+          distanceMatrixData[linearizeFunc(i1, i2)];
+      }
+    );
+
+    // Map back to original indices
+    this.renderMolIds = diverseIndicesInWorkingSet.map((workingIndex) => workingIndices[workingIndex]);
+  }
+
+  private createRandomSample(totalLength: number, sampleSize: number): number[] {
+    // Create array of all indices
+    const allIndices = Array.from({length: totalLength}, (_, i) => i);
+
+    // Filter out indices with missing values to avoid wasting sample space
+    const validIndices = allIndices.filter((i) => !this.targetColumn!.isNone(i));
+
+    if (validIndices.length <= sampleSize)
+      return validIndices;
+
+
+    // Fisher-Yates shuffle to get random sample
+    const shuffled = [...validIndices];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+
+    return shuffled.slice(0, sampleSize).sort((a, b) => a - b);
+  }
+
+  // Helper method to get information about sampling (useful for debugging/info)
+  getSamplingInfo(): {isSampled: boolean, originalSize?: number, sampleSize?: number, sampledIndices?: number[]} {
+    if (this.sampledIndices) {
+      return {
+        isSampled: true,
+        originalSize: this.targetColumn?.length,
+        sampleSize: this.sampledIndices.length,
+        sampledIndices: this.sampledIndices
+      };
+    }
+    return {isSampled: false};
   }
 }

--- a/packages/Bio/src/analysis/sequence-search-base-viewer.ts
+++ b/packages/Bio/src/analysis/sequence-search-base-viewer.ts
@@ -2,30 +2,87 @@ import * as ui from 'datagrok-api/ui';
 import * as DG from 'datagrok-api/dg';
 import * as grok from 'datagrok-api/grok';
 
-import {CHEM_SIMILARITY_METRICS} from '@datagrok-libraries/ml/src/distance-metrics-methods';
+import {MmDistanceFunctionsNames} from '@datagrok-libraries/ml/src/macromolecule-distance-functions';
 import {TAGS as bioTAGS} from '@datagrok-libraries/bio/src/utils/macromolecule';
 import {SearchBaseViewer} from '@datagrok-libraries/ml/src/viewers/search-base-viewer';
 
-const MAX_ROWS_FOR_DISTANCE_MATRIX = 22000;
+const MAX_ROWS_FOR_DISTANCE_MATRIX = 10000; // Reduced from 22000 to be safer
+const MAX_ROWS_FOR_FULL_CALCULATION = 15000; // Threshold for switching to sampling
 
 export class SequenceSearchBaseViewer extends SearchBaseViewer {
   distanceMetric: string;
   fingerprint: string;
-  metricsProperties = ['distanceMetric', 'fingerprint'];
-  fingerprintChoices = ['Morgan', 'Pattern'];
+  gapOpen: number;
+  gapExtend: number;
+
+  metricsProperties = ['distanceMetric', 'fingerprint', 'gapOpen', 'gapExtend'];
+  fingerprintChoices = ['Morgan', 'RDKit', 'Pattern', 'AtomPair', 'MACCS', 'TopologicalTorsion'];
+  distanceFunctionChoices = [
+    MmDistanceFunctionsNames.NEEDLEMANN_WUNSCH,
+    MmDistanceFunctionsNames.HAMMING,
+    MmDistanceFunctionsNames.LEVENSHTEIN,
+    MmDistanceFunctionsNames.MONOMER_CHEMICAL_DISTANCE
+  ];
+
   tags = [DG.TAGS.UNITS, bioTAGS.aligned, bioTAGS.separator, bioTAGS.alphabet, 'cell.renderer'];
   preComputeDistanceMatrix: boolean = false;
+  requiresSampling: boolean = false;
 
   constructor(name: string, semType: string) {
     super(name, semType);
-    this.fingerprint = this.string('fingerprint', this.fingerprintChoices[0], {choices: this.fingerprintChoices});
-    this.distanceMetric = this.string('distanceMetric', CHEM_SIMILARITY_METRICS[0], {choices: CHEM_SIMILARITY_METRICS});
+
+    // Initialize with macromolecule distance functions instead of chemical similarity metrics
+    this.distanceMetric = this.string('distanceMetric', this.distanceFunctionChoices[0], {
+      choices: this.distanceFunctionChoices
+    });
+
+    this.fingerprint = this.string('fingerprint', this.fingerprintChoices[0], {
+      choices: this.fingerprintChoices
+    });
+
+    // Gap penalty parameters for Needleman-Wunsch
+    this.gapOpen = this.float('gapOpen', -10.0);
+    this.gapExtend = this.float('gapExtend', -0.5);
   }
 
   async onTableAttached(): Promise<void> {
     super.onTableAttached();
 
-    if (this.dataFrame)
-      this.preComputeDistanceMatrix = this.dataFrame.rowCount <= MAX_ROWS_FOR_DISTANCE_MATRIX;
+    if (this.dataFrame) {
+      const rowCount = this.dataFrame.rowCount;
+      this.preComputeDistanceMatrix = rowCount <= MAX_ROWS_FOR_DISTANCE_MATRIX;
+      this.requiresSampling = rowCount > MAX_ROWS_FOR_FULL_CALCULATION;
+
+      if (this.requiresSampling)
+        grok.shell.info(`Large dataset detected (${rowCount} rows). Will use sampling for diversity calculation.`);
+    }
+  }
+
+  // Helper method to get distance function options for current selection
+  getDistanceFunctionOptions(): {[key: string]: any} {
+    const options: {[key: string]: any} = {};
+
+    if (this.distanceMetric === MmDistanceFunctionsNames.NEEDLEMANN_WUNSCH) {
+      options.gapOpen = this.gapOpen;
+      options.gapExtend = this.gapExtend;
+    }
+
+    if (this.distanceMetric === MmDistanceFunctionsNames.MONOMER_CHEMICAL_DISTANCE ||
+        this.distanceMetric === MmDistanceFunctionsNames.NEEDLEMANN_WUNSCH)
+      options.fingerprintType = this.fingerprint;
+
+
+    return options;
+  }
+
+  // Helper method to check if gap penalties are needed
+  needsGapPenalties(): boolean {
+    return this.distanceMetric === MmDistanceFunctionsNames.NEEDLEMANN_WUNSCH;
+  }
+
+  // Helper method to check if fingerprint is needed
+  needsFingerprint(): boolean {
+    return this.distanceMetric === MmDistanceFunctionsNames.MONOMER_CHEMICAL_DISTANCE ||
+           this.distanceMetric === MmDistanceFunctionsNames.NEEDLEMANN_WUNSCH;
   }
 }

--- a/packages/Bio/src/analysis/sequence-search-base-viewer.ts
+++ b/packages/Bio/src/analysis/sequence-search-base-viewer.ts
@@ -5,9 +5,9 @@ import * as grok from 'datagrok-api/grok';
 import {MmDistanceFunctionsNames} from '@datagrok-libraries/ml/src/macromolecule-distance-functions';
 import {TAGS as bioTAGS} from '@datagrok-libraries/bio/src/utils/macromolecule';
 import {SearchBaseViewer} from '@datagrok-libraries/ml/src/viewers/search-base-viewer';
+import {DistanceFunctionParams} from './sequence-space';
 
-const MAX_ROWS_FOR_DISTANCE_MATRIX = 10000; // Reduced from 22000 to be safer
-const MAX_ROWS_FOR_FULL_CALCULATION = 15000; // Threshold for switching to sampling
+const MAX_ROWS_FOR_DISTANCE_MATRIX = 10000;
 
 export class SequenceSearchBaseViewer extends SearchBaseViewer {
   distanceMetric: string;
@@ -31,8 +31,7 @@ export class SequenceSearchBaseViewer extends SearchBaseViewer {
   constructor(name: string, semType: string) {
     super(name, semType);
 
-    // Initialize with macromolecule distance functions instead of chemical similarity metrics
-    this.distanceMetric = this.string('distanceMetric', this.distanceFunctionChoices[0], {
+    this.distanceMetric = this.string('distanceMetric', MmDistanceFunctionsNames.HAMMING, {
       choices: this.distanceFunctionChoices
     });
 
@@ -40,9 +39,8 @@ export class SequenceSearchBaseViewer extends SearchBaseViewer {
       choices: this.fingerprintChoices
     });
 
-    // Gap penalty parameters for Needleman-Wunsch
-    this.gapOpen = this.float('gapOpen', -10.0);
-    this.gapExtend = this.float('gapExtend', -0.5);
+    this.gapOpen = this.float('gapOpen', 1);
+    this.gapExtend = this.float('gapExtend', 0.6);
   }
 
   async onTableAttached(): Promise<void> {
@@ -51,36 +49,22 @@ export class SequenceSearchBaseViewer extends SearchBaseViewer {
     if (this.dataFrame) {
       const rowCount = this.dataFrame.rowCount;
       this.preComputeDistanceMatrix = rowCount <= MAX_ROWS_FOR_DISTANCE_MATRIX;
-      this.requiresSampling = rowCount > MAX_ROWS_FOR_FULL_CALCULATION;
-
-      if (this.requiresSampling)
-        grok.shell.info(`Large dataset detected (${rowCount} rows). Will use sampling for diversity calculation.`);
+      this.requiresSampling = rowCount > MAX_ROWS_FOR_DISTANCE_MATRIX;
     }
   }
 
-  // Helper method to get distance function options for current selection
-  getDistanceFunctionOptions(): {[key: string]: any} {
-    const options: {[key: string]: any} = {};
-
-    if (this.distanceMetric === MmDistanceFunctionsNames.NEEDLEMANN_WUNSCH) {
-      options.gapOpen = this.gapOpen;
-      options.gapExtend = this.gapExtend;
-    }
-
-    if (this.distanceMetric === MmDistanceFunctionsNames.MONOMER_CHEMICAL_DISTANCE ||
-        this.distanceMetric === MmDistanceFunctionsNames.NEEDLEMANN_WUNSCH)
-      options.fingerprintType = this.fingerprint;
-
-
-    return options;
+  getDistanceFunctionParams(): DistanceFunctionParams {
+    return {
+      fingerprintType: this.fingerprint,
+      gapOpen: this.gapOpen,
+      gapExtend: this.gapExtend
+    };
   }
 
-  // Helper method to check if gap penalties are needed
   needsGapPenalties(): boolean {
     return this.distanceMetric === MmDistanceFunctionsNames.NEEDLEMANN_WUNSCH;
   }
 
-  // Helper method to check if fingerprint is needed
   needsFingerprint(): boolean {
     return this.distanceMetric === MmDistanceFunctionsNames.MONOMER_CHEMICAL_DISTANCE ||
            this.distanceMetric === MmDistanceFunctionsNames.NEEDLEMANN_WUNSCH;

--- a/packages/Bio/src/analysis/sequence-similarity-viewer.ts
+++ b/packages/Bio/src/analysis/sequence-similarity-viewer.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-len */
+/* eslint-disable space-infix-ops */
 import * as grok from 'datagrok-api/grok';
 import * as ui from 'datagrok-api/ui';
 import * as DG from 'datagrok-api/dg';
@@ -16,7 +18,7 @@ import {MmcrTemps, tempTAGS} from '@datagrok-libraries/bio/src/utils/cell-render
 export class SequenceSimilarityViewer extends SequenceSearchBaseViewer {
   cutoff: number;
   hotSearch: boolean;
-  similarColumnLabel: string | null; // Use postfix Label to prevent activating table column selection editor
+  similarColumnLabel: string | null;
 
   sketchedMolecule: string = '';
   curIdx: number = 0;
@@ -33,6 +35,12 @@ export class SequenceSimilarityViewer extends SequenceSearchBaseViewer {
   demo?: boolean;
   analysisGrid?: DG.Grid;
   subInited: boolean = false;
+
+  // Track last parameters to avoid unnecessary recomputation
+  private lastDistanceMetric: string = '';
+  private lastFingerprint: string = '';
+  private lastGapOpen: number = 0;
+  private lastGapExtend: number = 0;
 
   constructor(
     private readonly seqHelper: ISeqHelper,
@@ -106,14 +114,34 @@ export class SequenceSimilarityViewer extends SequenceSearchBaseViewer {
   private async computeByMM() {
     const len = this.targetColumn!.length;
     const actualLimit = Math.min(this.limit, len - 1);
-    if (!this.knn || this.kPrevNeighbors !== actualLimit) {
-      const encodedSequences =
-        (await getEncodedSeqSpaceCol(this.targetColumn!, MmDistanceFunctionsNames.LEVENSHTEIN)).seqList;
 
+    // Check if need to recalculate knn due to parameter changes
+    const needsRecalculation = !this.knn ||
+      this.kPrevNeighbors !== actualLimit ||
+      this.lastDistanceMetric !== this.distanceMetric ||
+      this.lastFingerprint !== this.fingerprint ||
+      this.lastGapOpen !== this.gapOpen ||
+      this.lastGapExtend !== this.gapExtend;
+
+    if (needsRecalculation) {
+      const distanceFunction = this.distanceMetric as MmDistanceFunctionsNames;
+      const params = this.getDistanceFunctionParams();
+
+      const encodedResult = await getEncodedSeqSpaceCol(this.targetColumn!, distanceFunction, params);
+      const encodedSequences = encodedResult.seqList;
+      const options = encodedResult.options;
+
+      // Store current parameters for next comparison
+      this.lastDistanceMetric = this.distanceMetric;
+      this.lastFingerprint = this.fingerprint;
+      this.lastGapOpen = this.gapOpen;
+      this.lastGapExtend = this.gapExtend;
       this.kPrevNeighbors = actualLimit;
+
       this.knn = await (new SparseMatrixService()
-        .getKNN(encodedSequences, MmDistanceFunctionsNames.LEVENSHTEIN, Math.min(this.limit, len - 1)));
+        .getKNN(encodedSequences, distanceFunction, actualLimit, options));
     }
+
     const indexWScore = new Array(actualLimit).fill(0).map((_, i) => ({
       idx: this.knn!.knnIndexes[this.targetMoleculeIdx][i],
       score: 1 - this.knn!.knnDistances[this.targetMoleculeIdx][i],

--- a/packages/Bio/src/package.ts
+++ b/packages/Bio/src/package.ts
@@ -544,8 +544,16 @@ export async function macromoleculePreprocessingFunction(
   fingerprintType = 'Morgan'): Promise<PreprocessFunctionReturnType> {
   if (col.semType !== DG.SEMTYPE.MACROMOLECULE)
     return {entries: col.toList(), options: {}};
-  const {seqList, options} = await getEncodedSeqSpaceCol(col, metric, fingerprintType);
-  return {entries: seqList, options: {...options, gapOpen, gapExtend}};
+
+  // Use the new DistanceFunctionParams object structure
+  const params = {
+    fingerprintType,
+    gapOpen,
+    gapExtend
+  };
+
+  const {seqList, options} = await getEncodedSeqSpaceCol(col, metric, params);
+  return {entries: seqList, options};
 }
 
 //name: Helm Fingerprints


### PR DESCRIPTION
Satisfies https://reddata.atlassian.net/browse/GROK-18258

- harmonized option passing for various distance metrics (it's now done through `getEncodedSeqSpaceCol`.
- rerenders are triggered correctly now (storing last option values now)
- sampling simplified/no array destructuring
- corrected default gapExtend/gapOpen values to those suggested in the N-W implementation

