### PR TITLE
[ticket] CLAUDE-14: Curves: Skip series with unknown fit function in renderCurves

### DIFF
--- a/packages/Curves/src/fit/fit-renderer.ts
+++ b/packages/Curves/src/fit/fit-renderer.ts
@@ -439,6 +439,8 @@ export class FitChartCellRenderer extends DG.GridCellRenderer {
 
       let userParamsFlag = true;
       const fitFunc = getSeriesFitFunction(series);
+      if (!fitFunc)
+        continue;
       let curve: ((x: number) => number) | null = null;
       if (!(series.connectDots && !series.showFitLine)) {
         if (series.parameters) {


### PR DESCRIPTION
## Summary
- Added null guard for `fitFunc` returned by `getSeriesFitFunction()` in `renderCurves`
- Prevents TypeError when a series references a fit function not registered in the `fitFunctions` registry
- Report: public #2076

## Test plan
- [ ] Open a table with curve data that references an unknown fit function
- [ ] Verify no errors are thrown during rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)