### PR TITLE
[ticket] CLAUDE-19: EDA: Fix PLS Regression 'Incorrect parameters count'

### DIFF
--- a/packages/EDA/CHANGELOG.md
+++ b/packages/EDA/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EDA changelog
 
+## v.next
+
+* CLAUDE-19: Fixed PLS Regression apply failing with 'Incorrect parameters count' when DataFrame has extra columns
+
 ## 1.5.1 (2026-03-27)
 
 Add formula for prediction in multivariate analysis

--- a/packages/EDA/src/pls/pls-ml.ts
+++ b/packages/EDA/src/pls/pls-ml.ts
@@ -245,7 +245,17 @@ export class PlsModel {
     if (this.specn === null)
       throw new Error('Predicting failed: model is not trained');
 
-    return getPredictionByLinearRegression(features, this.specn.params);
+    const featureNames = this.specn.names.slice(0, this.specn.dim);
+    const featureCols: DG.Column[] = [];
+
+    for (const name of featureNames) {
+      if (!features.contains(name))
+        throw new Error(`Feature column '${name}' not found`);
+      featureCols.push(features.byName(name));
+    }
+
+    const selectedFeatures = DG.DataFrame.fromColumns(featureCols).columns;
+    return getPredictionByLinearRegression(selectedFeatures, this.specn.params);
   }
 
   /** Return loadings and regression coefficients viewers */


### PR DESCRIPTION
## Summary

- Fixed `PlsModel.predict()` to filter input features by the model's stored feature names, instead of passing all DataFrame columns
- Root cause: `applyPLSRegression` passed `df.columns` (all columns) to `predict()`, but the model only has params for its training features
- Report: #2077, user AlexKlyanchin, public instance

## Test plan

- [ ] Train a PLS Regression model on a subset of columns
- [ ] Apply the model to a DataFrame with extra columns (target, metadata)
- [ ] Verify prediction succeeds without 'Incorrect parameters count' error
- [ ] Verify existing PLS tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)