### PR TITLE
CLAUDE-435: Chem: Make Chem:addChemRisksColumns idempotent by skipping risk columns whose name already exists in the target table

### DIFF
--- a/packages/Chem/CHANGELOG.md
+++ b/packages/Chem/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v.next
 
 * Scaffold tree: Migrated drop handler to the new `doDrop(args)` signature in `ui.makeDroppable`
+* Chem: Toxicity Risks: Make `addChemRisksColumns` idempotent — skip risk columns whose name already exists (fixes "Column named 'Mutagenicity' already exists" when MPO transform and a mutagenicity-enabled MPO profile both apply)
 
 ## 1.17.5 (2026-04-15)
 

--- a/packages/Chem/package-lock.json
+++ b/packages/Chem/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datagrok/chem",
-  "version": "1.17.6",
+  "version": "1.17.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datagrok/chem",
-      "version": "1.17.6",
+      "version": "1.17.7",
       "dependencies": {
         "@datagrok-libraries/chem-meta": "^1.2.12",
         "@datagrok-libraries/gridext": "^1.5.4",

--- a/packages/Chem/src/package.ts
+++ b/packages/Chem/src/package.ts
@@ -2264,7 +2264,10 @@ export class PackageFunctions {
     const pb = DG.TaskBarProgressIndicator.create('Toxicity risks ...');
     try {
       const toxCols = await getToxicityRisksColumns(molecules, {mutagenicity, tumorigenicity, irritatingEffects, reproductiveEffects});
-      toxCols.forEach((col) => table.columns.add(col));
+      toxCols.forEach((col) => {
+        if (!table.columns.contains(col.name))
+          table.columns.add(col);
+      });
     } finally {
       pb.close();
     }


### PR DESCRIPTION
## Summary

`Chem:addChemRisksColumns` (the Chem | Calculate | Toxicity Risks function, also invoked by `chem:mpoTransformFunction` and the MPO Score dialog's apply path) was not idempotent: calling it twice on the same DataFrame with the same enabled risks threw `Invalid argument(s): Column named 'Mutagenicity' already exists` from `ColumnList.add` because the risk column names come from a fixed map (`Mutagenicity`, `Tumorigenicity`, `Irritating effects`, `Reproductive effects`).

This surfaced in the wild when a user opened an Admetica demo file (whose on-open transform calls `chem:mpoTransformFunction` and adds the Mutagenicity column) and then opened the MPO Score dialog with a profile (`bew`) whose mutagenicity/tumorigenicity flags are true — the dialog's apply path re-ran `addChemRisksColumns`, hitting the duplicate-add and crashing.

## Fix

In `public/packages/Chem/src/package.ts` (`addChemRisksColumns`, around line 2267), skip risk columns whose name already exists in the target table:

```ts
toxCols.forEach((col) => {
  if (!table.columns.contains(col.name))
    table.columns.add(col);
});
```

This is the single chokepoint for every entry path (top-menu, on-open transform, MPO dialog apply, hit-triage), so one guard covers them all. Skipping (rather than renaming via `getUnusedName`) preserves the canonical column names that downstream MPO scoring looks up.

## Crash site

- Package: `Chem`
- File: `public/packages/Chem/src/package.ts`
- Method: `addChemRisksColumns` (forEach → `table.columns.add(col)`, line 2267)
- Error pattern: `Invalid argument(s): Column named 'Mutagenicity' already exists`

See the linked JIRA ticket for the full report, console excerpt, and reproduction screenshots.

## Testing

- `npm run build` in `public/packages/Chem` exits 0 (webpack compiled with only pre-existing asset-size warnings).
- Reproduction recipe (per the report): open `System.AppData/Admetica/demo_files/mol1K-demo-app.csv`, then invoke `Chem:addChemRisksColumns` twice with `mutagenicity:true`. Without the fix, the second call throws `Column named 'Mutagenicity' already exists`. With the fix, the second call is a no-op for already-present risks and does not throw.
