### PR TITLE
GROK-19993: GIS: Fix Map viewer crash on close

### DIFF
--- a/packages/GIS/CHANGELOG.md
+++ b/packages/GIS/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GIS changelog
 
+## v.next
+
+* Fixed crash on closing Map viewer caused by pointer events firing after disposal
+
 ## 1.3.1 (2025-03-30)
 
 * Fixed build issues

--- a/packages/GIS/src/gis-openlayer.ts
+++ b/packages/GIS/src/gis-openlayer.ts
@@ -138,6 +138,7 @@ export class OpenLayers {
 
   currentAreaObject: Feature | null = null;
 
+  disposed: boolean = false;
   useWebGLFlag: boolean = true;
   preventFocusing: boolean = false;
   //map interacions
@@ -754,6 +755,7 @@ export class OpenLayers {
   }
 
   removeAllLayers(): void {
+    this.disposed = true;
     if (this.olMap) {
       const layersArr = this.olMap.getAllLayers();
       for (let i = 0; i < layersArr.length; i++) {
@@ -1020,6 +1022,8 @@ export class OpenLayers {
 
   //map base events handlers>>
   onMapClick(evt: MapBrowserEvent<any>): void {
+    if (this.disposed)
+      return;
     const arrFeatures: FeatureLike[] = [];
     const res: OLCallbackParam = {
       coord: evt.coordinate,
@@ -1027,9 +1031,14 @@ export class OpenLayers {
       features: arrFeatures,
     };
 
-    this.olMap.forEachFeatureAtPixel(evt.pixel, function(feature) {
-      arrFeatures.push(feature);
-    });
+    try {
+      this.olMap.forEachFeatureAtPixel(evt.pixel, function(feature) {
+        arrFeatures.push(feature);
+      });
+    }
+    catch (e) {
+      return;
+    }
     if (arrFeatures.length == 0)
       return;
 
@@ -1056,6 +1065,8 @@ export class OpenLayers {
   }
 
   onMapPointermove(evt: MapBrowserEvent<any>) {
+    if (this.disposed)
+      return;
     if (evt.dragging)
       return;
 
@@ -1070,7 +1081,13 @@ export class OpenLayers {
     const getFeaturesOption = {
       layerFilter: this.selectCondition.bind(this),
     };
-    const ftArr = this.olMap.getFeaturesAtPixel(evt.pixel, getFeaturesOption);
+    let ftArr: FeatureLike[];
+    try {
+      ftArr = this.olMap.getFeaturesAtPixel(evt.pixel, getFeaturesOption);
+    }
+    catch (e) {
+      return;
+    }
     if (ftArr.length > 0) {
       for (let i = 0; i < ftArr.length; i++) {
         const geom = ftArr[i].getGeometry();


### PR DESCRIPTION
## Summary

- Added `disposed` flag to `OpenLayers` class in `gis-openlayer.ts`
- Set flag in `removeAllLayers()` (called during viewer detach)
- Guard `onMapClick` and `onMapPointermove` with early return when disposed
- Prevents `Cannot read properties of null (reading 'hasRenderer')` error when closing the Map viewer

Generated with [Claude Code](https://claude.com/claude-code)