### PR TITLE
[ticket] CLAUDE-5: Chem: Fix unhandled error in removeDuplicates for malformed molecules

### DIFF
--- a/js-api/src/chem.ts
+++ b/js-api/src/chem.ts
@@ -659,7 +659,8 @@ export namespace chem {
         storage.length ?
         grok.functions
           .call('Chem:removeDuplicates', { molecules: storage, molecule: molecule })
-          .then((array: any) => localStorage.setItem(localStorageKey, JSON.stringify([molecule, ...array.slice(0, 9)]))) :
+          .then((array: any) => localStorage.setItem(localStorageKey, JSON.stringify([molecule, ...array.slice(0, 9)])))
+          .catch(() => localStorage.setItem(localStorageKey, JSON.stringify([molecule, ...storage.slice(0, 9)]))) :
         localStorage.setItem(localStorageKey, JSON.stringify([molecule]));
       }
     }

--- a/packages/Chem/CHANGELOG.md
+++ b/packages/Chem/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v.next
 
 * Fixed crash in checkCurrentView when table is opened in Files preview without a registered TableView
+* CLAUDE-5: Fixed unhandled error in removeDuplicates when molecule from Ketcher Sketcher is malformed
 
 ## 1.17.4 (2026-03-30)
 

--- a/packages/Chem/src/package.ts
+++ b/packages/Chem/src/package.ts
@@ -2252,7 +2252,7 @@ export class PackageFunctions {
   static removeDuplicates(molecules: string[], molecule: string): string[] {
     const mol1 = checkMoleculeValid(molecule);
     if (!mol1)
-      throw new Error(`Molecule is possibly malformed`);
+      return molecules;
     const filteredMolecules = molecules.filter((smiles) => !checkMolEqualSmiles(mol1, smiles));
     mol1.delete();
     return filteredMolecules;


### PR DESCRIPTION
## Summary

- Fixed `removeDuplicates` in Chem package to return the original array instead of throwing when a molecule is malformed (cannot be parsed by RDKit)
- Added `.catch()` handler in `Sketcher.checkDuplicatesAndAddToStorage` (js-api) to prevent unhandled promise rejections
- Addresses user report #2059: error triggered when saving a molecule from Ketcher Sketcher to favorites/recents

## Test plan

- [ ] Open a dataset with molecules, open Ketcher Sketcher
- [ ] Draw/paste a malformed molecule and click OK
- [ ] Verify no error is shown and the molecule is added to recents
- [ ] Verify valid molecules still deduplicate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)