### PR TITLE
CLAUDE-29: Chem: Guard against null TableView in activity cliffs

### DIFF
--- a/packages/Chem/src/package.ts
+++ b/packages/Chem/src/package.ts
@@ -1133,6 +1133,7 @@ export class PackageFunctions {
       }).call(undefined, undefined, {processed: false});
 
       const view = grok.shell.tv;
+      if (!view) return;
 
       const description = `Molecules: ${molecules.name}, activities: ${activities.name}, method: ${methodName}, ${options ? `options: ${JSON.stringify(options)},` : ``} similarity: ${similarityMetric}, similarity cutoff: ${similarity}`;
       view.addViewer(DG.VIEWER.SCATTER_PLOT, {


### PR DESCRIPTION
## Summary
- Add null guard for `grok.shell.tv` in activity cliffs to prevent crash when no TableView is active

## Test plan
- [ ] Run activity cliffs analysis
- [ ] Navigate away from TableView before analysis completes
- [ ] Verify no crash occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)