### PR TITLE
CLAUDE-14: Curves: Guard against undefined fit function in renderCurves

### DIFF
--- a/packages/Curves/src/fit/fit-renderer.ts
+++ b/packages/Curves/src/fit/fit-renderer.ts
@@ -440,7 +440,7 @@ export class FitChartCellRenderer extends DG.GridCellRenderer {
       let userParamsFlag = true;
       const fitFunc = getSeriesFitFunction(series);
       let curve: ((x: number) => number) | null = null;
-      if (!(series.connectDots && !series.showFitLine)) {
+      if (fitFunc && !(series.connectDots && !series.showFitLine)) {
         if (series.parameters) {
           if (data.chartOptions?.logX) {
             if (series.parameters[2] > 0) // check if sigmoid, then log


### PR DESCRIPTION
## Summary
- Added null guard for `fitFunc` in `FitChartCellRenderer.renderCurves` to prevent `TypeError: Cannot read properties of undefined (reading 'y')` when `getSeriesFitFunction` returns undefined for an unregistered fit function name.

## Test plan
- [ ] Open a table with curves column containing an unknown fit function name
- [ ] Verify rendering does not crash and points are still rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)