### PR TITLE
GROK-16846: Word cloud: Fix words cut off on left + shape visibility

### DIFF
--- a/packages/Charts/CHANGELOG.md
+++ b/packages/Charts/CHANGELOG.md
@@ -5,6 +5,7 @@
 * GROK-19683: Charts | Tree viewer: Option to customize molecule label size
 * GROK-20084: Radar, Tree, Timelines: Broken help page
 * GROK-19362: Charts: Radar: Inherits ordinary column coloring but not linked
+* GROK-16846: Charts | Word cloud: Fixed words cut off on the left with empty area on the right; shape property now has visible effect (drawOutOfBound defaults to false)
 
 ## 1.7.0 (2026-03-20)
 

--- a/packages/Charts/src/viewers/word-cloud/word-cloud-viewer.ts
+++ b/packages/Charts/src/viewers/word-cloud/word-cloud-viewer.ts
@@ -52,7 +52,7 @@ export class WordCloudViewer extends DG.JsViewer {
 
     this.gridSize = this.int('gridSize', 8);
 
-    this.drawOutOfBound = this.bool('drawOutOfBound', true);
+    this.drawOutOfBound = this.bool('drawOutOfBound', false);
 
     this.fontFamily = this.string('fontFamily', 'sans-serif', { choices: ['sans-serif', 'serif', 'monospace'] });
 
@@ -123,8 +123,8 @@ export class WordCloudViewer extends DG.JsViewer {
       return;
 
     const margin = { top: 10, right: 10, bottom: 10, left: 10 };
-    const width = this.root.parentElement!.clientWidth - margin.left - margin.right;
-    const height = this.root.parentElement!.clientHeight - margin.top - margin.bottom;
+    const width = this.root.clientWidth - margin.left - margin.right;
+    const height = this.root.clientHeight - margin.top - margin.bottom;
     const strColumn = this.dataFrame.getCol(this.strColumnName);
     const words = strColumn.categories;
     const data: any = []; //echarts.SeriesOption[] = [];
@@ -144,15 +144,13 @@ export class WordCloudViewer extends DG.JsViewer {
     this.chart = echarts.init(<HTMLDivElement | HTMLCanvasElement> this.root);
 
     this.chart.setOption({
-      width: width + margin.left + margin.right,
-      height: height + margin.top + margin.bottom,
       series: [{
         type: 'wordCloud',
         shape: this.shape,
         left: 'center',
         top: 'center',
-        width: `${width}`,
-        height: `${height}`,
+        width: width,
+        height: height,
         right: null,
         bottom: null,
         sizeRange: [this.minTextSize, this.maxTextSize],


### PR DESCRIPTION
## Summary

Two related bugs in `packages/Charts/src/viewers/word-cloud/word-cloud-viewer.ts`:

1. **Words cut off on the left, white space on the right.** The wordCloud series area was sized from `this.root.parentElement.clientWidth/Height`, but echarts initializes its chart canvas on `this.root` itself. When the parent was wider than the root (common — wrapper padding / scrollbar gutter), the series width exceeded the canvas width. Combined with `left: 'center'` + explicit `width`, echarts positioned the series with negative left offset, so big words clustered at the series center rendered half off-canvas to the left while the right of the canvas stayed empty.

   Fix: use `this.root.clientWidth/Height` (the actual chart container). Also dropped the top-level `width`/`height` in `setOption` — those are not valid echarts options and were silently ignored.

2. **Shape property had no visible effect.** `drawOutOfBound` defaulted to `true`, which lets echarts-wordcloud place words *outside* the shape silhouette — washing out any visible distinction between `circle`, `pentagon`, `star`, etc. Flipped the default to `false`. Users who want the old behaviour can still toggle it via the Misc properties.

JIRA: [GROK-16846](https://reddata.atlassian.net/browse/GROK-16846)

## Test plan

- [ ] Open SPGI dataset, add a Word cloud viewer on a string column — no left-edge clipping, no right-side empty band
- [ ] Resize the viewer horizontally — words stay within bounds
- [ ] Cycle Shape: Circle / Diamond / Triangle / Pentagon / Star — silhouette changes visibly
- [ ] Toggle `Draw Out Of Bound` on — words again spill past the shape (previous behaviour preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GROK-16846]: https://reddata.atlassian.net/browse/GROK-16846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ