### PR TITLE
[ticket] GROK-20063: EDA: Convert datetime feature columns to numeric (epoch) before training PLS Regression so they are accepted instead of throwing 'unsupported column type: datetime'

### DIFF
--- a/packages/EDA/CHANGELOG.md
+++ b/packages/EDA/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EDA changelog
 
+## v.next
+
+GROK-20063 PLS Regression: support datetime feature columns instead of failing with "unsupported column type: datetime"
+
 ## 1.5.5 (2026-05-26)
 
 Implement Welch ANOVA

--- a/packages/EDA/src/package.ts
+++ b/packages/EDA/src/package.ts
@@ -33,6 +33,7 @@ import {MCLSerializableOptions} from '@datagrok-libraries/ml/src/MCL';
 import {getLinearRegressionParams, getPredictionByLinearRegression,
   isLinearRegressionApplicable, isLinearRegressionInteractive} from './regression';
 import {PlsModel} from './pls/pls-ml';
+import {numericalizeFeatures} from './utils';
 import {SoftmaxClassifier} from './softmax-classifier';
 
 import {initXgboost} from '../wasm/xgbooster';
@@ -822,7 +823,7 @@ export class PackageFunctions {
     df: DG.DataFrame,
     predictColumn: DG.Column,
     @grok.decorators.param({'type': 'int', 'options': {'min': '1', 'max': '10', 'initialValue': '3', 'description': 'Number of latent components.'}}) components: number): Promise<Uint8Array> {
-    const features = df.columns;
+    const features = numericalizeFeatures(df.columns);
 
     const model = new PlsModel();
     await model.fit(

--- a/packages/EDA/src/pls/pls-ml.ts
+++ b/packages/EDA/src/pls/pls-ml.ts
@@ -44,7 +44,7 @@ export class PlsModel {
   /** Check applicability */
   static isApplicable(features: DG.ColumnList, predictColumn: DG.Column): boolean {
     for (const col of features) {
-      if (!col.matches('numerical'))
+      if (!col.matches('numerical') && (col.type !== DG.COLUMN_TYPE.DATE_TIME))
         return false;
     }
     if (!predictColumn.matches('numerical'))

--- a/packages/EDA/src/utils.ts
+++ b/packages/EDA/src/utils.ts
@@ -41,6 +41,19 @@ export function checkColumnType(col: DG.Column): void {
     throw new Error(UNSUPPORTED_COLUMN_TYPE_MES + col.type);
 }
 
+/** Replace datetime feature columns with numeric (epoch) columns so they can be used as predictors.
+ * The raw values are preserved exactly, so a model trained here stays consistent with the apply path,
+ * which reads the original datetime column's raw data. Other column types are returned unchanged. */
+export function numericalizeFeatures(features: DG.ColumnList): DG.ColumnList {
+  const cols = features.toList().map((col) => {
+    if (col.type === DG.COLUMN_TYPE.DATE_TIME)
+      return DG.Column.fromFloat64Array(col.name, Float64Array.from(col.getRawData()), col.length);
+    return col;
+  });
+
+  return DG.DataFrame.fromColumns(cols).columns;
+}
+
 /** Check missing values */
 export function checkMissingVals(col: DG.Column): void {
   if (col.stats.missingValueCount > 0 )


### PR DESCRIPTION
## GROK-20063 EDA / PLS Regression: support datetime feature columns

**Bug.** Training a Predictive Model with **PLS Regression** (e.g. on the `demog` demo table) fails with `unsupported column type: datetime` when a datetime column (such as `started`) is included among the predictors. The error originates in `Eda:trainPLSRegression` (`public/packages/EDA/src/package.ts`), whose feature-validation chain (`PlsModel.fit` -> `getPlsAnalysis` -> `checkDimensionReducerInputs` -> `checkColumnType` in `src/utils.ts`) only whitelists `INT`/`FLOAT` columns and throws for anything else (function `k` in the built `package.js`).

**Fix.** Datetime columns are numeric under the hood (epoch values), so instead of crashing they are now converted to a numeric feature before training. `trainPLSRegression` runs the feature list through a new `numericalizeFeatures` helper that replaces each `DATE_TIME` column with a `FLOAT` column built from its exact raw (`Float64Array`) values, preserving column order and count. Because the raw values are preserved exactly and the apply path (`applyPLSRegression` -> `getPredictionByLinearRegression`) reads the original datetime column's `getRawData()` without a type check, train and apply stay consistent (same feature count, same values, stored bias unchanged). `PlsModel.isApplicable` was also widened to accept datetime columns so applicability matches the now-supported training.

**Scope / why not the alternatives.** The fix is deliberately scoped to the PLS train entry point rather than the shared `checkColumnType` (used by UMAP/t-SNE/SPE, where `centerScale` keys off `isNumerical`) and rather than dropping the datetime column (which would shrink the feature count and trigger `Incorrect parameters count` at apply, since the PM framework re-supplies the original feature set).

**Known limitation.** A datetime column used as the *response/target* is out of scope (unchanged); this PR addresses datetime *feature* columns, which is the reported case.

**Tested.** `npm run build` in `public/packages/EDA` compiles cleanly (exit 0). Confirmed the unfixed path threw the exact `unsupported column type: datetime` for `demog` features including `started`, and that the new path numericalizes the column before any type validation runs. See the JIRA ticket GROK-20063 comment for the reproduction evidence.