### PR TITLE
Entities: Add ApiTests + ApiSamples for polymorphic dapi.entities.save

### DIFF
--- a/packages/ApiSamples/scripts/dapi/entities-polymorphic-save.js
+++ b/packages/ApiSamples/scripts/dapi/entities-polymorphic-save.js
@@ -1,0 +1,19 @@
+// `grok.dapi.entities.save` is polymorphic: it accepts any Entity subclass
+// and dispatches client-side to the matching typed endpoint. Pass a Project
+// and it lands the same way `grok.dapi.projects.save` would; pass a
+// DataConnection and it goes through `grok.dapi.connections.save`.
+
+const project = DG.Project.create();
+project.name = 'sample_polymorphic_save_project';
+const savedProject = await grok.dapi.entities.save(project);
+grok.shell.info(`Saved Project as ${savedProject.id}`);
+
+const dc = DG.DataConnection.create('sample_polymorphic_save_conn', {
+  dataSource: 'PostgresDart', server: 'localhost:5432', db: 'datagrok_dev',
+  login: 'datagrok_dev', password: '123',
+});
+const savedConn = await grok.dapi.entities.save(dc);
+grok.shell.info(`Saved DataConnection as ${savedConn.id}`);
+
+await grok.dapi.projects.delete(savedProject);
+await grok.dapi.connections.delete(savedConn);

--- a/packages/ApiTests/CHANGELOG.md
+++ b/packages/ApiTests/CHANGELOG.md
@@ -1,5 +1,9 @@
 # API Tests changelog
 
+## 1.10.3 (WIP)
+
+Add `Dapi: entities.save (polymorphic)` tests covering Project and DataConnection round-trip via `grok.dapi.entities.save`.
+
 ## 1.10.2 (2026-03-17)
 
 Additonal setOptions tests

--- a/packages/ApiTests/src/dapi/entities-save.ts
+++ b/packages/ApiTests/src/dapi/entities-save.ts
@@ -1,0 +1,53 @@
+import type * as _grok from 'datagrok-api/grok';
+import type * as _DG from 'datagrok-api/dg';
+declare let grok: typeof _grok, DG: typeof _DG;
+
+import {after, category, expect, test} from '@datagrok-libraries/test/src/test';
+
+const created: _DG.Entity[] = [];
+
+category('Dapi: entities.save (polymorphic)', () => {
+
+  test('Project: save via entities.save round-trips via projects.find', async () => {
+    const project = DG.Project.create();
+    project.name = `entities_save_project_${DG.Utils.randomString(6)}`;
+    const saved = await grok.dapi.entities.save(project) as _DG.Project;
+    created.push(saved);
+    expect(!!saved.id, true);
+
+    const reloaded = await grok.dapi.projects.find(saved.id);
+    expect(reloaded.id, saved.id);
+    expect(reloaded.name, project.name);
+  }, {owner: 'aparamonov@datagrok.ai'});
+
+  test('DataConnection: save via entities.save round-trips via connections.find', async () => {
+    const dcParams = {
+      dataSource: 'PostgresDart', server: 'localhost:5432', db: 'datagrok_dev',
+      login: 'datagrok_dev', password: '123',
+    };
+    const dc = DG.DataConnection.create(`entities_save_conn_${DG.Utils.randomString(6)}`, dcParams);
+    const saved = await grok.dapi.entities.save(dc) as _DG.DataConnection;
+    created.push(saved);
+    expect(!!saved.id, true);
+
+    const reloaded = await grok.dapi.connections.find(saved.id);
+    expect(reloaded.id, saved.id);
+    expect(reloaded.friendlyName, dc.friendlyName);
+  }, {owner: 'aparamonov@datagrok.ai'});
+
+  // The bare EntityRecord path is exercised end-to-end by the existing
+  // 'Dapi: entities' tests in entities.ts (which call entities.save with a
+  // bare row through the `setProperties` flow). We don't repeat it here.
+
+  after(async () => {
+    for (const e of created) {
+      try {
+        if (e instanceof DG.Project) await grok.dapi.projects.delete(e);
+        else if (e instanceof DG.DataConnection) await grok.dapi.connections.delete(e);
+        else await grok.dapi.entities.delete(e);
+      } catch (_) {}
+    }
+    created.length = 0;
+  });
+
+}, {owner: 'aparamonov@datagrok.ai'});

--- a/packages/ApiTests/src/package-test.ts
+++ b/packages/ApiTests/src/package-test.ts
@@ -27,6 +27,7 @@ import './dapi/groups';
 import './dapi/dapi';
 import './dapi/connection';
 import './dapi/entities';
+import './dapi/entities-save';
 import './dapi/layouts';
 import './dapi/packages';
 import './dapi/tables';


### PR DESCRIPTION
## Summary

Pairs with the [reddata core change](https://bitbucket.org/skalkin/reddata) that makes `EntitiesClient.save` (Dart) dispatch to the appropriate typed client based on the runtime `Entity` subclass — so `grok.dapi.entities.save(project)` now does the same thing as `grok.dapi.projects.save(project)`, including round-tripping all typed fields.

This PR adds the JS-side test coverage and sample to verify the new behavior.

- `ApiTests/src/dapi/entities-save.ts` — round-trip Project + DataConnection through `grok.dapi.entities.save` and verify they re-fetch correctly via the typed `find` endpoints.
- `ApiSamples/scripts/dapi/entities-polymorphic-save.js` — minimal demo using Project + DataConnection.
- `ApiTests/CHANGELOG.md` — 1.10.3 (WIP) entry.

The bare `EntityRecord` flow is unchanged and is already covered by the existing `Dapi: entities` tests, so this PR doesn't repeat that.

## Test plan

- [ ] `grok test --category "Dapi: entities.save (polymorphic)"` against a dev Datagrok with the matching reddata branch published — expect both Project and DataConnection tests green.
- [ ] Sanity-check that the existing `Dapi: entities` tests still pass (bare-record path is untouched).
- [ ] Run the sample (`grok eval` on `entities-polymorphic-save.js`) and confirm both info balloons appear with non-null IDs.

> Requires the matching `reddata` core branch (`claude/entities-save-dispatch`) to be deployed to the test server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)