### PR TITLE
GROK-19985: ClinicalCase: Precheck docker container before validation

### DIFF
--- a/packages/ClinicalCase/CHANGELOG.md
+++ b/packages/ClinicalCase/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Clinical Case changelog
 
+## v.next
+
+* GROK-19985: Validation: Throw a clear error when the clinical-case container is unavailable instead of the platform-level NoSuchMethodError
+
 ## 1.4.0 (2026-03-16)
 
 * xpt file handler + linter fixes

--- a/packages/ClinicalCase/src/package.ts
+++ b/packages/ClinicalCase/src/package.ts
@@ -265,6 +265,10 @@ export class PackageFunctions {
       'optional': true,
     }) options?: any,
   ): Promise<string> {
+    const containers = await grok.dapi.docker.dockerContainers.filter('name = "clinical-case"').list();
+    if (containers.length === 0)
+      throw new Error('Clinical Case validation container "clinical-case" is not available on this server');
+
     const result = await grok.functions.call('ClinicalCase:run_core_validate', {
       standard,
       version,


### PR DESCRIPTION
Look up the clinical-case docker container before invoking ClinicalCase:run_core_validate and throw a clear error when it isn't present on the server. Without the precheck the call surfaces as an opaque "NoSuchMethodError: The getter 'status' was called on null" from the platform's docker queue interceptor and breaks the study Summary view.