### PR TITLE
[ticket] CLAUDE-3: PowerPack: Fix AddNewColumnDialog crash on undefined codeMirror

### DIFF
--- a/packages/PowerPack/CHANGELOG.md
+++ b/packages/PowerPack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Power Pack changelog
 
+## v.next
+
+* CLAUDE-3: Fixed crash in Add New Column dialog when interacting with inputs before CodeMirror initializes
+
 ## 1.8.0 (2026-03-13)
 
 ### Features

--- a/packages/PowerPack/src/dialogs/add-new-column.ts
+++ b/packages/PowerPack/src/dialogs/add-new-column.ts
@@ -359,7 +359,7 @@ export class AddNewColumnDialog {
     return Object.fromEntries([
       [this.placeholderName, this.inputName!.value],
       [this.placeholderType, typeForHistory],
-      [this.placeholderExpression, this.codeMirror!.state.doc.toString()],
+      [this.placeholderExpression, this.codeMirror?.state.doc.toString() ?? ''],
     ]);
   }
 
@@ -367,18 +367,21 @@ export class AddNewColumnDialog {
   loadInputHistory(history: any): void {
     this.inputName!.value = history[this.placeholderName];
     this.inputType!.value = history[this.placeholderType];
-    this.codeMirror!.dispatch({changes: {
-      from: 0,
-      to: this.codeMirror!.state.doc.length,
-      insert: history[this.placeholderExpression],
-    }});
+    if (this.codeMirror) {
+      this.codeMirror.dispatch({changes: {
+        from: 0,
+        to: this.codeMirror.state.doc.length,
+        insert: history[this.placeholderExpression],
+      }});
+    }
   }
 
   /** Creates and initializes the "Column Name" input field. */
   initInputName(): DG.InputBase {
     const control = ui.input.string('', {value: ''});
     control.onInput.subscribe(async () => {
-      await this.updatePreview(this.codeMirror!.state.doc.toString(), true);
+      if (!this.codeMirror) return;
+      await this.updatePreview(this.codeMirror.state.doc.toString(), true);
     });
     control.setTooltip(this.tooltips['name']);
 
@@ -401,7 +404,8 @@ export class AddNewColumnDialog {
       this.call.getParamValue('type') : defaultChoice, items: this.supportedTypes});
     control.onInput.subscribe(async () => {
       this.changedType = true;
-      await this.updatePreview(this.codeMirror!.state.doc.toString(), false);
+      if (!this.codeMirror) return;
+      await this.updatePreview(this.codeMirror.state.doc.toString(), false);
     });
     control.setTooltip(this.tooltips['type']);
 


### PR DESCRIPTION
## Summary
- Fixed `TypeError: Cannot read properties of undefined (reading 'state')` in AddNewColumnDialog
- Added null guards for `this.codeMirror` in `onInput` handlers for name/type inputs, `saveInputHistory`, and `loadInputHistory`
- Root cause: dialog is shown before async CodeMirror initialization completes; user interaction with inputs during that window crashes

## Test plan
- [ ] Open Add New Column dialog, quickly type in the Name field before CodeMirror loads — no crash
- [ ] Change column type dropdown before CodeMirror loads — no crash
- [ ] Normal Add New Column workflow still works after CodeMirror is ready

🤖 Generated with [Claude Code](https://claude.ai/claude-code)