### PR TITLE
BioStructure Viewer: sequence extraction based on the PDB_ID value

### DIFF
--- a/packages/Bio/src/widgets/sequence-scrolling-widget.ts
+++ b/packages/Bio/src/widgets/sequence-scrolling-widget.ts
@@ -351,7 +351,6 @@ export function handleSequenceHeaderRendering() {
 
         const isMSA = sh.isMsa();
 
-        // Only create scrolling header for MSA sequences
         if (isMSA) {
           const ifNan = (a: number, els: number) => (Number.isNaN(a) ? els : a);
           const getStart = () => ifNan(Math.max(Number.parseInt(seqCol.getTag(bioTAGS.positionShift) ?? '0'), 0), 0) + 1;
@@ -538,9 +537,7 @@ export function handleSequenceHeaderRendering() {
               console.error('Failed to initialize monomer library:', error);
             });
         } else {
-          // For non-MSA sequences, just use standard sequence rendering
-          // No scrolling header needed - the cell renderer will handle display
-          console.log(`Skipping scrolling header for non-MSA sequence column: ${seqCol.name}`);
+          // For non-MSA sequences, just use standard sequence rendering.
         }
       }
     }, 1000);

--- a/packages/BiostructureViewer/.eslintrc.json
+++ b/packages/BiostructureViewer/.eslintrc.json
@@ -16,7 +16,6 @@
     "no-throw-literal": "error",
     "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": ["warn", { "varsIgnorePattern": "^(_|ui$|grok$|DG$)", "argsIgnorePattern": "^_"}],
-    "@typescript-eslint/require-array-sort-compare": "error",
     "require-jsdoc": "off",
     "valid-jsdoc": "warn",
     "spaced-comment": "off",

--- a/packages/BiostructureViewer/src/package-api.ts
+++ b/packages/BiostructureViewer/src/package-api.ts
@@ -225,8 +225,7 @@ export namespace funcs {
     return await grok.functions.call('@datagrok/biostructure-viewer:Structure3D', { molecule });
   }
 
-  //? These are for demo purposes only.
-  //Extract protein sequences using Molstar parser (just demos)
+  //Extract protein sequences using Molstar parser
   export async function extractProteinSequencesMolstar(pdbId: string): Promise<any> {
     return await grok.functions.call('@datagrok/biostructure-viewer:ExtractProteinSequencesMolstar', { pdbId });
   }
@@ -240,6 +239,4 @@ export namespace funcs {
   export async function testMolstarMultiple(): Promise<any> {
     return await grok.functions.call('@datagrok/biostructure-viewer:TestMolstarMultiple', {});
   }
-  //? These are for demo purposes only.
-
 }

--- a/packages/BiostructureViewer/src/package-api.ts
+++ b/packages/BiostructureViewer/src/package-api.ts
@@ -230,8 +230,7 @@ export namespace funcs {
     return await grok.functions.call('@datagrok/biostructure-viewer:ExtractSequenceColumnsToDataFrame', {});
   }
 
-  //Extract protein sequences using GraphQL (fast method)
-  export async function extractSequences(): Promise<any> {
-    return await grok.functions.call('@datagrok/biostructure-viewer:ExtractSequences', {});
+  export async function fetchSequencesFromPdb(table: DG.DataFrame, pdbId: DG.Column): Promise<any> {
+    return await grok.functions.call('@datagrok/biostructure-viewer:FetchSequencesFromPdb', { table, pdbId });
   }
 }

--- a/packages/BiostructureViewer/src/package-api.ts
+++ b/packages/BiostructureViewer/src/package-api.ts
@@ -4,6 +4,7 @@ import * as DG from 'datagrok-api/dg';
 
 
 export namespace funcs {
+  //export async function init() 
   export async function init(): Promise<any> {
     return await grok.functions.call('@datagrok/biostructure-viewer:Init', {});
   }
@@ -140,10 +141,12 @@ export namespace funcs {
     return await grok.functions.call('@datagrok/biostructure-viewer:GetPdbHelper', {});
   }
 
+  //export async function dockingDemo() 
   export async function dockingDemo(): Promise<any> {
     return await grok.functions.call('@datagrok/biostructure-viewer:DockingDemo', {});
   }
 
+  //export async function inGridDemo() 
   export async function inGridDemo(): Promise<any> {
     return await grok.functions.call('@datagrok/biostructure-viewer:InGridDemo', {});
   }
@@ -221,4 +224,22 @@ export namespace funcs {
   export async function structure3D(molecule: any): Promise<any> {
     return await grok.functions.call('@datagrok/biostructure-viewer:Structure3D', { molecule });
   }
+
+  //? These are for demo purposes only.
+  //Extract protein sequences using Molstar parser (just demos)
+  export async function extractProteinSequencesMolstar(pdbId: string): Promise<any> {
+    return await grok.functions.call('@datagrok/biostructure-viewer:ExtractProteinSequencesMolstar', { pdbId });
+  }
+
+  //Test the Molstar-based extraction
+  export async function testMolstarExtraction(pdbId: string): Promise<any> {
+    return await grok.functions.call('@datagrok/biostructure-viewer:TestMolstarExtraction', { pdbId });
+  }
+
+  //Test Molstar extraction with multiple PDBs
+  export async function testMolstarMultiple(): Promise<any> {
+    return await grok.functions.call('@datagrok/biostructure-viewer:TestMolstarMultiple', {});
+  }
+  //? These are for demo purposes only.
+
 }

--- a/packages/BiostructureViewer/src/package-api.ts
+++ b/packages/BiostructureViewer/src/package-api.ts
@@ -239,4 +239,14 @@ export namespace funcs {
   export async function testMolstarMultiple(): Promise<any> {
     return await grok.functions.call('@datagrok/biostructure-viewer:TestMolstarMultiple', {});
   }
+
+  //Extract protein sequences from all PDB IDs and add as columns to current dataframe
+  export async function extractSequenceColumnsToDataFrame(): Promise<any> {
+    return await grok.functions.call('@datagrok/biostructure-viewer:ExtractSequenceColumnsToDataFrame', {});
+  }
+
+  //Alias for extractSequenceColumnsToDataFrame (shorter console command)
+  export async function extractSequences(): Promise<any> {
+    return await grok.functions.call('@datagrok/biostructure-viewer:ExtractSequences', {});
+  }
 }

--- a/packages/BiostructureViewer/src/package-api.ts
+++ b/packages/BiostructureViewer/src/package-api.ts
@@ -225,27 +225,12 @@ export namespace funcs {
     return await grok.functions.call('@datagrok/biostructure-viewer:Structure3D', { molecule });
   }
 
-  //Extract protein sequences using Molstar parser
-  export async function extractProteinSequencesMolstar(pdbId: string): Promise<any> {
-    return await grok.functions.call('@datagrok/biostructure-viewer:ExtractProteinSequencesMolstar', { pdbId });
-  }
-
-  //Test the Molstar-based extraction
-  export async function testMolstarExtraction(pdbId: string): Promise<any> {
-    return await grok.functions.call('@datagrok/biostructure-viewer:TestMolstarExtraction', { pdbId });
-  }
-
-  //Test Molstar extraction with multiple PDBs
-  export async function testMolstarMultiple(): Promise<any> {
-    return await grok.functions.call('@datagrok/biostructure-viewer:TestMolstarMultiple', {});
-  }
-
-  //Extract protein sequences from all PDB IDs and add as columns to current dataframe
+  //Extract protein sequences from all PDB IDs and add as columns to current dataframe (GraphQL-powered)
   export async function extractSequenceColumnsToDataFrame(): Promise<any> {
     return await grok.functions.call('@datagrok/biostructure-viewer:ExtractSequenceColumnsToDataFrame', {});
   }
 
-  //Alias for extractSequenceColumnsToDataFrame (shorter console command)
+  //Extract protein sequences using GraphQL (fast method)
   export async function extractSequences(): Promise<any> {
     return await grok.functions.call('@datagrok/biostructure-viewer:ExtractSequences', {});
   }

--- a/packages/BiostructureViewer/src/pdb-entry.ts
+++ b/packages/BiostructureViewer/src/pdb-entry.ts
@@ -1,4 +1,5 @@
 import {genRange} from '@datagrok-libraries/utils/src/vector-operations';
+import {RcsbGraphQLAdapter} from './utils/rcsb-gql-adapter';
 
 type Tracks = {[kind: string]: number[]};
 type _Tracks = {[kind: string]: Set<number>};
@@ -10,28 +11,24 @@ interface Chain {
 }
 
 /** Polymer entity data. */
- interface Entity {
+interface Entity {
   id: string;
   sequence: string;
   chains: Chain[];
 }
 
 /** RCSB REST API URLs. */
-// eslint-disable-next-line no-unused-vars
 enum RCSBRESTAPI {
-  // eslint-disable-next-line no-unused-vars
   file = 'https://files.rcsb.org/download/{entry_id}.pdb',
-  // eslint-disable-next-line no-unused-vars
   entry = 'https://data.rcsb.org/rest/v1/core/entry/{entry_id}',
-  // eslint-disable-next-line no-unused-vars
   entity = 'https://data.rcsb.org/rest/v1/core/polymer_entity/{entry_id}/{entity_id}',
-  // eslint-disable-next-line no-unused-vars
   instance = 'https://data.rcsb.org/rest/v1/core/polymer_entity_instance/{entry_id}/{asym_id}',
 }
 
 /**
+ * Enhanced PdbEntry class with GraphQL capabilities.
  * Can be used to retrieve primary, secondary, and tertiary structure
- * of polymers from RCSB PDB. Primarily designed for proteins.
+ * of polymers from RCSB PDB using both REST and GraphQL APIs.
  */
 export class PdbEntry {
   protected RCSB = RCSBRESTAPI;
@@ -39,21 +36,121 @@ export class PdbEntry {
   protected pdbID: string;
   protected pdbBody: string;
   protected items: Entity[];
+  protected useGraphQL: boolean;
 
-  constructor(pdbID: string) {
-    this.pdbID = pdbID.toLocaleLowerCase();
+  constructor(pdbID: string, useGraphQL: boolean = true) {
+    this.pdbID = pdbID.toLowerCase();
     this.pdbBody = '';
     this.items = [];
+    this.useGraphQL = useGraphQL;
   }
 
-  /** Fetches all pieces of data. */
-  async fetchInfo() {
+  /** 
+   * Fetches all pieces of data using the preferred method (GraphQL or REST).
+   */
+  async fetchInfo(): Promise<void> {
+    if (this.useGraphQL) {
+      await this.fetchInfoGraphQL();
+    } else {
+      await this.fetchInfoREST();
+    }
+  }
+
+  /**
+   * Fetches polymer sequences using GraphQL.
+   * Much more efficient than downloading the entire structure file.
+   */
+  async fetchPolymerSequences(): Promise<{[entityId: string]: {sequence: string; type: string; chains: string[]}}> {
+    return await RcsbGraphQLAdapter.getPolymerSequences(this.pdbID);
+  }
+
+  /**
+   * Get only protein sequences using GraphQL.
+   * Filters out DNA/RNA and returns a simple chain -> sequence mapping.
+   */
+  async getProteinSequences(): Promise<{[chainId: string]: string}> {
+    return await RcsbGraphQLAdapter.getProteinSequences(this.pdbID);
+  }
+
+  /**
+   * Get basic entry information using GraphQL.
+   */
+  async getEntryInfo(): Promise<{id: string; title?: string; resolution?: number; experimentalMethod?: string}> {
+    return await RcsbGraphQLAdapter.getEntryInfo(this.pdbID);
+  }
+
+  /**
+   * Create a DataFrame with sequence data using GraphQL.
+   */
+  async createSequenceDataFrame(): Promise<any> { // Using 'any' to avoid DG import in this context
+    return await RcsbGraphQLAdapter.createSequenceDataFrame(this.pdbID);
+  }
+
+  /**
+   * Enhanced fetchInfo using GraphQL for polymer data and REST for structure file.
+   * This hybrid approach gets sequences efficiently while still providing full structure access.
+   */
+  private async fetchInfoGraphQL(): Promise<void> {
+    // Get basic info and sequences via GraphQL
+    const [entryInfo, polymerData] = await Promise.all([
+      this.getEntryInfo(),
+      this.fetchPolymerSequences()
+    ]);
+
+    // Convert GraphQL data to the existing Entity format
+    this.items = await this.convertGraphQLToEntities(polymerData);
+
+    // Optionally fetch the structure file (only if needed)
+    // this.pdbBody = await this._getPDBAsText();
+  }
+
+  /**
+   * Original REST-based fetchInfo method (preserved for compatibility).
+   */
+  private async fetchInfoREST(): Promise<void> {
     this.pdbBody = await this._getPDBAsText();
 
     const entry = await this._getPDBEntry();
     const entityIDs = entry['rcsb_entry_container_identifiers']['polymer_entity_ids'];
 
     this.items = await this._cycleThroughPDBEntities(entityIDs);
+  }
+
+  /**
+   * Convert GraphQL polymer data to the existing Entity interface format.
+   */
+  private async convertGraphQLToEntities(polymerData: {[entityId: string]: {sequence: string; type: string; chains: string[]}}): Promise<Entity[]> {
+    const entities: Entity[] = [];
+
+    for (const [entityId, data] of Object.entries(polymerData)) {
+      const chains: Chain[] = [];
+      
+      // For each chain, create a Chain object
+      // Note: GraphQL doesn't provide secondary structure info, so tracks will be empty
+      // You could extend this to make additional GraphQL queries for secondary structure if needed
+      for (const chainId of data.chains) {
+        chains.push({
+          id: chainId,
+          tracks: {} // Empty for now - could be populated with additional GraphQL queries
+        });
+      }
+
+      entities.push({
+        id: entityId,
+        sequence: data.sequence,
+        chains: chains
+      });
+    }
+
+    return entities;
+  }
+
+  /**
+   * Fetch secondary structure information for a specific chain using REST.
+   * This can be used to populate tracks when full secondary structure info is needed.
+   */
+  async fetchSecondaryStructure(asymId: string): Promise<Tracks> {
+    return await this._filterPDBPolymerEntityInstances(asymId);
   }
 
   /** Downloads structure file as a string. */
@@ -104,7 +201,7 @@ export class PdbEntry {
   }
 
   /**
-   * Filters polymer chains and returns hositions with secondary structure information assigned.
+   * Filters polymer chains and returns positions with secondary structure information assigned.
    * @param {string} asymID Chain ID of an entity.
    */
   protected async _filterPDBPolymerEntityInstances(asymID: string): Promise<Tracks> {
@@ -122,7 +219,6 @@ export class PdbEntry {
       if (this.secondaryKinds.includes(annotType)) {
         if (_tracks[annotType] === undefined)
           _tracks[annotType] = new Set();
-
 
         for (const pos of annot['feature_positions']) {
           const range = genRange(pos['beg_seq_id'], pos['end_seq_id']);
@@ -142,8 +238,13 @@ export class PdbEntry {
 
   /** Tertiary structure as a string. */
   get body(): string {
-    if (this.pdbBody.length == 0)
-      throw new Error('Call fetchInfo before getting file body.');
+    if (this.pdbBody.length == 0) {
+      if (this.useGraphQL) {
+        throw new Error('Structure file not loaded. Call fetchInfoREST() or _getPDBAsText() to load structure file.');
+      } else {
+        throw new Error('Call fetchInfo() before getting file body.');
+      }
+    }
 
     return this.pdbBody;
   }
@@ -151,9 +252,23 @@ export class PdbEntry {
   /** Primary and secondary structure. */
   get entities(): Entity[] {
     if (this.items.length == 0)
-      throw new Error('Call fetchInfo before getting entities.');
+      throw new Error('Call fetchInfo() before getting entities.');
 
     return this.items;
+  }
+
+  /** Get sequences only (lightweight access). */
+  get sequences(): {[entityId: string]: string} {
+    const result: {[entityId: string]: string} = {};
+    for (const entity of this.entities) {
+      result[entity.id] = entity.sequence;
+    }
+    return result;
+  }
+
+  /** Switch between GraphQL and REST mode. */
+  setGraphQLMode(useGraphQL: boolean): void {
+    this.useGraphQL = useGraphQL;
   }
 
   //TODO: remove - demo use only
@@ -166,7 +281,7 @@ export class PdbEntry {
  * Helper function to request information by URL.
  *
  * @param {string} url URL to request.
- * @param {boolean} [asJSON=false] Whether to reply with JSIN or simple string.
+ * @param {boolean} [asJSON=false] Whether to reply with JSON or simple string.
  * @return {(Promise<string | any>)} Result of the request.
  */
 async function _fetchTextFromURL(url: string, asJSON = false): Promise<string | any> {

--- a/packages/BiostructureViewer/src/pdb-entry.ts
+++ b/packages/BiostructureViewer/src/pdb-entry.ts
@@ -1,5 +1,6 @@
 import {genRange} from '@datagrok-libraries/utils/src/vector-operations';
 import {RcsbGraphQLAdapter} from './utils/rcsb-gql-adapter';
+import * as DG from 'datagrok-api/dg';
 
 type Tracks = {[kind: string]: number[]};
 type _Tracks = {[kind: string]: Set<number>};
@@ -81,9 +82,10 @@ export class PdbEntry {
   /**
    * Create a DataFrame with sequence data using GraphQL.
    */
-  async createSequenceDataFrame(): Promise<any> { // Using 'any' to avoid DG import in this context
+  async createSequenceDataFrame(): Promise<DG.DataFrame> {
     return await RcsbGraphQLAdapter.createSequenceDataFrame(this.pdbID);
   }
+
 
   /**
    * Enhanced fetchInfo using GraphQL for polymer data and REST for structure file.

--- a/packages/BiostructureViewer/src/pdb-entry.ts
+++ b/packages/BiostructureViewer/src/pdb-entry.ts
@@ -45,15 +45,14 @@ export class PdbEntry {
     this.useGraphQL = useGraphQL;
   }
 
-  /** 
+  /**
    * Fetches all pieces of data using the preferred method (GraphQL or REST).
    */
   async fetchInfo(): Promise<void> {
-    if (this.useGraphQL) {
+    if (this.useGraphQL)
       await this.fetchInfoGraphQL();
-    } else {
+    else
       await this.fetchInfoREST();
-    }
   }
 
   /**
@@ -124,7 +123,7 @@ export class PdbEntry {
 
     for (const [entityId, data] of Object.entries(polymerData)) {
       const chains: Chain[] = [];
-      
+
       // For each chain, create a Chain object
       // Note: GraphQL doesn't provide secondary structure info, so tracks will be empty
       // You could extend this to make additional GraphQL queries for secondary structure if needed
@@ -239,11 +238,10 @@ export class PdbEntry {
   /** Tertiary structure as a string. */
   get body(): string {
     if (this.pdbBody.length == 0) {
-      if (this.useGraphQL) {
+      if (this.useGraphQL)
         throw new Error('Structure file not loaded. Call fetchInfoREST() or _getPDBAsText() to load structure file.');
-      } else {
+      else
         throw new Error('Call fetchInfo() before getting file body.');
-      }
     }
 
     return this.pdbBody;
@@ -260,9 +258,9 @@ export class PdbEntry {
   /** Get sequences only (lightweight access). */
   get sequences(): {[entityId: string]: string} {
     const result: {[entityId: string]: string} = {};
-    for (const entity of this.entities) {
+    for (const entity of this.entities)
       result[entity.id] = entity.sequence;
-    }
+
     return result;
   }
 

--- a/packages/BiostructureViewer/src/utils/pdb-grid-cell-renderer.ts
+++ b/packages/BiostructureViewer/src/utils/pdb-grid-cell-renderer.ts
@@ -16,7 +16,7 @@ import {getGridCellColTemp} from '@datagrok-libraries/bio/src/utils/cell-rendere
 import {IPdbGridCellRenderer} from './types';
 import {_getNglGlService} from '../package-utils';
 
-import {_package} from '../package';
+import {_package, extractProteinSequencesMolstar} from '../package';
 import {LruCache} from 'datagrok-api/dg';
 
 export const enum Temps {
@@ -161,22 +161,10 @@ export class PdbGridCellRenderer extends DG.GridCellRenderer {
   }
 }
 
-
 /// Shows PDB id when the cell is small, and renders protein if the cell is higher than 40 pixels
-
-
 export class PdbIdGridCellRenderer extends DG.GridCellRenderer {
   imageCache: LruCache<string, HTMLImageElement> = new LruCache<string, HTMLImageElement>();
   pdbIdHeight: number = 25;
-  
-  // Simple boolean to show/hide sequence button
-  private renderViewChainsPortal: boolean = true;
-  private buttonWidth: number = 50;
-  private buttonHeight: number = 16;
-  
-  // Hover state tracking
-  private hoveredCell: DG.GridCell | null = null;
-  private isButtonHovered: boolean = false;
 
   get defaultWidth() { return 100; }
   get defaultHeight() { return 100; }
@@ -191,29 +179,11 @@ export class PdbIdGridCellRenderer extends DG.GridCellRenderer {
     const cellValue = (renderedOnGrid ? gridCell.cell.valueString : (gridCell.cell?.value ?? '').toString()).toLowerCase();
 
     if (h < 40 || cellValue.length < 4 || w < 40) {
-      // Small cell - render text with optional button
-      this.renderSmallCell(g, x, y, w, h, gridCell, cellStyle);
-    } else {
-      // Large cell - render image with text header and optional button
-      this.renderLargeCell(g, x, y, w, h, gridCell, cellStyle, cellValue, renderedOnGrid);
-    }
-  }
-
-  private renderSmallCell(
-    g: CanvasRenderingContext2D, x: number, y: number, w: number, h: number,
-    gridCell: DG.GridCell, cellStyle: DG.GridCellStyle
-  ): void {
-    if (this.renderViewChainsPortal && w > this.buttonWidth + 10) {
-      // Render text in reduced area
-      const textWidth = w - this.buttonWidth - 4;
-      DG.GridCellRenderer.byName('string')?.render(g, x, y, textWidth, h, gridCell, cellStyle);
-      
-      // Render button with hover state
-      const isHovered = this.hoveredCell === gridCell && this.isButtonHovered;
-      this.drawSequenceButton(g, x + textWidth + 2, y + 2, this.buttonWidth, h - 4, isHovered);
-    } else {
-      // Normal text rendering
+      // Small cell - render text only
       DG.GridCellRenderer.byName('string')?.render(g, x, y, w, h, gridCell, cellStyle);
+    } else {
+      // Large cell - render image with text header
+      this.renderLargeCell(g, x, y, w, h, gridCell, cellStyle, cellValue, renderedOnGrid);
     }
   }
 
@@ -225,10 +195,6 @@ export class PdbIdGridCellRenderer extends DG.GridCellRenderer {
     const url = `https://cdn.rcsb.org/images/structures/${pdb}_assembly-1.jpeg`;
     const cache = this.imageCache;
 
-    // Calculate text area width (leave space for button if enabled)
-    const textWidth = this.renderViewChainsPortal ? w - this.buttonWidth - 4 : w;
-    const isHovered = this.hoveredCell === gridCell && this.isButtonHovered;
-
     if (this.imageCache.has(url)) {
       const img = this.imageCache.get(url);
       if (img) {
@@ -236,21 +202,11 @@ export class PdbIdGridCellRenderer extends DG.GridCellRenderer {
         g.drawImage(img, fit.x, fit.y, fit.width, fit.height);
         
         // Render text in header
-        DG.GridCellRenderer.byName('string')?.render(g, x, y, textWidth, this.pdbIdHeight, gridCell, cellStyle);
-        
-        // Render button in header with hover state
-        if (this.renderViewChainsPortal) {
-          this.drawSequenceButton(g, x + textWidth + 2, y + 2, this.buttonWidth, this.pdbIdHeight - 4, isHovered);
-        }
+        DG.GridCellRenderer.byName('string')?.render(g, x, y, w, this.pdbIdHeight, gridCell, cellStyle);
       }
     } else {
       // Render text in header while loading
-      DG.GridCellRenderer.byName('string')?.render(g, x, y, textWidth, this.pdbIdHeight, gridCell, cellStyle);
-      
-      // Render button in header with hover state
-      if (this.renderViewChainsPortal) {
-        this.drawSequenceButton(g, x + textWidth + 2, y + 2, this.buttonWidth, this.pdbIdHeight - 4, isHovered);
-      }
+      DG.GridCellRenderer.byName('string')?.render(g, x, y, w, this.pdbIdHeight, gridCell, cellStyle);
 
       fetch(url).then(async (response) => {
         if (!response.ok) {
@@ -271,210 +227,6 @@ export class PdbIdGridCellRenderer extends DG.GridCellRenderer {
           URL.revokeObjectURL(img.src);
         };
       }).catch((_) => { });
-    }
-  }
-
-  private drawSequenceButton(g: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, hovered: boolean = false): void {
-    // Button background - different colors for hover state
-    g.fillStyle = hovered ? '#45a049' : '#4CAF50';
-    g.fillRect(x, y, w, h);
-    
-    // Button border
-    g.strokeStyle = hovered ? '#3d8b40' : '#45a049';
-    g.lineWidth = 1;
-    g.strokeRect(x, y, w, h);
-    
-    // Button text
-    g.fillStyle = 'white';
-    g.font = '9px sans-serif';
-    g.textAlign = 'center';
-    g.textBaseline = 'middle';
-    g.fillText('SEQ', x + w/2, y + h/2);
-  }
-
-  onMouseMove(gridCell: DG.GridCell, e: MouseEvent): void {
-    if (!this.renderViewChainsPortal) return;
-    
-    const rect = gridCell.bounds;
-    const cellRect = gridCell.gridColumn.grid.canvas.getBoundingClientRect();
-    
-    // Calculate mouse position relative to cell
-    const mouseX = e.clientX - cellRect.left - rect.x;
-    const mouseY = e.clientY - cellRect.top - rect.y;
-    
-    // Check if mouse is in button area
-    let buttonX: number, buttonY: number;
-    
-    if (rect.height < 40 || rect.width < 40) {
-      // Small cell layout
-      buttonX = rect.width - this.buttonWidth - 2;
-      buttonY = 2;
-    } else {
-      // Large cell layout (button in header)
-      const textWidth = rect.width - this.buttonWidth - 4;
-      buttonX = textWidth + 2;
-      buttonY = 2;
-    }
-    
-    const wasHovered = this.isButtonHovered;
-    this.isButtonHovered = mouseX >= buttonX && mouseX <= buttonX + this.buttonWidth && 
-                          mouseY >= buttonY && mouseY <= buttonY + this.buttonHeight;
-    
-    if (this.isButtonHovered !== wasHovered) {
-      this.hoveredCell = gridCell;
-      gridCell.render(); // Trigger redraw to show hover state
-      
-      // Change cursor style
-      const canvas = gridCell.gridColumn.grid.canvas;
-      canvas.style.cursor = this.isButtonHovered ? 'pointer' : 'default';
-    }
-  }
-
-  onMouseLeave(gridCell: DG.GridCell, e: MouseEvent): void {
-    if (this.hoveredCell === gridCell) {
-      this.hoveredCell = null;
-      this.isButtonHovered = false;
-      gridCell.render(); // Trigger redraw to remove hover state
-      
-      // Reset cursor
-      const canvas = gridCell.gridColumn.grid.canvas;
-      canvas.style.cursor = 'default';
-    }
-  }
-
-  onClick(gridCell: DG.GridCell, e: MouseEvent): void {
-    if (!this.renderViewChainsPortal) return;
-    
-    const cellValue = gridCell.cell.valueString?.toLowerCase();
-    if (!cellValue || cellValue.length < 4) return;
-
-    // Get cell bounds
-    const rect = gridCell.bounds;
-    const cellRect = gridCell.gridColumn.grid.canvas.getBoundingClientRect();
-    
-    // Calculate click position relative to cell
-    const clickX = e.clientX - cellRect.left - rect.x;
-    const clickY = e.clientY - cellRect.top - rect.y;
-    
-    // Check if click is in button area
-    let buttonX: number, buttonY: number;
-    
-    if (rect.height < 40 || rect.width < 40) {
-      // Small cell layout
-      buttonX = rect.width - this.buttonWidth - 2;
-      buttonY = 2;
-    } else {
-      // Large cell layout (button in header)
-      const textWidth = rect.width - this.buttonWidth - 4;
-      buttonX = textWidth + 2;
-      buttonY = 2;
-    }
-    
-    // Check if click is within button bounds
-    if (clickX >= buttonX && clickX <= buttonX + this.buttonWidth && 
-        clickY >= buttonY && clickY <= buttonY + this.buttonHeight) {
-      
-      e.stopPropagation();
-      e.preventDefault();
-      
-      this.handleSequenceButtonClick(cellValue.toUpperCase());
-    }
-  }
-
-  private detectSequenceType(sequence: string): string {
-    const seq = sequence.toUpperCase();
-    const length = seq.length;
-    
-    // Count nucleotides and amino acids
-    const nucleotides = (seq.match(/[ATGCUN]/g) || []).length;
-    const aminoAcids = (seq.match(/[ACDEFGHIKLMNPQRSTVWY]/g) || []).length;
-    const hasU = seq.includes('U');
-    const hasT = seq.includes('T');
-    
-    // If mostly nucleotides
-    if (nucleotides / length > 0.85) {
-      if (hasU && !hasT) return 'RNA';
-      if (hasT && !hasU) return 'DNA';
-      return 'Nucleotide'; // Mixed or unclear
-    }
-    
-    // If mostly amino acids
-    if (aminoAcids / length > 0.85) {
-      return 'Protein';
-    }
-    
-    // Default fallback
-    return 'Macromolecule';
-  }
-
-  private async handleSequenceButtonClick(pdbId: string): Promise<void> {
-    try {
-      grok.shell.info(`Extracting sequences from ${pdbId}...`);
-      
-      // Call your existing sequence extraction function
-      const sequences = await grok.functions.call('BiostructureViewer:extractProteinSequencesMolstar', {
-        pdbId: pdbId
-      });
-      
-      if (!sequences || Object.keys(sequences).length === 0) {
-        grok.shell.warning(`No protein sequences found in ${pdbId}`);
-        return;
-      }
-      
-      // Create transposed dataframe - one column per chain
-      const chainIds = Object.keys(sequences);
-      const columns: DG.Column[] = [];
-      
-      for (const chainId of chainIds) {
-        const sequence = sequences[chainId] as string;
-        const sequenceType = this.detectSequenceType(sequence);
-        
-        // Create column for this chain
-        const col = DG.Column.string(`Chain_${chainId}`, 1).init((_i) => sequence);
-        
-        // Set appropriate semantic type based on sequence content
-        switch (sequenceType) {
-          case 'Protein':
-            col.semType = 'Macromolecule';
-            col.setTag('alphabet', 'PT'); // Protein
-            break;
-          case 'DNA':
-            col.semType = 'Macromolecule';
-            col.setTag('alphabet', 'DNA');
-            break;
-          case 'RNA':
-            col.semType = 'Macromolecule';
-            col.setTag('alphabet', 'RNA');
-            break;
-          default:
-            col.semType = 'Macromolecule';
-            col.setTag('alphabet', 'PT'); // Default to protein
-            break;
-        }
-        
-        // Copy exact tags from working FASTA example
-        col.setTag('units', 'fasta');
-        col.setTag('aligned', 'SEQ');
-        col.setTag('cell.renderer', 'sequence');
-        
-        columns.push(col);
-      }
-      
-      // Create dataframe from columns
-      const df = DG.DataFrame.fromColumns(columns);
-      df.name = `${pdbId}_sequences`;
-      
-      // Use addTablePreview to make it floating by default
-      const tableView = grok.shell.addTablePreview(df);
-      tableView.name = `${pdbId} Protein Sequences`;
-      
-      const chainCount = chainIds.length;
-      const totalResidues = Object.values(sequences).reduce((sum:number, seq) => sum + (seq as string).length, 0);
-      grok.shell.info(`Extracted ${chainCount} chain${chainCount > 1 ? 's' : ''} (${totalResidues} total residues) from ${pdbId}`);
-      
-    } catch (error: any) {
-      console.error('Failed to extract sequences:', error);
-      grok.shell.error(`Failed to extract sequences from ${pdbId}: ${error.message}`);
     }
   }
 }

--- a/packages/BiostructureViewer/src/utils/pdb-grid-cell-renderer.ts
+++ b/packages/BiostructureViewer/src/utils/pdb-grid-cell-renderer.ts
@@ -16,7 +16,7 @@ import {getGridCellColTemp} from '@datagrok-libraries/bio/src/utils/cell-rendere
 import {IPdbGridCellRenderer} from './types';
 import {_getNglGlService} from '../package-utils';
 
-import {_package, extractProteinSequencesMolstar} from '../package';
+import {_package, } from '../package';
 import {LruCache} from 'datagrok-api/dg';
 
 export const enum Temps {

--- a/packages/BiostructureViewer/src/utils/pdb-grid-cell-renderer.ts
+++ b/packages/BiostructureViewer/src/utils/pdb-grid-cell-renderer.ts
@@ -164,6 +164,7 @@ export class PdbGridCellRenderer extends DG.GridCellRenderer {
 
 /// Shows PDB id when the cell is small, and renders protein if the cell is higher than 40 pixels
 
+
 export class PdbIdGridCellRenderer extends DG.GridCellRenderer {
   imageCache: LruCache<string, HTMLImageElement> = new LruCache<string, HTMLImageElement>();
   pdbIdHeight: number = 25;
@@ -447,11 +448,14 @@ export class PdbIdGridCellRenderer extends DG.GridCellRenderer {
             break;
           default:
             col.semType = 'Macromolecule';
+            col.setTag('alphabet', 'PT'); // Default to protein
             break;
         }
         
-        // Keep it simple - let Datagrok auto-detect the renderer
-        // Don't set cell.renderer or aligned tags to avoid MSA behavior
+        // Copy exact tags from working FASTA example
+        col.setTag('units', 'fasta');
+        col.setTag('aligned', 'SEQ');
+        col.setTag('cell.renderer', 'sequence');
         
         columns.push(col);
       }

--- a/packages/BiostructureViewer/src/utils/rcsb-gql-adapter.ts
+++ b/packages/BiostructureViewer/src/utils/rcsb-gql-adapter.ts
@@ -1,15 +1,20 @@
 import * as grok from 'datagrok-api/grok';
 import * as DG from 'datagrok-api/dg';
 
+
+// TODO: For later, i guess, if the need arises, but this can be well augmented
+// by importing RCSB's data-api graphql defitinitions for stuff like ligands and nonpoly entities
+// and in general much smoother and precise access to data.
+
+
 /**
  * GraphQL adapter for RCSB PDB API.
  * Provides efficient, selective data retrieval from RCSB PDB using GraphQL.
  */
 export class RcsbGraphQLAdapter {
   private static readonly GRAPHQL_ENDPOINT = 'https://data.rcsb.org/graphql';
-  
+
   private static readonly QUERIES = {
-    // Query to get polymer sequences for a given PDB ID (fixed schema)
     POLYMER_SEQUENCES: `
       query GetPolymerSequences($entryId: String!) {
         entry(entry_id: $entryId) {
@@ -31,8 +36,7 @@ export class RcsbGraphQLAdapter {
         }
       }
     `,
-    
-    // Query to get basic entry information
+
     ENTRY_INFO: `
       query GetEntryInfo($entryId: String!) {
         entry(entry_id: $entryId) {
@@ -48,7 +52,6 @@ export class RcsbGraphQLAdapter {
       }
     `,
 
-    // Batch query for multiple entries (more efficient)
     BATCH_POLYMER_SEQUENCES: `
       query GetBatchPolymerSequences($entryIds: [String!]!) {
         entries(entry_ids: $entryIds) {
@@ -91,15 +94,13 @@ export class RcsbGraphQLAdapter {
         }),
       });
 
-      if (!response.ok) {
+      if (!response.ok)
         throw new Error(`GraphQL request failed: ${response.status} ${response.statusText}`);
-      }
 
       const result = await response.json();
-      
-      if (result.errors) {
+
+      if (result.errors)
         throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
-      }
 
       return result.data as T;
     } catch (error) {
@@ -110,7 +111,6 @@ export class RcsbGraphQLAdapter {
 
   /**
    * Get polymer sequences for a PDB entry.
-   * Returns sequences mapped by entity ID and chain ID.
    */
   static async getPolymerSequences(pdbId: string): Promise<{
     [entityId: string]: {
@@ -139,22 +139,20 @@ export class RcsbGraphQLAdapter {
       };
     }>(
       this.QUERIES.POLYMER_SEQUENCES,
-      { entryId: pdbId.toUpperCase() }
+      {entryId: pdbId.toUpperCase()}
     );
 
-    if (!data.entry || !data.entry.polymer_entities) {
+    if (!data.entry || !data.entry.polymer_entities)
       throw new Error(`No polymer entities found for PDB ID: ${pdbId}`);
-    }
 
     const result: {[entityId: string]: {sequence: string; type: string; chains: string[]}} = {};
 
     for (const entity of data.entry.polymer_entities) {
-      if (entity.entity_poly?.pdbx_seq_one_letter_code && 
+      if (entity.entity_poly?.pdbx_seq_one_letter_code &&
           entity.rcsb_polymer_entity_container_identifiers?.entity_id) {
-        
         const entityId = entity.rcsb_polymer_entity_container_identifiers.entity_id;
         const chains = entity.rcsb_polymer_entity_container_identifiers.asym_ids || [];
-        
+
         result[entityId] = {
           sequence: entity.entity_poly.pdbx_seq_one_letter_code.replace(/\n/g, '').trim(),
           type: entity.entity_poly.type || 'unknown',
@@ -166,95 +164,86 @@ export class RcsbGraphQLAdapter {
     return result;
   }
 
-/**
- * Batch extract protein sequences for multiple PDB IDs using GraphQL.
- * Processes in parallel with rate limiting to avoid overwhelming the API.
- */
-static async batchGetProteinSequences(
-  pdbIds: string[], 
-  batchSize: number = 10,
-  onProgress?: (completed: number, total: number, currentPdbId: string) => void
-): Promise<{[pdbId: string]: {[chainId: string]: string}}> {
-  const results: {[pdbId: string]: {[chainId: string]: string}} = {};
-  const uniquePdbIds = [...new Set(pdbIds.map(id => id.trim().toUpperCase()))];
-  let completed = 0;
-  
-  // Process in batches to avoid rate limiting
-  for (let i = 0; i < uniquePdbIds.length; i += batchSize) {
-    const batch = uniquePdbIds.slice(i, i + batchSize);
-    
-    // Process batch in parallel
-    const batchPromises = batch.map(async (pdbId) => {
-      try {
-        onProgress?.(completed, uniquePdbIds.length, pdbId);
-        const sequences = await this.getProteinSequences(pdbId);
-        completed++;
-        return { pdbId, sequences, success: true };
-      } catch (error) {
-        console.error(`GraphQL batch failed for ${pdbId}:`, error);
-        completed++;
-        return { pdbId, sequences: {}, success: false, error: error };
-      }
-    });
-    
-    const batchResults = await Promise.all(batchPromises);
-    
-    // Store results
-    for (const result of batchResults) {
-      results[result.pdbId] = result.sequences;
-    }
-    
-    // Brief pause between batches to be nice to the API
-    if (i + batchSize < uniquePdbIds.length) {
-      await new Promise(resolve => setTimeout(resolve, 100));
-    }
-  }
-  
-  return results;
-}
+  /**
+   * Batch extract protein sequences for multiple PDB IDs.
+   */
+  static async batchGetProteinSequences(
+    pdbIds: string[],
+    batchSize: number = 10,
+    onProgress?: (completed: number, total: number, currentPdbId: string) => void
+  ): Promise<{[pdbId: string]: {[chainId: string]: string}}> {
+    const results: {[pdbId: string]: {[chainId: string]: string}} = {};
+    const uniquePdbIds = Array.from(new Set(pdbIds.map((id) => id.trim().toUpperCase())));
+    let completed = 0;
 
-/**
- * Batch extract all polymer data for multiple PDB IDs.
- * Similar to batchGetProteinSequences but returns full polymer information.
- */
-static async batchGetPolymerSequences(
-  pdbIds: string[], 
-  batchSize: number = 10,
-  onProgress?: (completed: number, total: number, currentPdbId: string) => void
-): Promise<{[pdbId: string]: {[entityId: string]: {sequence: string; type: string; chains: string[]}}}> {
-  const results: {[pdbId: string]: {[entityId: string]: {sequence: string; type: string; chains: string[]}}} = {};
-  const uniquePdbIds = [...new Set(pdbIds.map(id => id.trim().toUpperCase()))];
-  let completed = 0;
-  
-  for (let i = 0; i < uniquePdbIds.length; i += batchSize) {
-    const batch = uniquePdbIds.slice(i, i + batchSize);
-    
-    const batchPromises = batch.map(async (pdbId) => {
-      try {
-        onProgress?.(completed, uniquePdbIds.length, pdbId);
-        const polymerData = await this.getPolymerSequences(pdbId);
-        completed++;
-        return { pdbId, polymerData, success: true };
-      } catch (error) {
-        console.error(`GraphQL polymer batch failed for ${pdbId}:`, error);
-        completed++;
-        return { pdbId, polymerData: {}, success: false, error: error };
-      }
-    });
-    
-    const batchResults = await Promise.all(batchPromises);
-    
-    for (const result of batchResults) {
-      results[result.pdbId] = result.polymerData;
+    for (let i = 0; i < uniquePdbIds.length; i += batchSize) {
+      const batch = uniquePdbIds.slice(i, i + batchSize);
+
+      const batchPromises = batch.map(async (pdbId) => {
+        try {
+          onProgress?.(completed, uniquePdbIds.length, pdbId);
+          const sequences = await this.getProteinSequences(pdbId);
+          completed++;
+          return {pdbId, sequences, success: true};
+        } catch (error) {
+          console.error(`GraphQL batch failed for ${pdbId}:`, error);
+          completed++;
+          return {pdbId, sequences: {}, success: false, error: error};
+        }
+      });
+
+      const batchResults = await Promise.all(batchPromises);
+
+      for (const result of batchResults)
+        results[result.pdbId] = result.sequences;
+
+      if (i + batchSize < uniquePdbIds.length)
+        await new Promise((resolve) => setTimeout(resolve, 100));
     }
-    
-    if (i + batchSize < uniquePdbIds.length) {
-      await new Promise(resolve => setTimeout(resolve, 100));
-    }
+
+    return results;
   }
-  
-  return results;
-}
+
+  /**
+   * Batch extract all polymer data for multiple PDB IDs.
+   */
+  static async batchGetPolymerSequences(
+    pdbIds: string[],
+    batchSize: number = 10,
+    onProgress?: (completed: number, total: number, currentPdbId: string) => void
+  ): Promise<{[pdbId: string]: {[entityId: string]: {sequence: string; type: string; chains: string[]}}}> {
+    const results: {[pdbId: string]: {[entityId: string]: {sequence: string; type: string; chains: string[]}}} = {};
+    const uniquePdbIds = Array.from(new Set(pdbIds.map((id) => id.trim().toUpperCase())));
+    let completed = 0;
+
+    for (let i = 0; i < uniquePdbIds.length; i += batchSize) {
+      const batch = uniquePdbIds.slice(i, i + batchSize);
+
+      const batchPromises = batch.map(async (pdbId) => {
+        try {
+          onProgress?.(completed, uniquePdbIds.length, pdbId);
+          const polymerData = await this.getPolymerSequences(pdbId);
+          completed++;
+          return {pdbId, polymerData, success: true};
+        } catch (error) {
+          console.error(`GraphQL polymer batch failed for ${pdbId}:`, error);
+          completed++;
+          return {pdbId, polymerData: {}, success: false, error: error};
+        }
+      });
+
+      const batchResults = await Promise.all(batchPromises);
+
+      for (const result of batchResults)
+        results[result.pdbId] = result.polymerData;
+
+      if (i + batchSize < uniquePdbIds.length)
+        await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    return results;
+  }
+
   /**
    * Get basic entry information for a PDB ID.
    */
@@ -275,12 +264,11 @@ static async batchGetPolymerSequences(
       };
     }>(
       this.QUERIES.ENTRY_INFO,
-      { entryId: pdbId.toUpperCase() }
+      {entryId: pdbId.toUpperCase()}
     );
 
-    if (!data.entry) {
+    if (!data.entry)
       throw new Error(`Entry not found for PDB ID: ${pdbId}`);
-    }
 
     return {
       id: data.entry.rcsb_id,
@@ -291,22 +279,17 @@ static async batchGetPolymerSequences(
   }
 
   /**
-   * Get protein sequences as a simplified format for quick access.
-   * Returns only protein sequences (filters out DNA/RNA).
+   * Get protein sequences only, filtering out DNA/RNA.
    */
   static async getProteinSequences(pdbId: string): Promise<{[chainId: string]: string}> {
     const polymerData = await this.getPolymerSequences(pdbId);
     const proteinSequences: {[chainId: string]: string} = {};
 
     for (const [entityId, entityData] of Object.entries(polymerData)) {
-      // Filter for proteins only
-      if (entityData.type?.toLowerCase().includes('protein') || 
+      if (entityData.type?.toLowerCase().includes('protein') ||
           entityData.type === 'polypeptide(L)') {
-        
-        // Map each chain to its sequence
-        for (const chainId of entityData.chains) {
+        for (const chainId of entityData.chains)
           proteinSequences[chainId] = entityData.sequence;
-        }
       }
     }
 
@@ -315,11 +298,10 @@ static async batchGetPolymerSequences(
 
   /**
    * Create a DataFrame with polymer sequence data.
-   * Useful for integration with Datagrok's data structures.
    */
   static async createSequenceDataFrame(pdbId: string): Promise<DG.DataFrame> {
     const polymerData = await this.getPolymerSequences(pdbId);
-    
+
     const entityIds: string[] = [];
     const sequences: string[] = [];
     const types: string[] = [];
@@ -336,16 +318,15 @@ static async batchGetPolymerSequences(
 
     const df = DG.DataFrame.fromColumns([
       DG.Column.string('pdb_id', entityIds.length).init(() => pdbId.toUpperCase()),
-      DG.Column.string('entity_id', entityIds.length).init(i => entityIds[i]),
-      DG.Column.string('polymer_type', types.length).init(i => types[i]),
-      DG.Column.string('chain_ids', chainIds.length).init(i => chainIds[i]),
-      DG.Column.int('sequence_length', lengths.length).init(i => lengths[i]),
-      DG.Column.string('sequence', sequences.length).init(i => sequences[i])
+      DG.Column.string('entity_id', entityIds.length).init((i) => entityIds[i]),
+      DG.Column.string('polymer_type', types.length).init((i) => types[i]),
+      DG.Column.string('chain_ids', chainIds.length).init((i) => chainIds[i]),
+      DG.Column.int('sequence_length', lengths.length).init((i) => lengths[i]),
+      DG.Column.string('sequence', sequences.length).init((i) => sequences[i])
     ]);
 
-    // Set semantic types for better integration
     df.getCol('sequence').semType = 'Macromolecule';
-    df.getCol('sequence').setTag('alphabet', 'PT'); // Protein
+    df.getCol('sequence').setTag('alphabet', 'PT');
     df.getCol('sequence').setTag('units', 'fasta');
     df.getCol('pdb_id').semType = 'PDB_ID';
 
@@ -355,7 +336,6 @@ static async batchGetPolymerSequences(
 
 /**
  * Data provider function for GraphQL-based sequence retrieval.
- * Can be used as a Datagrok data provider.
  */
 export async function getPolymerSequencesGraphQL(pdbId: string): Promise<string> {
   try {
@@ -368,11 +348,10 @@ export async function getPolymerSequencesGraphQL(pdbId: string): Promise<string>
 }
 
 /**
- * Convenience function for batch extraction.
- * Wrapper around the static method for easier importing.
+ * Convenience wrapper for batch extraction.
  */
 export async function batchGetProteinSequencesGraphQL(
-  pdbIds: string[], 
+  pdbIds: string[],
   batchSize: number = 10,
   onProgress?: (completed: number, total: number, currentPdbId: string) => void
 ): Promise<{[pdbId: string]: {[chainId: string]: string}}> {

--- a/packages/BiostructureViewer/src/utils/rcsb-gql-adapter.ts
+++ b/packages/BiostructureViewer/src/utils/rcsb-gql-adapter.ts
@@ -1,0 +1,380 @@
+import * as grok from 'datagrok-api/grok';
+import * as DG from 'datagrok-api/dg';
+
+/**
+ * GraphQL adapter for RCSB PDB API.
+ * Provides efficient, selective data retrieval from RCSB PDB using GraphQL.
+ */
+export class RcsbGraphQLAdapter {
+  private static readonly GRAPHQL_ENDPOINT = 'https://data.rcsb.org/graphql';
+  
+  private static readonly QUERIES = {
+    // Query to get polymer sequences for a given PDB ID (fixed schema)
+    POLYMER_SEQUENCES: `
+      query GetPolymerSequences($entryId: String!) {
+        entry(entry_id: $entryId) {
+          rcsb_id
+          polymer_entities {
+            rcsb_id
+            entity_poly {
+              pdbx_seq_one_letter_code
+              type
+            }
+            rcsb_polymer_entity_container_identifiers {
+              entity_id
+              asym_ids
+            }
+            rcsb_polymer_entity {
+              pdbx_description
+            }
+          }
+        }
+      }
+    `,
+    
+    // Query to get basic entry information
+    ENTRY_INFO: `
+      query GetEntryInfo($entryId: String!) {
+        entry(entry_id: $entryId) {
+          rcsb_id
+          struct {
+            title
+          }
+          rcsb_entry_info {
+            resolution_combined
+            experimental_method
+          }
+        }
+      }
+    `,
+
+    // Batch query for multiple entries (more efficient)
+    BATCH_POLYMER_SEQUENCES: `
+      query GetBatchPolymerSequences($entryIds: [String!]!) {
+        entries(entry_ids: $entryIds) {
+          rcsb_id
+          struct {
+            title
+          }
+          polymer_entities {
+            rcsb_id
+            entity_poly {
+              pdbx_seq_one_letter_code
+              type
+            }
+            rcsb_polymer_entity_container_identifiers {
+              entity_id
+              asym_ids
+            }
+            rcsb_polymer_entity {
+              pdbx_description
+            }
+          }
+        }
+      }
+    `
+  };
+
+  /**
+   * Execute a GraphQL query against RCSB PDB API.
+   */
+  private static async executeQuery<T>(query: string, variables: Record<string, any>): Promise<T> {
+    try {
+      const response = await fetch(this.GRAPHQL_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query,
+          variables,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`GraphQL request failed: ${response.status} ${response.statusText}`);
+      }
+
+      const result = await response.json();
+      
+      if (result.errors) {
+        throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
+      }
+
+      return result.data as T;
+    } catch (error) {
+      console.error('GraphQL query failed:', error);
+      throw new Error(`Failed to execute GraphQL query: ${error}`);
+    }
+  }
+
+  /**
+   * Get polymer sequences for a PDB entry.
+   * Returns sequences mapped by entity ID and chain ID.
+   */
+  static async getPolymerSequences(pdbId: string): Promise<{
+    [entityId: string]: {
+      sequence: string;
+      type: string;
+      chains: string[];
+    }
+  }> {
+    const data = await this.executeQuery<{
+      entry: {
+        rcsb_id: string;
+        polymer_entities?: Array<{
+          rcsb_id: string;
+          entity_poly?: {
+            pdbx_seq_one_letter_code?: string;
+            type?: string;
+          };
+          rcsb_polymer_entity_container_identifiers?: {
+            entity_id: string;
+            asym_ids?: string[];
+          };
+          rcsb_polymer_entity?: {
+            pdbx_description?: string;
+          };
+        }>;
+      };
+    }>(
+      this.QUERIES.POLYMER_SEQUENCES,
+      { entryId: pdbId.toUpperCase() }
+    );
+
+    if (!data.entry || !data.entry.polymer_entities) {
+      throw new Error(`No polymer entities found for PDB ID: ${pdbId}`);
+    }
+
+    const result: {[entityId: string]: {sequence: string; type: string; chains: string[]}} = {};
+
+    for (const entity of data.entry.polymer_entities) {
+      if (entity.entity_poly?.pdbx_seq_one_letter_code && 
+          entity.rcsb_polymer_entity_container_identifiers?.entity_id) {
+        
+        const entityId = entity.rcsb_polymer_entity_container_identifiers.entity_id;
+        const chains = entity.rcsb_polymer_entity_container_identifiers.asym_ids || [];
+        
+        result[entityId] = {
+          sequence: entity.entity_poly.pdbx_seq_one_letter_code.replace(/\n/g, '').trim(),
+          type: entity.entity_poly.type || 'unknown',
+          chains: chains
+        };
+      }
+    }
+
+    return result;
+  }
+
+/**
+ * Batch extract protein sequences for multiple PDB IDs using GraphQL.
+ * Processes in parallel with rate limiting to avoid overwhelming the API.
+ */
+static async batchGetProteinSequences(
+  pdbIds: string[], 
+  batchSize: number = 10,
+  onProgress?: (completed: number, total: number, currentPdbId: string) => void
+): Promise<{[pdbId: string]: {[chainId: string]: string}}> {
+  const results: {[pdbId: string]: {[chainId: string]: string}} = {};
+  const uniquePdbIds = [...new Set(pdbIds.map(id => id.trim().toUpperCase()))];
+  let completed = 0;
+  
+  // Process in batches to avoid rate limiting
+  for (let i = 0; i < uniquePdbIds.length; i += batchSize) {
+    const batch = uniquePdbIds.slice(i, i + batchSize);
+    
+    // Process batch in parallel
+    const batchPromises = batch.map(async (pdbId) => {
+      try {
+        onProgress?.(completed, uniquePdbIds.length, pdbId);
+        const sequences = await this.getProteinSequences(pdbId);
+        completed++;
+        return { pdbId, sequences, success: true };
+      } catch (error) {
+        console.error(`GraphQL batch failed for ${pdbId}:`, error);
+        completed++;
+        return { pdbId, sequences: {}, success: false, error: error };
+      }
+    });
+    
+    const batchResults = await Promise.all(batchPromises);
+    
+    // Store results
+    for (const result of batchResults) {
+      results[result.pdbId] = result.sequences;
+    }
+    
+    // Brief pause between batches to be nice to the API
+    if (i + batchSize < uniquePdbIds.length) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+  
+  return results;
+}
+
+/**
+ * Batch extract all polymer data for multiple PDB IDs.
+ * Similar to batchGetProteinSequences but returns full polymer information.
+ */
+static async batchGetPolymerSequences(
+  pdbIds: string[], 
+  batchSize: number = 10,
+  onProgress?: (completed: number, total: number, currentPdbId: string) => void
+): Promise<{[pdbId: string]: {[entityId: string]: {sequence: string; type: string; chains: string[]}}}> {
+  const results: {[pdbId: string]: {[entityId: string]: {sequence: string; type: string; chains: string[]}}} = {};
+  const uniquePdbIds = [...new Set(pdbIds.map(id => id.trim().toUpperCase()))];
+  let completed = 0;
+  
+  for (let i = 0; i < uniquePdbIds.length; i += batchSize) {
+    const batch = uniquePdbIds.slice(i, i + batchSize);
+    
+    const batchPromises = batch.map(async (pdbId) => {
+      try {
+        onProgress?.(completed, uniquePdbIds.length, pdbId);
+        const polymerData = await this.getPolymerSequences(pdbId);
+        completed++;
+        return { pdbId, polymerData, success: true };
+      } catch (error) {
+        console.error(`GraphQL polymer batch failed for ${pdbId}:`, error);
+        completed++;
+        return { pdbId, polymerData: {}, success: false, error: error };
+      }
+    });
+    
+    const batchResults = await Promise.all(batchPromises);
+    
+    for (const result of batchResults) {
+      results[result.pdbId] = result.polymerData;
+    }
+    
+    if (i + batchSize < uniquePdbIds.length) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+  
+  return results;
+}
+  /**
+   * Get basic entry information for a PDB ID.
+   */
+  static async getEntryInfo(pdbId: string): Promise<{
+    id: string;
+    title?: string;
+    resolution?: number;
+    experimentalMethod?: string;
+  }> {
+    const data = await this.executeQuery<{
+      entry: {
+        rcsb_id: string;
+        struct?: { title: string };
+        rcsb_entry_info?: {
+          resolution_combined?: number[];
+          experimental_method?: string;
+        };
+      };
+    }>(
+      this.QUERIES.ENTRY_INFO,
+      { entryId: pdbId.toUpperCase() }
+    );
+
+    if (!data.entry) {
+      throw new Error(`Entry not found for PDB ID: ${pdbId}`);
+    }
+
+    return {
+      id: data.entry.rcsb_id,
+      title: data.entry.struct?.title,
+      resolution: data.entry.rcsb_entry_info?.resolution_combined?.[0],
+      experimentalMethod: data.entry.rcsb_entry_info?.experimental_method
+    };
+  }
+
+  /**
+   * Get protein sequences as a simplified format for quick access.
+   * Returns only protein sequences (filters out DNA/RNA).
+   */
+  static async getProteinSequences(pdbId: string): Promise<{[chainId: string]: string}> {
+    const polymerData = await this.getPolymerSequences(pdbId);
+    const proteinSequences: {[chainId: string]: string} = {};
+
+    for (const [entityId, entityData] of Object.entries(polymerData)) {
+      // Filter for proteins only
+      if (entityData.type?.toLowerCase().includes('protein') || 
+          entityData.type === 'polypeptide(L)') {
+        
+        // Map each chain to its sequence
+        for (const chainId of entityData.chains) {
+          proteinSequences[chainId] = entityData.sequence;
+        }
+      }
+    }
+
+    return proteinSequences;
+  }
+
+  /**
+   * Create a DataFrame with polymer sequence data.
+   * Useful for integration with Datagrok's data structures.
+   */
+  static async createSequenceDataFrame(pdbId: string): Promise<DG.DataFrame> {
+    const polymerData = await this.getPolymerSequences(pdbId);
+    
+    const entityIds: string[] = [];
+    const sequences: string[] = [];
+    const types: string[] = [];
+    const chainIds: string[] = [];
+    const lengths: number[] = [];
+
+    for (const [entityId, entityData] of Object.entries(polymerData)) {
+      entityIds.push(entityId);
+      sequences.push(entityData.sequence);
+      types.push(entityData.type);
+      chainIds.push(entityData.chains.join(','));
+      lengths.push(entityData.sequence.length);
+    }
+
+    const df = DG.DataFrame.fromColumns([
+      DG.Column.string('pdb_id', entityIds.length).init(() => pdbId.toUpperCase()),
+      DG.Column.string('entity_id', entityIds.length).init(i => entityIds[i]),
+      DG.Column.string('polymer_type', types.length).init(i => types[i]),
+      DG.Column.string('chain_ids', chainIds.length).init(i => chainIds[i]),
+      DG.Column.int('sequence_length', lengths.length).init(i => lengths[i]),
+      DG.Column.string('sequence', sequences.length).init(i => sequences[i])
+    ]);
+
+    // Set semantic types for better integration
+    df.getCol('sequence').semType = 'Macromolecule';
+    df.getCol('sequence').setTag('alphabet', 'PT'); // Protein
+    df.getCol('sequence').setTag('units', 'fasta');
+    df.getCol('pdb_id').semType = 'PDB_ID';
+
+    return df;
+  }
+}
+
+/**
+ * Data provider function for GraphQL-based sequence retrieval.
+ * Can be used as a Datagrok data provider.
+ */
+export async function getPolymerSequencesGraphQL(pdbId: string): Promise<string> {
+  try {
+    const df = await RcsbGraphQLAdapter.createSequenceDataFrame(pdbId);
+    return df.toCsv();
+  } catch (error) {
+    console.error(`Failed to get sequences for ${pdbId}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Convenience function for batch extraction.
+ * Wrapper around the static method for easier importing.
+ */
+export async function batchGetProteinSequencesGraphQL(
+  pdbIds: string[], 
+  batchSize: number = 10,
+  onProgress?: (completed: number, total: number, currentPdbId: string) => void
+): Promise<{[pdbId: string]: {[chainId: string]: string}}> {
+  return await RcsbGraphQLAdapter.batchGetProteinSequences(pdbIds, batchSize, onProgress);
+}

--- a/packages/BiostructureViewer/src/utils/rcsb-gql-adapter.ts
+++ b/packages/BiostructureViewer/src/utils/rcsb-gql-adapter.ts
@@ -83,7 +83,7 @@ export class RcsbGraphQLAdapter {
    */
   private static async executeQuery<T>(query: string, variables: Record<string, any>): Promise<T> {
     try {
-      const response = await fetch(this.GRAPHQL_ENDPOINT, {
+      const response = await grok.dapi.fetchProxy(this.GRAPHQL_ENDPOINT, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/packages/BiostructureViewer/src/utils/sequence-handler.ts
+++ b/packages/BiostructureViewer/src/utils/sequence-handler.ts
@@ -1,0 +1,79 @@
+import * as grok from 'datagrok-api/grok';
+import * as ui from 'datagrok-api/ui';
+import * as DG from 'datagrok-api/dg';
+import {RcsbGraphQLAdapter} from './rcsb-gql-adapter';
+
+export async function extractSequenceColumns(pdbIdColumn: DG.Column): Promise<void> {
+  if (!pdbIdColumn) {
+    grok.shell.error('Function was called without a valid PDB column.');
+    return;
+  }
+  const dataFrame = pdbIdColumn.dataFrame;
+
+
+  const pi = DG.TaskBarProgressIndicator.create('Extracting protein sequences via GraphQL...');
+
+  try {
+    const uniquePdbIds = pdbIdColumn.categories
+      .filter((id) => id && typeof id === 'string' && id.trim().length >= 4)
+      .map((id) => id.trim().toUpperCase());
+
+    if (uniquePdbIds.length === 0) {
+      grok.shell.warning('No valid PDB IDs found in the specified column.');
+      return;
+    }
+
+    grok.shell.info(`Processing ${uniquePdbIds.length} unique PDB ID(s) with GraphQL...`);
+
+    const allSequenceData = await RcsbGraphQLAdapter.batchGetProteinSequences(
+      uniquePdbIds,
+      20,
+      (completed, total, currentPdbId) => {
+        const progress = (completed / total) * 95;
+        pi.update(progress, `Extracting: ${currentPdbId} (${completed}/${total})`);
+      }
+    );
+
+    let maxChainCount = 0;
+    for (const pdbId in allSequenceData) {
+      const sequences = allSequenceData[pdbId];
+      if (sequences)
+        maxChainCount = Math.max(maxChainCount, Object.keys(sequences).length);
+    }
+
+    if (maxChainCount === 0) {
+      grok.shell.warning('No protein sequences could be extracted from any PDB structure.');
+      return;
+    }
+
+    const sequenceColumns: DG.Column[] = [];
+    for (let i = 0; i < maxChainCount; i++) {
+      const baseName = `Chain ${i + 1}`;
+      const colName = dataFrame.columns.getUnusedName(baseName);
+      sequenceColumns.push(DG.Column.string(colName, dataFrame.rowCount));
+    }
+
+    for (let i = 0; i < dataFrame.rowCount; i++) {
+      const pdbId = pdbIdColumn.get(i);
+      if (pdbId && allSequenceData[pdbId]) {
+        const sequences = allSequenceData[pdbId];
+        const chainIds = Object.keys(sequences).sort();
+        for (let j = 0; j < chainIds.length && j < sequenceColumns.length; j++)
+          sequenceColumns[j].set(i, sequences[chainIds[j]]);
+      }
+    }
+
+    for (const column of sequenceColumns) {
+      column.semType = 'Macromolecule';
+      column.setTag('alphabet', 'PT');
+      column.setTag('units', 'fasta');
+      column.setTag(DG.TAGS.CELL_RENDERER, 'sequence');
+      dataFrame.columns.add(column);
+    }
+  } catch (err) {
+    grok.shell.error('Failed to fetch protein sequences.');
+    console.error(err);
+  } finally {
+    pi.close();
+  }
+}


### PR DESCRIPTION
- sequence extraction based on the PDB_ID value, column selectable via Bio>Transform>Fetch sequences from PDB...

- Added RCSB Gql "adapter" which now has only polyme bindings to fetch only those entities and nothing else, but can be extended to arbitrary fields in an pdb-x/mmcif file where structural bio tasks are concerned.

- slightly changed the logic which determines when `[sequence-scrolling-widget.ts]` renders (i think we missed an MSA check so it used to still render for just `SEQ`) which was no bueno in this case.