### PR TITLE
GROK-20232: Curves: Guard JSON.parse in parseCellValue and degrade malformed fit-cell JSON to an empty chart

### DIFF
--- a/packages/Curves/CHANGELOG.md
+++ b/packages/Curves/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Curves changelog
 
+## v.next
+
+* GROK-20232: Fit renderer: degrade gracefully on malformed fit-cell JSON instead of throwing on every grid redraw
+
 ## 1.12.0 (2026-04-02)
 
 ### Features

--- a/packages/Curves/src/fit/curve-converter.ts
+++ b/packages/Curves/src/fit/curve-converter.ts
@@ -69,7 +69,14 @@ export function parseCellValue(cellValue: string, column?: DG.Column | null): IF
     return {series: []};
 
   const jsonStr = column ? convertCellValue(cellValue, column) : cellValue;
-  return JSON.parse(jsonStr ?? '{}') ?? {};
+  try {
+    return JSON.parse(jsonStr ?? '{}') ?? {};
+  } catch (_e) {
+    // Cell value is not valid fit JSON (e.g. a column mis-detected as 'fit' via a substring match).
+    // Degrade to an empty chart so the renderer hits the existing 'No series to show' path and draws the
+    // incorrect-fit marker, instead of throwing a SyntaxError on every grid redraw.
+    return {series: []};
+  }
 }
 
 /** Returns true if the column uses a non-native format (has a converter). */

--- a/packages/Curves/src/tests/converter-tests.ts
+++ b/packages/Curves/src/tests/converter-tests.ts
@@ -181,6 +181,12 @@ category('converters', () => {
     expect(chartData.series !== undefined && chartData.series.length === 0, true);
   });
 
+  test('parseCellValue.malformedJson', async () => {
+    // Unquoted-key value that passes the substring-based fit detection but is not valid JSON.
+    const chartData = parseCellValue('{series: [{name: "A", points: [{x:0,y:50}]}]}', null);
+    expect(chartData.series !== undefined && chartData.series.length === 0, true);
+  });
+
   test('converterCaching', async () => {
     registerCurveConverter('compact-dr', convertCompactDrToJson);
 


### PR DESCRIPTION
## GROK-20232: Curves: degrade gracefully on malformed fit-cell JSON

Pasting an invalid-JSON value containing the substrings `series` and `points` into a cell of a column that Curves' `detectFit` tags as `semType='fit'` caused `FitChartCellRenderer.render` to throw a `SyntaxError` on every grid redraw. The render path calls `getChartData` -> `parseCellValue` (`public/packages/Curves/src/fit/curve-converter.ts`), which ran `JSON.parse` with no guard, so the error fired before reaching the existing `showIncorrectFitCell()` degrade path.

### Fix
Wrap `JSON.parse` in `parseCellValue` (the single entry point for cell parsing) in a try/catch returning `{series: []}` on failure. This routes malformed values into the renderer's existing empty-series early-out (`CONDITION_MAP` 'No series to show' -> `showIncorrectFitCell`), so the cell draws the incorrect-fit marker instead of throwing.

### Testing
- `npm run build` in `packages/Curves` exits 0.
- Added regression test `parseCellValue.malformedJson`.

Refs JIRA GROK-20232. Crash site: `Curves` / `curve-converter.ts` / `parseCellValue`.