### PR TITLE
CLAUDE-27: SequenceTranslator: Handle empty alphabet error in bulk convert

### DIFF
--- a/packages/SequenceTranslator/src/apps/translator/view/ui.ts
+++ b/packages/SequenceTranslator/src/apps/translator/view/ui.ts
@@ -171,10 +171,14 @@ class TranslatorAppLayout {
       translatedColumn.semType = DG.SEMTYPE.MACROMOLECULE;
       const units = outputFormat == NUCLEOTIDES_FORMAT ? NOTATION.FASTA : NOTATION.HELM;
       translatedColumn.meta.units = units;
-      const seqHandler = this.seqHelper.getSeqHandler(translatedColumn as DG.Column<string>);
-      const setUnits = outputFormat == NUCLEOTIDES_FORMAT ? this.seqHelper.setUnitsToFastaColumn :
-        this.seqHelper.setUnitsToHelmColumn;
-      setUnits(seqHandler);
+      try {
+        const seqHandler = this.seqHelper.getSeqHandler(translatedColumn as DG.Column<string>);
+        const setUnits = outputFormat == NUCLEOTIDES_FORMAT ? this.seqHelper.setUnitsToFastaColumn :
+          this.seqHelper.setUnitsToHelmColumn;
+        setUnits(seqHandler);
+      } catch (e: any) {
+        grok.shell.warning(e.message ?? 'Failed to detect sequence alphabet');
+      }
     }
 
     // add newColumn to the table


### PR DESCRIPTION
## Summary
- Wrap `setUnits` call in try-catch in `processConvertBulkButtonClick` to handle empty alphabet gracefully
- Shows a warning message instead of crashing when converted sequences have unrecognizable alphabet

## Test plan
- [ ] Open Oligo Toolkit, switch to Translator tab
- [ ] Convert sequences that produce empty alphabet output
- [ ] Verify warning is shown instead of crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)