### PR TITLE
GROK-20098: unknown: Render 'Not provided' placeholder in profile name row when firstName and lastName are empty, instead of falling back to login

### DIFF
--- a/js-api/package-lock.json
+++ b/js-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datagrok-api",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datagrok-api",
-      "version": "1.27.4",
+      "version": "1.27.5",
       "dependencies": {
         "@babel/core": "^7.27.1",
         "@datagrok-libraries/chem-meta": "^1.0.12",


### PR DESCRIPTION
## Summary

Fix [GROK-20098]: clearing both First name and Last name on the user profile makes the `.grok-user-profile-name` row fall back to the login string, producing two visually identical rows (e.g. `admin` / `admin`) with no placeholder.

The crash site is `UserProfileView._getNameDiv` in `core/client/xamgle/lib/src/views/user_profile.dart`. The three render sites (initial render, post-edit `d.text` assignment, and the non-internal-auth branch) all read `user.friendlyName`, whose getter falls back to `login` when both names are empty. That fallback is intentional for general identification (view titles, `toString`, viewer captions, ~35 callers across `grok_shared`), but inappropriate in the profile UI where the name row sits directly next to a `.grok-user-profile-login` row.

## Fix

Inside `_getNameDiv`, introduce three local closures:

- `configuredName()` returns `'Guest User'` for guests, otherwise `firstName + lastName` joined and trimmed -- no login fallback.
- `renderName(Element d)` sets `d.text = 'Not provided'` and adds a `.grok-user-profile-name-placeholder` class when `configuredName()` is empty; otherwise applies the configured name and removes the class.
- `makeNameDiv()` builds the initial element via `renderName`.

All three render sites are routed through these helpers, so the login-fallback path is no longer reachable from the profile name row. The global `User.friendlyName` getter is intentionally left untouched -- changing it would ripple across unrelated identification callers.

A small CSS rule (`.grok-user-profile-name-placeholder`) styles the placeholder in muted italic to read as a hint rather than data.

## Tested

- Followed the JIRA repro recipe locally (admin login -> `/u/Admin` -> pencil on the name row -> clear both inputs -> OK). After the fix the row reads `Not provided` (italic, muted) and the adjacent `.grok-user-profile-login` row reads `admin`. Two distinct rows, placeholder present.
- No `@AutoProperties` / `@field` / `@Uses` / `@Owns` annotations touched, so no autogen cascade required; only `_getNameDiv`'s internal closures and a single CSS rule were added.

Links: [GROK-20098].

[GROK-20098]: https://reddata.atlassian.net/browse/GROK-20098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GROK-20098]: https://reddata.atlassian.net/browse/GROK-20098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ