### PR TITLE
GROK-20202: ML: Fix search viewer crash on table with no column of required semType

### DIFF
--- a/libraries/ml/CHANGELOG.md
+++ b/libraries/ml/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.10.13
 
-Search viewers: Fixed crash (`Cannot read properties of null (reading 'name')`) when a similarity/diversity search viewer is attached to a table without a column of the required semantic type
+Search viewers: Fixed crash (`Cannot read properties of null (reading 'name')`) when a similarity/diversity search viewer is attached to a table without a column of the required semantic type; the viewer now shows a "requires a … column" message and resolves the column automatically once semantic-type detection completes
 
 ## 6.10.11 (2026-03-27)
 

--- a/libraries/ml/CHANGELOG.md
+++ b/libraries/ml/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ml changelog
 
+## 6.10.13
+
+Search viewers: Fixed crash (`Cannot read properties of null (reading 'name')`) when a similarity/diversity search viewer is attached to a table without a column of the required semantic type
+
 ## 6.10.11 (2026-03-27)
 
 Dimentionality reduction: pass embeddings and cluster columns names as optional parameters

--- a/libraries/ml/package-lock.json
+++ b/libraries/ml/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datagrok-libraries/ml",
-  "version": "6.10.12",
+  "version": "6.10.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datagrok-libraries/ml",
-      "version": "6.10.12",
+      "version": "6.10.13",
       "dependencies": {
         "@datagrok-libraries/math": "^1.2.6",
         "@datagrok-libraries/utils": "^4.5.7",

--- a/libraries/ml/package.json
+++ b/libraries/ml/package.json
@@ -8,7 +8,7 @@
     "email": "drizhinashvili@datagrok.ai"
   },
   "friendlyName": "Datagrok ML library",
-  "version": "6.10.12",
+  "version": "6.10.13",
   "description": "Machine learning supporting utilities",
   "dependencies": {
     "@datagrok-libraries/math": "^1.2.6",

--- a/libraries/ml/src/viewers/search-base-viewer.ts
+++ b/libraries/ml/src/viewers/search-base-viewer.ts
@@ -45,14 +45,28 @@ export class SearchBaseViewer extends DG.JsViewer {
         .subscribe((_: any) => this.render(false)));
       this.subs.push(DG.debounce(ui.onSizeChanged(this.root), 50)
         .subscribe((_: any) => this.render(false)));
-      const targetColumnName = this.targetColumnName ?? this.dataFrame.columns.bySemType(this.semType)?.name;
-      if (targetColumnName) {
-        this.targetColumnName = targetColumnName;
-        this.targetColumn = this.dataFrame.col(targetColumnName)!;
-        this.getProperty('limit')!.fromOptions({min: 1, max: this.maxLimit});
-      }
+      this.subs.push(this.dataFrame.onSemanticTypeDetected.subscribe((_: any) => {
+        if (!this.targetColumn && this.resolveTargetColumn())
+          this.render();
+      }));
+      if (!this.resolveTargetColumn())
+        this.root.appendChild(ui.divText(`This viewer requires a ${this.semType} column`, 'd4-viewer-error'));
     }
     this.render();
+  }
+
+  /** Resolves [targetColumn] from a saved [targetColumnName] or the first column of [semType].
+   * Returns whether a suitable column was found. */
+  protected resolveTargetColumn(): boolean {
+    if (!this.dataFrame)
+      return false;
+    const targetColumnName = this.targetColumnName ?? this.dataFrame.columns.bySemType(this.semType)?.name;
+    if (!targetColumnName)
+      return false;
+    this.targetColumnName = targetColumnName;
+    this.targetColumn = this.dataFrame.col(targetColumnName)!;
+    this.getProperty('limit')!.fromOptions({min: 1, max: this.maxLimit});
+    return true;
   }
 
   onPropertyChanged(property: DG.Property): void {

--- a/libraries/ml/src/viewers/search-base-viewer.ts
+++ b/libraries/ml/src/viewers/search-base-viewer.ts
@@ -45,9 +45,12 @@ export class SearchBaseViewer extends DG.JsViewer {
         .subscribe((_: any) => this.render(false)));
       this.subs.push(DG.debounce(ui.onSizeChanged(this.root), 50)
         .subscribe((_: any) => this.render(false)));
-      this.targetColumnName ??= this.dataFrame.columns.bySemType(this.semType)!.name;
-      this.targetColumn = this.dataFrame.col(this.targetColumnName)!;
-      this.getProperty('limit')!.fromOptions({min: 1, max: this.maxLimit});
+      const targetColumnName = this.targetColumnName ?? this.dataFrame.columns.bySemType(this.semType)?.name;
+      if (targetColumnName) {
+        this.targetColumnName = targetColumnName;
+        this.targetColumn = this.dataFrame.col(targetColumnName)!;
+        this.getProperty('limit')!.fromOptions({min: 1, max: this.maxLimit});
+      }
     }
     this.render();
   }


### PR DESCRIPTION
## What

Fixes report 22892 — `TypeError: Cannot read properties of null (reading 'name')`.

`SearchBaseViewer.onTableAttached` dereferenced `this.dataFrame.columns.bySemType(this.semType)!.name`. When a similarity/diversity search viewer (Bio `SequenceSimilarityViewer` / `SequenceDiversityViewer`, also NLP `SentenceSimilarityViewer`) is attached to a table that has **no column of the required semantic type**, `bySemType(...)` returns `null` and `!.name` throws.

The gallery/menu applicability gate prevents adding the viewer to an unsuitable table through the UI, but **viewer re-instantiation paths bypass that gate** — most notably **layout/project restore** (and programmatic `addViewer`). The stack confirms re-instantiation (`Func.run → FuncCall.resultParams → JsViewerHostDescriptor.fromFunc → setJsViewer → onTableAttached`).

## Fix

`libraries/ml/src/viewers/search-base-viewer.ts`:

1. **No crash** — the column lookup is null-safe (`bySemType(...)?.name`) and `targetColumn`/`limit` are only resolved when a column exists (factored into `resolveTargetColumn()`).
2. **Informative empty state** — instead of a blank panel, the viewer shows the conventional `d4-viewer-error` message *"This viewer requires a `<semType>` column"*, matching how core viewers (scatter/box/line) and Charts viewers (Sunburst, Radar, …) handle missing required columns.
3. **Auto-recovery** — subscribes to `onSemanticTypeDetected` and resolves the target column automatically once detection completes, then re-renders. This covers the project/layout-reopen **race** where the column *is* a real sequence column but wasn't tagged `Macromolecule` yet at attach time. The success render path (`updateDivInnerHTML`) replaces the message.

Lives in the shared base class, so it covers all `SearchBaseViewer` subclasses (Bio similarity/diversity + NLP sentence similarity) in one place.

## Notes

- `@datagrok-libraries/ml` bumped `6.10.12 → 6.10.13` + CHANGELOG entry.
- 4 pre-existing eslint errors in the file are unrelated and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
