### PR TITLE
[report 22546] CLAUDE-548: Chem: Guard Chem:ChemSpaceEditor and Chem:ActivityCliffsEditor against null current table / missing Molecule column

### DIFF
--- a/packages/Chem/CHANGELOG.md
+++ b/packages/Chem/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v.next
 
 * GROK-20108: Docker API: Throw a clear error when the `chem-chem` container is not available, instead of `Cannot read properties of undefined (reading 'id')`
+* Chem: Guard `ChemSpaceEditor` and `ActivityCliffsEditor` against null current table / missing Molecule column to avoid `NullError: method not found: 'dart' on null` from `DimensionalityReductionEditor.getColInput`
 
 ## 1.17.8 (2026-05-12)
 

--- a/packages/Chem/package-lock.json
+++ b/packages/Chem/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datagrok/chem",
-  "version": "1.17.6",
+  "version": "1.17.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datagrok/chem",
-      "version": "1.17.6",
+      "version": "1.17.8",
       "dependencies": {
         "@datagrok-libraries/chem-meta": "^1.2.12",
         "@datagrok-libraries/gridext": "^1.5.4",

--- a/packages/Chem/src/package-api.ts
+++ b/packages/Chem/src/package-api.ts
@@ -201,10 +201,6 @@ export namespace funcs {
     return await grok.functions.call('Chem:RecalculateCoords', { table, molecules, method, join });
   }
 
-  export async function chemTooltip(col: DG.Column ): Promise<any> {
-    return await grok.functions.call('Chem:ChemTooltip', { col });
-  }
-
   export async function scaffoldTreeViewer(): Promise<any> {
     return await grok.functions.call('Chem:ScaffoldTreeViewer', {});
   }

--- a/packages/Chem/src/package.ts
+++ b/packages/Chem/src/package.ts
@@ -761,6 +761,15 @@ export class PackageFunctions {
   @grok.decorators.editor()
   static ChemSpaceEditor(
     @grok.decorators.param({type: 'funccall'}) call: DG.FuncCall): void {
+    const df = grok.shell.tv?.dataFrame;
+    if (!df) {
+      grok.shell.error('Chemical Space requires an open table with a Molecule column');
+      return;
+    }
+    if (df.columns.bySemType(DG.SEMTYPE.MOLECULE) == null) {
+      grok.shell.error('Current table does not contain a Molecule column');
+      return;
+    }
     const funcEditor = new DimReductionBaseEditor({semtype: DG.SEMTYPE.MOLECULE});
     const clusterMCS = ui.input.bool('Cluster MCS', {value: false, tooltipText: 'Perform MCS on clustered data'});
     const editor = funcEditor.getEditor();
@@ -1067,6 +1076,15 @@ export class PackageFunctions {
   @grok.decorators.editor()
   static ActivityCliffsEditor(
     call: DG.FuncCall): void {
+    const df = grok.shell.tv?.dataFrame;
+    if (!df) {
+      grok.shell.error('Activity Cliffs requires an open table with a Molecule column');
+      return;
+    }
+    if (df.columns.bySemType(DG.SEMTYPE.MOLECULE) == null) {
+      grok.shell.error('Current table does not contain a Molecule column');
+      return;
+    }
     const funcEditor = new ActivityCliffsFunctionEditor({semtype: DG.SEMTYPE.MOLECULE});
     const dialog = ui.dialog({title: 'Activity Cliffs'})
       .add(funcEditor.getEditor())


### PR DESCRIPTION
## Summary

Fix `NullError: method not found: 'dart' on null` thrown from `Chem:ChemSpaceEditor` (and by symmetry `Chem:ActivityCliffsEditor`) when invoked with no currently-open table.

Reproduction: with no table open, run `await grok.functions.call('Chem:ChemSpaceEditor', {})` in the dev console. The DimReductionBaseEditor constructor stores `grok.shell.tv?.dataFrame` (null) in its `tableInput`, then `regenerateColInput` → `getColInput` calls `ui.input.column('Column', {table: null, value: null, ...})`. Internally `setColumnInputTable` (js-api.js:27803) dereferences `.dart` on the null column and throws.

## Fix

Guard at editor entry in `packages/Chem/src/package.ts`:
- `ChemSpaceEditor` and `ActivityCliffsEditor` now show a user-friendly `grok.shell.error` and return early if `grok.shell.tv?.dataFrame` is null or if the current dataframe has no `DG.SEMTYPE.MOLECULE` column.

This mirrors the established pattern from Bio commit 15c60488d8 (CLAUDE-459), which applied the same guard to `SequenceSpaceEditor`/`SeqActivityCliffsEditor` for the macromolecule case. The root cause (null-safe `getColInput` in `@datagrok-libraries/ml`) lives in a sibling library out of scope for this Chem-only PR.

## Crash site

- Package: `Chem`
- Surfaced through: `@datagrok-libraries/ml/src/functionEditors/dimensionality-reduction-editor.ts` `DimReductionBaseEditor.getColInput`
- Error pattern: `NullError: method not found: 'dart' on null`

## Test plan

- [x] `npm run build` in `packages/Chem/` exits 0 (webpack compiled with 2 size-budget warnings only).
- [x] Verified the reproduction recipe before the fix: `grok.functions.call('Chem:ChemSpaceEditor', {})` with no open table throws the exact error pattern (see JIRA ticket comment for stack trace).
- [x] Walked the patched code path: with `grok.shell.tv?.dataFrame == null`, the function short-circuits at the new guard and `new DimReductionBaseEditor(...)` never runs, so the failing `getColInput`/`setColumnInputTable` line is unreachable.
- [ ] Manual: with a table containing a Molecule column open, both editors still open their dialog normally.