### PR TITLE
CLAUDE-159: KetcherSketcher: Defer Ketcher React Editor mount until ketcher-host has non-zero dimensions, using a ResizeObserver to avoid SVGLength relative-length resolution failure in <RulerArea>

### DIFF
--- a/packages/KetcherSketcher/CHANGELOG.md
+++ b/packages/KetcherSketcher/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Ketcher Sketcher changelog
 
+## 2.4.3 (2026-05-08)
+
+* KetcherSketcher: Defer React Editor mount until the host has non-zero dimensions, preventing RulerArea SVGLength `Could not resolve relative length` error when the sketcher is rendered into a hidden or zero-sized container
+
 ## 2.4.2 (2026-04-23)
 
 * Reset explicitMol on change only if molecule has been already set

--- a/packages/KetcherSketcher/package-lock.json
+++ b/packages/KetcherSketcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datagrok/ketcher-sketcher",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datagrok/ketcher-sketcher",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "dependencies": {
         "@datagrok-libraries/test": "^1.1.0",
         "@datagrok-libraries/utils": "^4.6.5",

--- a/packages/KetcherSketcher/package.json
+++ b/packages/KetcherSketcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@datagrok/ketcher-sketcher",
   "friendlyName": "Ketcher Sketcher",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "author": {
     "name": "Maria Dolotova",
     "email": "mdolotova@datagrok.ai"

--- a/packages/KetcherSketcher/src/ketcher.tsx
+++ b/packages/KetcherSketcher/src/ketcher.tsx
@@ -21,6 +21,9 @@ export class KetcherSketcher extends grok.chem.SketcherBase {
   _sketcher: Ketcher | null = null;
   ketcherHost: HTMLDivElement;
   reactRoot: ReactDOM.Root | null = null;
+  private _editorComponent: React.ReactElement | null = null;
+  private _editorMounted = false;
+  private _resizeObserver: ResizeObserver | null = null;
 
   constructor() {
     super();
@@ -67,12 +70,43 @@ export class KetcherSketcher extends grok.chem.SketcherBase {
     };
 
     this.ketcherHost = ui.div([], 'ketcher-host');
-
-    const component = React.createElement(Editor, props, null);
-    this.reactRoot = ReactDOM.createRoot(this.ketcherHost);
-    this.reactRoot.render(component);
-
+    this._editorComponent = React.createElement(Editor, props, null);
     this.root.appendChild(this.ketcherHost);
+
+    // Mounting Ketcher's <Editor> into a zero-sized or detached host causes
+    // <RulerArea> to throw NotSupportedError reading SVGLength.value
+    // ('Could not resolve relative length') because the canvas SVG uses
+    // width/height="100%" and cannot resolve relative units without a sized
+    // containing block. Defer the React mount until the host actually has
+    // non-zero dimensions.
+    this._mountEditorWhenSized();
+  }
+
+  private _mountEditorWhenSized(): void {
+    if (this._editorMounted) return;
+    const rect = this.ketcherHost.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      this._mountEditor();
+      return;
+    }
+    this._resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.contentRect.width > 0 && entry.contentRect.height > 0) {
+          this._mountEditor();
+          break;
+        }
+      }
+    });
+    this._resizeObserver.observe(this.ketcherHost);
+  }
+
+  private _mountEditor(): void {
+    if (this._editorMounted || !this._editorComponent) return;
+    this._editorMounted = true;
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = null;
+    this.reactRoot = ReactDOM.createRoot(this.ketcherHost);
+    this.reactRoot.render(this._editorComponent);
   }
 
   async init(host: grok.chem.Sketcher) {
@@ -191,6 +225,9 @@ export class KetcherSketcher extends grok.chem.SketcherBase {
 
   detach() {
     // grok.dapi.userDataStorage.postValue(KETCHER_OPTIONS, KETCHER_USER_STORAGE, JSON.stringify(this._sketcher?.editor.options()), true);
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = null;
+    this._editorComponent = null;
     this.reactRoot?.unmount();
     this.reactRoot = null;
     super.detach();


### PR DESCRIPTION
## Summary

Fix `Failed to read the 'value' property from 'SVGLength': Could not resolve relative length` thrown from ketcher-react's `<RulerArea>` when the KetcherSketcher widget is mounted into a hidden or zero-sized container — observed when expanding the Chemistry → Gasteiger Partial Charges info panel on a smiles cell, and reproducible by mounting `grok.functions.call('KetcherSketcher:ketcherSketcher', {})` into a `width:0;height:0;overflow:hidden` div.

## Root cause

ketcher-react's macromolecules `<EditorContainer>` renders its canvas with `width="100%" height="100%"` and `<RulerArea>` reads `editor.canvas.width.baseVal.value` on mount (`vendors-node_modules_ketcher-react_dist_index_modern-b9db71c5_js.js:20130`, source ≈ `index.modern-b9db71c5.js:18843`). Reading `.baseVal.value` on a percentage-based `SVGLength` throws `NotSupportedError` when the SVG's containing block has no resolvable width.

`KetcherSketcher`'s constructor in `public/packages/KetcherSketcher/src/ketcher.tsx` was calling `ReactDOM.createRoot(this.ketcherHost).render(<Editor .../>)` synchronously, before `this.root` was attached to a sized parent. When React committed, the Editor (and its `<RulerArea>`) mounted against a host whose layout was still zero-sized, and the SVG could not resolve relative units.

## Fix

Defer the React Editor mount until `ketcherHost` actually has non-zero dimensions:

- Construct the React element eagerly, but do not call `ReactDOM.createRoot(...).render(...)` yet.
- Check `getBoundingClientRect()` synchronously; if the host already has a real size (the common in-grid / sketcher-dialog case), mount immediately — behavior unchanged.
- Otherwise, observe the host with a `ResizeObserver`; mount the Editor on the first observation with width > 0 and height > 0, then disconnect.
- `detach()` disconnects the observer and clears the cached element so a hidden-but-never-shown widget is cleaned up correctly.

No changes to ketcher-react, ketcher-core, or sibling packages — the fix is contained to KetcherSketcher.

## Testing

- `npm run build` (KetcherSketcher) exits 0.
- Reproduced original error against the unfixed package: console fired `NotSupportedError: Failed to read the 'value' property from 'SVGLength': Could not resolve relative length.` from `<RulerArea>` immediately on mount into a zero-sized div, and on the Gasteiger Partial Charges info-panel path.
- With the fix applied, `<RulerArea>` is no longer mounted while the host is zero-sized, so the failing `editor.canvas.width.baseVal.value` line cannot execute against an unresolvable SVG. When the host is later sized, the Editor mounts normally.

Reproduction evidence is attached to the JIRA comment thread (smiles-grid + gasteiger-ruler-error screenshots).
