### PR TITLE
CLAUDE-459: Bio: Guard Bio sequence dim-reduction editors against null current table / missing Macromolecule column

### DIFF
--- a/packages/Bio/CHANGELOG.md
+++ b/packages/Bio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bio changelog
 
+## v.next
+
+* Sequence Space / Sequence Activity Cliffs editors: bail with a clear error when no current table or Macromolecule column is available (prevents NullError in DimReductionBaseEditor)
+
 ## 2.27.4 (2026-04-29)
 
 * Support for non canonical RNA and correct splitting in helm

--- a/packages/Bio/src/package.ts
+++ b/packages/Bio/src/package.ts
@@ -236,6 +236,15 @@ export class PackageFunctions {
 
   @grok.decorators.editor({tags: ['editor']})
   static SequenceSpaceEditor(call: DG.FuncCall) {
+    const df = grok.shell.tv?.dataFrame;
+    if (!df) {
+      grok.shell.error('Sequence Space requires an open table with a Macromolecule column');
+      return;
+    }
+    if (df.columns.bySemType(DG.SEMTYPE.MACROMOLECULE) == null) {
+      grok.shell.error('Current table does not contain a Macromolecule column');
+      return;
+    }
     const funcEditor = new DimReductionBaseEditor({semtype: DG.SEMTYPE.MACROMOLECULE});
     const dialog = ui.dialog({title: 'Sequence Space'})
       .add(funcEditor.getEditor())
@@ -258,6 +267,15 @@ export class PackageFunctions {
 
   @grok.decorators.editor({tags: ['editor']})
   static SeqActivityCliffsEditor(call: DG.FuncCall) {
+    const df = grok.shell.tv?.dataFrame;
+    if (!df) {
+      grok.shell.error('Sequence Activity Cliffs requires an open table with a Macromolecule column');
+      return;
+    }
+    if (df.columns.bySemType(DG.SEMTYPE.MACROMOLECULE) == null) {
+      grok.shell.error('Current table does not contain a Macromolecule column');
+      return;
+    }
     const funcEditor = new ActivityCliffsEditor({semtype: DG.SEMTYPE.MACROMOLECULE});
     const dialog = ui.dialog({title: 'Activity Cliffs'})
       .add(funcEditor.getEditor())


### PR DESCRIPTION
## Summary

Fixes a `NullError: method not found: 'dart' on null` thrown when the user invokes **Bio > Analyze > Sequence Space...** (or **Sequence Activity Cliffs**) with no current table open. The crash fires from `DimReductionBaseEditor.getColInput()` inside `@datagrok-libraries/ml`, which calls `ui.input.column({table: this.tableInput.value!, ...})` while `tableInput.value` is null because `grok.shell.tv.dataFrame` was null when the editor was constructed.

## Fix

`Bio:SequenceSpaceEditor` and `Bio:SeqActivityCliffsEditor` now bail with a clear `grok.shell.error(...)` message before instantiating the dim-reduction editor when there is no current table view, or when the current table contains no Macromolecule column. This matches the existing Bio convention (`Current table does not contain sequences`, package.ts:1056).

The root cause is in `@datagrok-libraries/ml/src/functionEditors/dimensionality-reduction-editor.ts` (sibling library, out of scope here); the guard is placed at the highest preventable frame inside the Bio package.

## Files

- `packages/Bio/src/package.ts` — early-return guards in `SequenceSpaceEditor` and `SeqActivityCliffsEditor`.
- `packages/Bio/CHANGELOG.md` — v.next entry.

## Crash site (from reporter)

- Package: `Bio`
- File: `webpack://bio/node_modules/@datagrok-libraries/ml/src/functionEditors/dimensionality-reduction-editor.js`
- Method: `getColInput` / `regenerateColInput` (line 152 / 166 / 89 in the bundled `.js`)
- Error pattern: `NullError: method not found: 'dart' on null` (variant of the triaged `'name' on null` for the same null-dataframe deref chain).

## Tested

- `npm run build` in `public/packages/Bio` exits 0 (webpack 5.105.2, 2 size warnings unrelated to this change).
- Manual replay matching the reproduction recipe: with no current table, invoking `Bio:sequenceSpaceTopMenu` via `fc.edit()` now shows the user-facing error and does not reach `DimReductionBaseEditor` construction, so the crash path is no longer executed.

Report reference: see the JIRA ticket linked by the bug-triage pipeline (Report 22615).