### PR TITLE
CLAUDE-30: Charts Globe: Handle missing columns gracefully

### DIFF
--- a/packages/Charts/src/viewers/globe/globe-viewer.ts
+++ b/packages/Charts/src/viewers/globe/globe-viewer.ts
@@ -164,12 +164,17 @@ export class GlobeViewer extends DG.JsViewer {
       this.points = [];
       return;
     }
+    const latCol = this.dataFrame.col(this.latitudeColumnName);
+    const lonCol = this.dataFrame.col(this.longitudeColumnName);
+    const colorByCol = this.dataFrame.col(this.colorByColumnName);
+    const mag = this.dataFrame.col(this.magnitudeColumnName);
+    if (!latCol || !lonCol || !colorByCol || !mag) {
+      this.points = [];
+      return;
+    }
     this.points.length = 0;
-    const lat = this.dataFrame.getCol(this.latitudeColumnName).getRawData();
-    const lon = this.dataFrame.getCol(this.longitudeColumnName).getRawData();
-
-    const colorByCol = this.dataFrame.getCol(this.colorByColumnName);
-    const mag = this.dataFrame.getCol(this.magnitudeColumnName);
+    const lat = latCol.getRawData();
+    const lon = lonCol.getRawData();
 
     const magRange = [mag.min, mag.max];
     const color = scaleSequential().interpolator(interpolateYlOrRd);


### PR DESCRIPTION
## Summary
- Use `col()` (returns null) instead of `getCol()` (throws) in Globe viewer `getCoordinates`
- Add null guards for all required columns (latitude, longitude, colorBy, magnitude)
- Clear points and return early when columns are missing

## Test plan
- [ ] Open Globe viewer on a table with lat/lon columns
- [ ] Remove a required column while the viewer is active
- [ ] Verify viewer handles it gracefully without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)