### PR TITLE
CLAUDE-107: EDA: Filter non-numerical columns out of PLS feature inputs and name the offending column in checkColumnType errors

### DIFF
--- a/packages/EDA/CHANGELOG.md
+++ b/packages/EDA/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EDA changelog
 
+## 1.5.3 (WIP)
+
+PLS Regression: skip non-numerical columns when training and report column name on type errors
+
 ## 1.5.2 (2026-04-24)
 
 Fix the column_list issue in PCA

--- a/packages/EDA/src/package.ts
+++ b/packages/EDA/src/package.ts
@@ -822,7 +822,10 @@ export class PackageFunctions {
     df: DG.DataFrame,
     predictColumn: DG.Column,
     @grok.decorators.param({'type': 'int', 'options': {'min': '1', 'max': '10', 'initialValue': '3', 'description': 'Number of latent components.'}}) components: number): Promise<Uint8Array> {
-    const features = df.columns;
+    const numericalCols = df.columns.toList().filter((c) => c.matches('numerical'));
+    if (numericalCols.length < 1)
+      throw new Error('PLS Regression requires at least one numerical (int or float) feature column.');
+    const features = DG.DataFrame.fromColumns(numericalCols).columns;
 
     const model = new PlsModel();
     await model.fit(

--- a/packages/EDA/src/utils.ts
+++ b/packages/EDA/src/utils.ts
@@ -38,7 +38,7 @@ const INCORRECT_CUTOFF_MES = 'cutoff must be non-negative.';
 /** Check column type */
 export function checkColumnType(col: DG.Column): void {
   if ((col.type != DG.COLUMN_TYPE.FLOAT) && (col.type != DG.COLUMN_TYPE.INT))
-    throw new Error(UNSUPPORTED_COLUMN_TYPE_MES + col.type);
+    throw new Error(`${UNSUPPORTED_COLUMN_TYPE_MES}${col.type} (column '${col.name}')`);
 }
 
 /** Check missing values */


### PR DESCRIPTION
## Summary

Fixes `Error: unsupported column type: datetime` thrown from `EDA` `checkColumnType` (webpack://eda/src/utils.ts) when calling `trainPLSRegression` with a DataFrame that contains a datetime feature column.

## Root cause

`trainPLSRegression` (`packages/EDA/src/package.ts`) passed `df.columns` verbatim into `PlsModel.fit()`. The validation chain `getPlsAnalysis` → `checkWasmDimensionReducerInputs` → `checkDimensionReducerInputs` → `checkColumnType` only accepts `FLOAT`/`INT`, so any datetime column in the input DataFrame caused the call to throw before training could begin. `PlsModel.isApplicable` already uses `col.matches('numerical')` as the feature-eligibility check, but the train entry point did not apply the same filter.

## Fix

1. `packages/EDA/src/package.ts` — `trainPLSRegression` now filters `df.columns` to numerical columns (`col.matches('numerical')`) before passing them to `PlsModel.fit`, mirroring `PlsModel.isApplicable`. If no numerical columns remain, throw an actionable error.
2. `packages/EDA/src/utils.ts` — `checkColumnType` now includes the offending column's name in its error message, so any remaining call path (e.g. `getRowsOfNumericalColumnns`) produces a diagnosable message instead of a bare type tag.
3. `packages/EDA/CHANGELOG.md` — added 1.5.3 (WIP) entry.

## Validation

- Reproduced the original error against the unfixed package via the JS-API repro from the JIRA comment (`grok.data.demo.demog()` → DataFrame with `age` + `started` → `trainPLSRegression`) — confirmed the `unsupported column type: datetime` throw on master.
- After the fix, the same call path no longer reaches `checkColumnType` for the datetime column; PLS trains on the numerical subset.
- `npm run build` exits 0 in `packages/EDA` (only pre-existing asset-size warnings).

See the report on the JIRA ticket for the full reproduction stack trace and console excerpt.