### PR TITLE
[ticket] CLAUDE-18: SequenceTranslator: Catch empty alphabet error during bulk convert

### DIFF
--- a/packages/SequenceTranslator/src/apps/translator/view/ui.ts
+++ b/packages/SequenceTranslator/src/apps/translator/view/ui.ts
@@ -171,10 +171,14 @@ class TranslatorAppLayout {
       translatedColumn.semType = DG.SEMTYPE.MACROMOLECULE;
       const units = outputFormat == NUCLEOTIDES_FORMAT ? NOTATION.FASTA : NOTATION.HELM;
       translatedColumn.meta.units = units;
-      const seqHandler = this.seqHelper.getSeqHandler(translatedColumn as DG.Column<string>);
-      const setUnits = outputFormat == NUCLEOTIDES_FORMAT ? this.seqHelper.setUnitsToFastaColumn :
-        this.seqHelper.setUnitsToHelmColumn;
-      setUnits(seqHandler);
+      try {
+        const seqHandler = this.seqHelper.getSeqHandler(translatedColumn as DG.Column<string>);
+        const setUnits = outputFormat == NUCLEOTIDES_FORMAT ? this.seqHelper.setUnitsToFastaColumn :
+          this.seqHelper.setUnitsToHelmColumn;
+        setUnits(seqHandler);
+      } catch (e: any) {
+        grok.shell.warning(e.message ?? 'Failed to set sequence tags');
+      }
     }
 
     // add newColumn to the table


### PR DESCRIPTION
## Summary
- Wrap setUnits call in try-catch in processConvertBulkButtonClick
- Shows user-friendly warning instead of unhandled error when alphabet is empty
- Report: public #2082

## Test plan
- [ ] Open Oligo Toolkit > Translator > Convert with invalid sequence data
- [ ] Verify warning message shown instead of crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)