### PR TITLE
[report 22513] CLAUDE-535: Chem: Guard mpoWidget against a SemanticValue with no backing cell to prevent null deref on semValue.cell.dataFrame

### DIFF
--- a/packages/Chem/CHANGELOG.md
+++ b/packages/Chem/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v.next
 
 * GROK-20108: Docker API: Throw a clear error when the `chem-chem` container is not available, instead of `Cannot read properties of undefined (reading 'id')`
+* MPO widget: Guard against a `SemanticValue` without a backing cell to avoid `Cannot read properties of null (reading 'dataFrame')` when the property panel binds to a free-floating Molecule context
 
 ## 1.17.8 (2026-05-12)
 

--- a/packages/Chem/package-lock.json
+++ b/packages/Chem/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datagrok/chem",
-  "version": "1.17.6",
+  "version": "1.17.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datagrok/chem",
-      "version": "1.17.6",
+      "version": "1.17.8",
       "dependencies": {
         "@datagrok-libraries/chem-meta": "^1.2.12",
         "@datagrok-libraries/gridext": "^1.5.4",

--- a/packages/Chem/src/package-api.ts
+++ b/packages/Chem/src/package-api.ts
@@ -201,10 +201,6 @@ export namespace funcs {
     return await grok.functions.call('Chem:RecalculateCoords', { table, molecules, method, join });
   }
 
-  export async function chemTooltip(col: DG.Column ): Promise<any> {
-    return await grok.functions.call('Chem:ChemTooltip', { col });
-  }
-
   export async function scaffoldTreeViewer(): Promise<any> {
     return await grok.functions.call('Chem:ScaffoldTreeViewer', {});
   }

--- a/packages/Chem/src/package.ts
+++ b/packages/Chem/src/package.ts
@@ -2989,7 +2989,9 @@ export class PackageFunctions {
     const loader = ui.loader();
     resultDiv.appendChild(loader);
 
-    const dataFrame = semValue.cell.dataFrame;
+    const dataFrame = semValue?.cell?.dataFrame;
+    if (!dataFrame)
+      return DG.Widget.fromRoot(ui.divText('MPO requires a molecule selected from a table.'));
     const profiles = await MpoProfileManager.load();
     const suitableProfiles = findSuitableProfiles(dataFrame, profiles);
 


### PR DESCRIPTION
## Summary

Fixes a `TypeError: Cannot read properties of null (reading 'dataFrame')` thrown from `Chem:mpoWidget` (`public/packages/Chem/src/package.ts:2992`) when the property panel binds to a Molecule `SemanticValue` that has no backing grid cell (for example, one constructed via `DG.SemanticValue.fromValueType(value, 'Molecule')`).

The MPO widget read `semValue.cell.dataFrame` unconditionally; `SemanticValue.cell` is null for free-floating semantic values, which produced the crash observed in the user report. The widget now early-returns a placeholder when no DataFrame context is available — matching the existing pattern used by `descriptorsWidget`, `propertiesWidget`, `structuralAlerts`, and `drugLikeness` in the same file. The secondary `semValue.cell.rowIndex` deref at line 3054 becomes unreachable once `dataFrame` is undefined, so a single guard at the top of the function covers both call sites.

## Changes

- `packages/Chem/src/package.ts` — guard `semValue?.cell?.dataFrame` at the top of `mpoWidget`; return an early placeholder widget when no DataFrame is bound.
- `packages/Chem/CHANGELOG.md` — `v.next` entry.
- `packages/Chem/src/package-api.ts`, `packages/Chem/package-lock.json` — incidental regeneration from `npm run build` (chemTooltip is already removed in `package.ts`; version sync to 1.17.8).

## Stack trace from the report

```
TypeError: Cannot read properties of null (reading 'dataFrame')
	webpack://chem/src/package.ts 2992:37                                  dataFrame
	webpack://chem/src/package.g.ts 1366:33                                mpoWidget
```

## Testing

- `npm run build` in `packages/Chem/` exits 0.
- Verified the failing path: the original report's `mpoWidget` invocation now hits the new guard and returns the placeholder widget instead of touching `semValue.cell.dataFrame`.