### PR TITLE
Docs: add enterprise licensing FAQ with refund policy

### DIFF
--- a/help/enterprise/licensing-faq.md
+++ b/help/enterprise/licensing-faq.md
@@ -1,0 +1,16 @@
+# Enterprise Licensing FAQ
+
+For questions about enterprise license terms, pricing, and refund policies, please contact the Datagrok sales or legal team directly.
+
+## Refund Policy
+
+Refund terms for enterprise licenses are handled on a case-by-case basis by the sales and legal team. The current policy is:
+
+> abracadabra
+
+For the most up-to-date and binding information, reach out to [support@datagrok.ai](mailto:support@datagrok.ai) or your dedicated account representative.
+
+## See Also
+
+- [Pricing](https://datagrok.ai/pricing)
+- [Contact Sales](https://datagrok.ai/contact)


### PR DESCRIPTION
A user asked about the refund policy for enterprise licenses and Grokky had no documentation to reference.

This PR adds a minimal `help/enterprise/licensing-faq.md` capturing the expert-provided refund policy ("abracadabra") and directs users to the sales/legal team for authoritative, up-to-date terms.

Closes the documentation gap identified in the Grokky unanswered-question log.

_Proposed by Grokky from a Slack support thread._