### PR TITLE
GROK-20058: Projects: Add IncludeInProject flag for tables and views

### DIFF
--- a/js-api/src/api/ddt.api.g.ts
+++ b/js-api/src/api/ddt.api.g.ts
@@ -209,6 +209,8 @@ export class Tags {
 
   static DataSync = '.data-sync';
 
+  static IncludeInProject = '.include-in-project';
+
   static IsDbEntity = '.db.entity';
 
   static IsDbView = '.db.view';

--- a/js-api/src/api/grok_api.g.ts
+++ b/js-api/src/api/grok_api.g.ts
@@ -1146,6 +1146,8 @@ export interface IDartApi {
   grok_ViewInfo_FromJson(json: String): any;
   grok_ViewInfo_FromViewState(state: String): any;
   grok_ViewInfo_ToJson(info: any): any;
+  grok_ViewInfo_Get_IncludeInProject(info: any): any;
+  grok_ViewInfo_Set_IncludeInProject(info: any, v: Bool): any;
   grok_Qnum_Parse(s: String): any;
   grok_Qnum_ToString(x: Num): any;
   grok_Qnum_Qualifier(x: Num): any;
@@ -1552,6 +1554,8 @@ export interface IDartApi {
   grok_TableInfo_Get_DataFrame(ti: any): any;
   grok_TableInfo_Get_Columns(ti: any): any;
   grok_TableInfo_Get_Tags(ti: any): any;
+  grok_TableInfo_Get_IncludeInProject(ti: any): any;
+  grok_TableInfo_Set_IncludeInProject(ti: any, v: Bool): any;
   grok_ColumnInfo_Get_Type(ci: any): any;
   grok_ColumnInfo_Get_SemType(ci: any): any;
   grok_ColumnInfo_Get_LayoutColumnId(ci: any): any;

--- a/js-api/src/entities/table-info.ts
+++ b/js-api/src/entities/table-info.ts
@@ -32,6 +32,10 @@ export class TableInfo extends Entity {
   get dataFrame(): DataFrame { return toJs(api.grok_TableInfo_Get_DataFrame(this.dart)); }
 
   get columns(): ColumnInfo[] { return toJs(api.grok_TableInfo_Get_Columns(this.dart)); }
+
+  /** Whether this table is materialized in the workspace when its project opens. */
+  get includeInProject(): boolean { return api.grok_TableInfo_Get_IncludeInProject(this.dart); }
+  set includeInProject(value: boolean) { api.grok_TableInfo_Set_IncludeInProject(this.dart, value); }
 }
 
 

--- a/js-api/src/entities/view-layout.ts
+++ b/js-api/src/entities/view-layout.ts
@@ -96,4 +96,8 @@ export class ViewInfo extends Entity {
   toJson(): string {
     return api.grok_ViewInfo_ToJson(this.dart);
   }
+
+  /** Whether this view is materialized as a TableView when its project opens. */
+  get includeInProject(): boolean { return api.grok_ViewInfo_Get_IncludeInProject(this.dart); }
+  set includeInProject(value: boolean) { api.grok_ViewInfo_Set_IncludeInProject(this.dart, value); }
 }

--- a/packages/ApiTests/src/package-test.ts
+++ b/packages/ApiTests/src/package-test.ts
@@ -45,6 +45,7 @@ import './packages/docker';
 import './packages/user-settings-storage';
 import './packages/upload-migrations';
 import './packages/upload-project-isolation';
+import './packages/include-in-project';
 import './grid/grid';
 import './grid/filterGroup';
 import './shell/events';

--- a/packages/ApiTests/src/packages/include-in-project.ts
+++ b/packages/ApiTests/src/packages/include-in-project.ts
@@ -1,0 +1,89 @@
+import type * as _grok from 'datagrok-api/grok';
+import type * as _DG from 'datagrok-api/dg';
+declare let grok: typeof _grok, DG: typeof _DG;
+
+import {after, category, expect, test} from '@datagrok-libraries/test/src/test';
+
+category('Projects: include-in-project', () => {
+  const createdProjectIds: string[] = [];
+  const createdTableIds: string[] = [];
+  const createdViewIds: string[] = [];
+
+  after(async () => {
+    for (const id of createdViewIds) {
+      const vi = await grok.dapi.views.find(id);
+      if (vi != null)
+        await grok.dapi.views.delete(vi);
+    }
+    for (const id of createdProjectIds) {
+      const proj = await grok.dapi.projects.find(id);
+      if (proj != null)
+        await grok.dapi.projects.delete(proj);
+    }
+    for (const id of createdTableIds) {
+      const ti = await grok.dapi.tables.find(id);
+      if (ti != null)
+        await grok.dapi.tables.delete(ti);
+    }
+  });
+
+  test('TableInfo.includeInProject default true; round-trips false locally', async () => {
+    const df = DG.DataFrame.fromColumns([DG.Column.fromInt32Array('a', new Int32Array([1, 2, 3]))]);
+    df.name = 't1';
+    const ti = DG.TableInfo.fromDataFrame(df);
+    expect(ti.includeInProject, true, 'absent flag must default to true');
+    ti.includeInProject = false;
+    expect(ti.includeInProject, false, 'after setter false, getter returns false');
+    expect(ti.tags['.include-in-project'], 'false', 'underlying metaParam must store the literal string "false"');
+    ti.includeInProject = true;
+    expect(ti.includeInProject, true, 'after setter true, getter returns true');
+    expect(ti.tags['.include-in-project'] == null, true, 'underlying metaParam must be removed when toggled back to true');
+  }, {owner: 'dkovalyov@datagrok.ai'});
+
+  test('TableInfo IncludeInProject=false persists across project save/find', async () => {
+    const df = DG.DataFrame.fromColumns([DG.Column.fromInt32Array('a', new Int32Array([1, 2, 3]))]);
+    df.name = `t_intermediate_${Date.now()}`;
+    const tableId = await grok.dapi.tables.uploadDataFrame(df);
+    createdTableIds.push(tableId);
+    const ti = await grok.dapi.tables.find(tableId);
+    ti.includeInProject = false;
+    await grok.dapi.tables.save(ti);
+
+    const project = DG.Project.create();
+    project.name = `IncludeInProjectRoundTrip_${Date.now()}`;
+    project.addChild(ti);
+    const saved = await grok.dapi.projects.save(project);
+    createdProjectIds.push(saved.id);
+
+    const reloaded = await grok.dapi.projects.find(saved.id);
+    const reloadedTi = reloaded.children.find((e) => e.id === tableId) as _DG.TableInfo | undefined;
+    expect(reloadedTi != null, true, `reloaded child with id ${tableId} must be present`);
+    expect(reloadedTi!.includeInProject, false, 'TableInfo IncludeInProject=false must round-trip through dapi.projects.save → find');
+  }, {owner: 'dkovalyov@datagrok.ai', timeout: 30000});
+
+  test('ViewInfo IncludeInProject=false persists across project save/find', async () => {
+    const df = DG.DataFrame.fromColumns([DG.Column.fromInt32Array('a', new Int32Array([1, 2, 3]))]);
+    df.name = `t_for_view_${Date.now()}`;
+    const tableId = await grok.dapi.tables.uploadDataFrame(df);
+    createdTableIds.push(tableId);
+    const ti = await grok.dapi.tables.find(tableId);
+
+    const tv = grok.shell.addTableView(df);
+    const vi = tv.getInfo() as unknown as _DG.ViewInfo;
+    vi.includeInProject = false;
+    await grok.dapi.views.save(vi);
+    createdViewIds.push(vi.id);
+
+    const project = DG.Project.create();
+    project.name = `ViewInfoIncludeRoundTrip_${Date.now()}`;
+    project.addChild(ti);
+    project.addChild(vi);
+    const saved = await grok.dapi.projects.save(project);
+    createdProjectIds.push(saved.id);
+
+    const reloaded = await grok.dapi.projects.find(saved.id);
+    const reloadedVi = reloaded.children.find((e) => e instanceof DG.ViewInfo) as _DG.ViewInfo | undefined;
+    expect(reloadedVi != null, true, 'reloaded project must contain the ViewInfo');
+    expect(reloadedVi!.includeInProject, false, 'ViewInfo IncludeInProject=false (stored in userData) must round-trip through dapi.views.save + dapi.projects.save → find');
+  }, {owner: 'dkovalyov@datagrok.ai', timeout: 30000});
+}, {owner: 'dkovalyov@datagrok.ai'});


### PR DESCRIPTION
## Summary

- Adds JS API surface for `TableInfo.includeInProject` / `ViewInfo.includeInProject` (default `true`); `false` keeps the entity in the project but skips materializing the DataFrame in `shell.tables` and the auto-`TableView` on open.
- Companion to the Dart-side feature in `reddata`. ApiTests cover the local getter/setter and round-trips through `dapi.projects.save` / `dapi.views.save`.

## Test plan

- [x] `TableInfo.includeInProject` default getter, setter writes `'false'` literal to `metaParams['.include-in-project']`, removed when toggled back to `true`.
- [x] `TableInfo` round-trip: save flag=false, save project, find project, flag persists.
- [x] `ViewInfo` round-trip: save flag=false via `dapi.views.save`, save project, find project, flag persists in `userData`.
- [x] Backward compat: existing projects with no flag default to `includeInProject = true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)