### PR TITLE
Docking: Add hover comparison for docking pose energy properties

### DIFF
--- a/packages/Docking/src/package-test.ts
+++ b/packages/Docking/src/package-test.ts
@@ -5,6 +5,7 @@ import '@datagrok-libraries/bio/src/types/ngl'; // To enable import from the NGL
 import {runTests, tests, TestContext, initAutoTests as initTests } from '@datagrok-libraries/test/src/test';
 
 import './tests/autodock-tests';
+import './tests/utils-tests';
 
 export let _package = new DG.Package();
 export {tests};

--- a/packages/Docking/src/package.ts
+++ b/packages/Docking/src/package.ts
@@ -12,7 +12,7 @@ import {_runAutodock, AutoDockService, _runAutodock2, ensureNoDockingError} from
 import {TARGET_PATH, BINDING_ENERGY_COL, POSE_COL, BINDING_ENERGY_COL_UNUSED, POSE_COL_UNUSED, ERROR_COL_NAME, ERROR_MESSAGE, AUTODOCK_PROPERTY_DESCRIPTIONS} from './utils/constants';
 import { _demoDocking } from './demo/demo';
 import { DockingViewApp } from './demo/docking-app';
-import { addColorCoding, buildComparisonTable, formatColumns, getFromPdb, getFromPdbs, getReceptorData, processAutodockResults, prop } from './utils/utils';
+import { addColorCoding, buildComparisonTable, formatColumns, getRemarksFromPdb, getRemarksFromPdbs, getReceptorData, processAutodockResults, prop } from './utils/utils';
 export * from './package.g';
 export const _package = new DG.Package();
 
@@ -188,7 +188,7 @@ export class PackageFunctions{
     if (!addedToPdb)
       return new DG.Widget(ui.divText('Docking has not been run'));
 
-    const autodockResults: DG.DataFrame = getFromPdbs(molecule);
+    const autodockResults: DG.DataFrame = getRemarksFromPdbs(molecule);
     const widget = new DG.Widget(ui.div([]));
 
     if (table)
@@ -219,7 +219,7 @@ export class PackageFunctions{
 
     const currentRowIdx = molecule.cell.rowIndex;
     const ligandCol = molecule.cell.column;
-    const currentValues = getFromPdb(ligandCol.get(currentRowIdx));
+    const currentValues = getRemarksFromPdb(ligandCol.get(currentRowIdx));
 
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
     const sub = currentTable.onMouseOverRowChanged.subscribe(() => {
@@ -230,7 +230,7 @@ export class PackageFunctions{
         if (hovIdx >= 0 && hovIdx !== currentRowIdx) {
           const hovPdb = ligandCol.get(hovIdx);
           if (hovPdb && hovPdb.includes(BINDING_ENERGY_COL)) {
-            result.appendChild(buildComparisonTable(currentValues, getFromPdb(hovPdb)));
+            result.appendChild(buildComparisonTable(currentValues, getRemarksFromPdb(hovPdb)));
             return;
           }
         }

--- a/packages/Docking/src/package.ts
+++ b/packages/Docking/src/package.ts
@@ -12,7 +12,7 @@ import {_runAutodock, AutoDockService, _runAutodock2, ensureNoDockingError} from
 import {TARGET_PATH, BINDING_ENERGY_COL, POSE_COL, BINDING_ENERGY_COL_UNUSED, POSE_COL_UNUSED, ERROR_COL_NAME, ERROR_MESSAGE, AUTODOCK_PROPERTY_DESCRIPTIONS} from './utils/constants';
 import { _demoDocking } from './demo/demo';
 import { DockingViewApp } from './demo/docking-app';
-import { addColorCoding, formatColumns, getFromPdbs, getReceptorData, processAutodockResults, prop } from './utils/utils';
+import { addColorCoding, buildComparisonTable, formatColumns, getFromPdb, getFromPdbs, getReceptorData, processAutodockResults, prop } from './utils/utils';
 export * from './package.g';
 export const _package = new DG.Package();
 
@@ -116,7 +116,7 @@ export class PackageFunctions{
   })
   static async runAutodock(
     @grok.decorators.param({options: {description: '\'Input data table\''}}) table: DG.DataFrame,
-    @grok.decorators.param({options: {type: 'categorical', semType: 'Molecule', description: '\'Small molecules to dock\''}}) ligands: DG.Column,
+    @grok.decorators.param({options: {semType: 'Molecule', description: '\'Small molecules to dock\''}}) ligands: DG.Column,
     @grok.decorators.param({options: {choices: 'Docking:getConfigFiles', description: '\'Folder with config and macromolecule\''}}) target: string,
     @grok.decorators.param({type: 'int', options: {initialValue: '10', description: '\'Number of output conformations for each small molecule\''}}) poses: number): Promise<void> {
 
@@ -205,14 +205,39 @@ export class PackageFunctions{
     if (!showProperties) return widget;
 
     const result = ui.div();
-    const map: { [_: string]: any } = {};
-    for (let i = 0; i < autodockResults!.columns.length; ++i) {
-      const columnName = autodockResults!.columns.names()[i];
-      const propertyCol = autodockResults!.col(columnName);
-      map[columnName] = prop(molecule, propertyCol!, result, AUTODOCK_PROPERTY_DESCRIPTIONS);
-    }
-    result.appendChild(ui.tableFromMap(map));
+    const buildPropertyMap = () => {
+      const map: { [_: string]: any } = {};
+      for (let i = 0; i < autodockResults!.columns.length; ++i) {
+        const columnName = autodockResults!.columns.names()[i];
+        const propertyCol = autodockResults!.col(columnName);
+        map[columnName] = prop(molecule, propertyCol!, result, AUTODOCK_PROPERTY_DESCRIPTIONS);
+      }
+      return ui.tableFromMap(map);
+    };
+    result.appendChild(buildPropertyMap());
     widget.root.append(result);
+
+    const currentRowIdx = molecule.cell.rowIndex;
+    const ligandCol = molecule.cell.column;
+    const currentValues = getFromPdb(ligandCol.get(currentRowIdx));
+
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const sub = currentTable.onMouseOverRowChanged.subscribe(() => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        const hovIdx = currentTable.mouseOverRowIdx;
+        result.innerHTML = '';
+        if (hovIdx >= 0 && hovIdx !== currentRowIdx) {
+          const hovPdb = ligandCol.get(hovIdx);
+          if (hovPdb && hovPdb.includes(BINDING_ENERGY_COL)) {
+            result.appendChild(buildComparisonTable(currentValues, getFromPdb(hovPdb)));
+            return;
+          }
+        }
+        result.appendChild(buildPropertyMap());
+      }, 50);
+    });
+    widget.subs.push(sub);
 
     return widget;
   }

--- a/packages/Docking/src/package.ts
+++ b/packages/Docking/src/package.ts
@@ -221,21 +221,17 @@ export class PackageFunctions{
     const ligandCol = molecule.cell.column;
     const currentValues = getRemarksFromPdb(ligandCol.get(currentRowIdx));
 
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-    const sub = currentTable.onMouseOverRowChanged.subscribe(() => {
-      if (debounceTimer) clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(() => {
-        const hovIdx = currentTable.mouseOverRowIdx;
-        result.innerHTML = '';
-        if (hovIdx >= 0 && hovIdx !== currentRowIdx) {
-          const hovPdb = ligandCol.get(hovIdx);
-          if (hovPdb && hovPdb.includes(BINDING_ENERGY_COL)) {
-            result.appendChild(buildComparisonTable(currentValues, getRemarksFromPdb(hovPdb)));
-            return;
-          }
+    const sub = DG.debounce(currentTable.onMouseOverRowChanged, 50).subscribe(() => {
+      const hovIdx = currentTable.mouseOverRowIdx;
+      ui.empty(result);
+      if (hovIdx >= 0 && hovIdx !== currentRowIdx) {
+        const hovPdb = ligandCol.get(hovIdx);
+        if (hovPdb && hovPdb.includes(BINDING_ENERGY_COL)) {
+          result.appendChild(buildComparisonTable(currentValues, getRemarksFromPdb(hovPdb)));
+          return;
         }
-        result.appendChild(buildPropertyMap());
-      }, 50);
+      }
+      result.appendChild(buildPropertyMap());
     });
     widget.subs.push(sub);
 

--- a/packages/Docking/src/tests/utils-tests.ts
+++ b/packages/Docking/src/tests/utils-tests.ts
@@ -1,6 +1,6 @@
 import {category, expect, test} from '@datagrok-libraries/test/src/test';
 
-import {getFromPdb, buildComparisonTable} from '../utils/utils';
+import {getRemarksFromPdb, buildComparisonTable} from '../utils/utils';
 
 const SAMPLE_PDB = `REMARK  1  receptor. 1bdq J.
 REMARK  2  binding energy.  -12.70
@@ -21,14 +21,14 @@ const EXPECTED_VALUES: { [name: string]: number } = {
 };
 
 category('Utils', () => {
-  test('getFromPdb: parses energy values', async () => {
-    const values = getFromPdb(SAMPLE_PDB);
+  test('getRemarksFromPdb: parses energy values', async () => {
+    const values = getRemarksFromPdb(SAMPLE_PDB);
     for (const [name, expected] of Object.entries(EXPECTED_VALUES))
       expect(values[name], expected);
   });
 
-  test('getFromPdb: returns empty for no remarks', async () => {
-    expect(Object.keys(getFromPdb('ATOM 1 C1 LIG 1 0 0 0')).length, 0);
+  test('getRemarksFromPdb: returns empty for no remarks', async () => {
+    expect(Object.keys(getRemarksFromPdb('ATOM 1 C1 LIG 1 0 0 0')).length, 0);
   });
 
   test('buildComparisonTable: creates grid rows', async () => {

--- a/packages/Docking/src/tests/utils-tests.ts
+++ b/packages/Docking/src/tests/utils-tests.ts
@@ -1,0 +1,45 @@
+import {category, expect, test} from '@datagrok-libraries/test/src/test';
+
+import {getFromPdb, buildComparisonTable} from '../utils/utils';
+
+const SAMPLE_PDB = `REMARK  1  receptor. 1bdq J.
+REMARK  2  binding energy.  -12.70
+REMARK  3  intermolecular (1).  -15.68
+REMARK  4  electrostatic.  -0.15
+REMARK  5  ligand fixed.  -15.68
+REMARK  6  ligand moving.  0.00
+REMARK  7  total internal (2).  -1.55
+REMARK  8  torsional free (3).  2.98
+REMARK  9  unbound systems (4).  -1.55
+ATOM      1  C1  LIG     1       0.000   0.000   0.000`;
+
+const EXPECTED_VALUES: { [name: string]: number } = {
+  'binding energy': -12.70, 'intermolecular (1)': -15.68,
+  'electrostatic': -0.15, 'ligand fixed': -15.68,
+  'ligand moving': 0.00, 'total internal (2)': -1.55,
+  'torsional free (3)': 2.98, 'unbound systems (4)': -1.55,
+};
+
+category('Utils', () => {
+  test('getFromPdb: parses energy values', async () => {
+    const values = getFromPdb(SAMPLE_PDB);
+    for (const [name, expected] of Object.entries(EXPECTED_VALUES))
+      expect(values[name], expected);
+  });
+
+  test('getFromPdb: returns empty for no remarks', async () => {
+    expect(Object.keys(getFromPdb('ATOM 1 C1 LIG 1 0 0 0')).length, 0);
+  });
+
+  test('buildComparisonTable: creates grid rows', async () => {
+    const hovered = {'binding energy': -10.50, 'electrostatic': -2.36};
+    const table = buildComparisonTable(EXPECTED_VALUES, hovered);
+    expect(table instanceof HTMLElement, true);
+    expect(table.querySelectorAll('[style*="grid"]').length > 0, true);
+  });
+
+  test('buildComparisonTable: handles missing hovered property', async () => {
+    const table = buildComparisonTable(EXPECTED_VALUES, {'binding energy': -10.50});
+    expect(table instanceof HTMLElement, true);
+  });
+}, {owner: 'oserhiienko@datagrok.ai'});

--- a/packages/Docking/src/utils/utils.ts
+++ b/packages/Docking/src/utils/utils.ts
@@ -7,26 +7,28 @@ import { BiostructureData } from '@datagrok-libraries/bio/src/pdb/types';
 
 import { BINDING_ENERGY_COL, POSE_COL, setAffinity, setPose, TARGET_PATH } from './constants';
 
+export function getFromPdb(pdbString: string): { [name: string]: number } {
+  const result: { [name: string]: number } = {};
+  const remarkRegex = /REMARK\s+\d+\s+([\w\s\(\)-]+)\.\s+([-\d.]+)/g;
+  let match;
+  while ((match = remarkRegex.exec(pdbString)) !== null)
+    result[match[1].trim()] = parseFloat(match[2].trim());
+  return result;
+}
+
 export function getFromPdbs(pdb: DG.SemanticValue): DG.DataFrame {
-  const col = pdb.cell.column;    
+  const col = pdb.cell.column;
   const resultDf = DG.DataFrame.create(col.length);
-  
+
   for (let idx = 0; idx < col.length; idx++) {
-    const pdbValue = col.get(idx);
-    const remarkRegex = /REMARK\s+\d+\s+([\w\s\(\)-]+)\.\s+([-\d.]+)/g;
-    let match;
-  
-    while ((match = remarkRegex.exec(pdbValue)) !== null) {
-      const colName = match[1].trim();
-      const value = parseFloat(match[2].trim());
-        
+    const values = getFromPdb(col.get(idx));
+    for (const [colName, value] of Object.entries(values)) {
       let resultCol = resultDf.columns.byName(colName);
       if (!resultCol) resultCol = resultDf.columns.addNewFloat(colName);
-        
       resultDf.set(colName, idx, value);
     }
   }
-  
+
   return resultDf;
 }
   
@@ -86,7 +88,43 @@ export function prop(molecule: DG.SemanticValue, propertyCol: DG.Column, host: H
     .css('margin-right', '5px');
   
   const idx = molecule.cell.rowIndex;
-  return ui.divH([addColumnIcon, propertyCol.get(idx)], {style: {'position': 'relative'}});
+  const val: number = propertyCol.get(idx);
+  const numStyle = {style: {width: '42px', textAlign: 'right', flexShrink: '0', flexGrow: '0'}};
+  return ui.divH([addColumnIcon, ui.divText(val.toFixed(2), numStyle)],
+    {style: {position: 'relative'}});
+}
+
+export function buildComparisonTable(
+  currentValues: { [name: string]: number },
+  hoveredValues: { [name: string]: number },
+): HTMLElement {
+  const map: { [_: string]: any } = {};
+  for (const name of Object.keys(currentValues)) {
+    const cur = currentValues[name];
+    const hov = hoveredValues[name];
+    if (hov === undefined) {
+      map[name] = ui.divText(cur.toFixed(2));
+      continue;
+    }
+    const delta = hov - cur;
+    const sign = delta > 0 ? '+' : '';
+    const color = delta < 0 ? 'var(--green-2)' : delta > 0 ? 'var(--red-2)' : '';
+    const row = ui.div([
+      ui.divText(cur.toFixed(2)),
+      ui.divText('vs'),
+      ui.divText(hov.toFixed(2)),
+      ui.divText(`${sign}${delta.toFixed(2)}`),
+    ]);
+    row.style.cssText =
+      'display:grid;grid-template-columns:42px 16px 42px 42px;align-items:baseline;column-gap:12px;';
+    const cells = row.children as HTMLCollectionOf<HTMLElement>;
+    cells[0].style.cssText = 'text-align:right';
+    cells[1].style.cssText = 'text-align:center;color:var(--grey-4)';
+    cells[2].style.cssText = 'text-align:right';
+    cells[3].style.cssText = `text-align:right;font-size:11px;${color ? 'color:' + color : ''}`;
+    map[name] = row;
+  }
+  return ui.tableFromMap(map);
 }
 
 export function formatColumns(autodockResults: DG.DataFrame) {

--- a/packages/Docking/src/utils/utils.ts
+++ b/packages/Docking/src/utils/utils.ts
@@ -107,21 +107,21 @@ export function buildComparisonTable(
       continue;
     }
     const delta = hov - cur;
-    const sign = delta > 0 ? '+' : '';
+    const sign = delta >= 0 ? '+' : '';
     const color = delta < 0 ? 'var(--green-2)' : delta > 0 ? 'var(--red-2)' : '';
     const row = ui.div([
       ui.divText(cur.toFixed(2)),
       ui.divText('vs'),
       ui.divText(hov.toFixed(2)),
-      ui.divText(`${sign}${delta.toFixed(2)}`),
+      ui.divText(`\u0394${sign}${delta.toFixed(2)}`),
     ]);
     row.style.cssText =
-      'display:grid;grid-template-columns:42px 16px 42px 42px;align-items:baseline;column-gap:12px;';
+      'display:grid;grid-template-columns:42px 16px 42px auto;align-items:baseline;column-gap:12px;';
     const cells = row.children as HTMLCollectionOf<HTMLElement>;
     cells[0].style.cssText = 'text-align:right';
     cells[1].style.cssText = 'text-align:center;color:var(--grey-4)';
     cells[2].style.cssText = 'text-align:right';
-    cells[3].style.cssText = `text-align:right;font-size:11px;${color ? 'color:' + color : ''}`;
+    cells[3].style.cssText = `text-align:left;font-size:11px;${color ? 'color:' + color : ''}`;
     map[name] = row;
   }
   return ui.tableFromMap(map);

--- a/packages/Docking/src/utils/utils.ts
+++ b/packages/Docking/src/utils/utils.ts
@@ -7,7 +7,7 @@ import { BiostructureData } from '@datagrok-libraries/bio/src/pdb/types';
 
 import { BINDING_ENERGY_COL, POSE_COL, setAffinity, setPose, TARGET_PATH } from './constants';
 
-export function getFromPdb(pdbString: string): { [name: string]: number } {
+export function getRemarksFromPdb(pdbString: string): { [name: string]: number } {
   const result: { [name: string]: number } = {};
   const remarkRegex = /REMARK\s+\d+\s+([\w\s\(\)-]+)\.\s+([-\d.]+)/g;
   let match;
@@ -16,12 +16,12 @@ export function getFromPdb(pdbString: string): { [name: string]: number } {
   return result;
 }
 
-export function getFromPdbs(pdb: DG.SemanticValue): DG.DataFrame {
+export function getRemarksFromPdbs(pdb: DG.SemanticValue): DG.DataFrame {
   const col = pdb.cell.column;
   const resultDf = DG.DataFrame.create(col.length);
 
   for (let idx = 0; idx < col.length; idx++) {
-    const values = getFromPdb(col.get(idx));
+    const values = getRemarksFromPdb(col.get(idx));
     for (const [colName, value] of Object.entries(values)) {
       let resultCol = resultDf.columns.byName(colName);
       if (!resultCol) resultCol = resultDf.columns.addNewFloat(colName);


### PR DESCRIPTION
When hovering over a different docking pose, the context panel now shows a side-by-side comparison of energy values

Changes made:

- Implementation of comparison of docking pose `binding energy`, `electrostatic `etc. between two molecules

Here is the current viusalization:
<img width="452" height="645" alt="Screenshot 2026-04-15 134031" src="https://github.com/user-attachments/assets/614f6f15-1a26-4455-99c8-1b869ca13d05" />
