### PR TITLE
GROK-19595: Dendrogram: Disable the crashing 'centroid' linkage option in Hierarchical Clustering and guard the programmatic entry point

### DIFF
--- a/packages/Dendrogram/CHANGELOG.md
+++ b/packages/Dendrogram/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Dendrogram changelog
 
+## v.next
+
+* GROK-19595 Hierarchical Clustering: Remove the broken "centroid" linkage option (the fastcluster WASM centroid routine crashes with "memory access out of bounds" on real data and hangs the progress indicator)
+
 ## 1.4.14 (2026-05-19)
 
 * GROK-20143 Demo: Heatmap: cells are editable due to incorrect demo setup

--- a/packages/Dendrogram/src/package.g.ts
+++ b/packages/Dendrogram/src/package.g.ts
@@ -70,7 +70,7 @@ export async function hierarchicalClusteringSequencesApp() : Promise<void> {
 //input: dataframe df 
 //input: column_list colNameList 
 //input: string distance = 'euclidean' { choices: ["euclidean","manhattan"] }
-//input: string linkage = 'ward' { choices: ["single","complete","average","weighted","centroid","median","ward"] }
+//input: string linkage = 'ward' { choices: ["single","complete","average","weighted","median","ward"] }
 export async function hierarchicalClustering(df: DG.DataFrame, colNameList: DG.ColumnList, distance: any, linkage: string) : Promise<void> {
   await PackageFunctions.hierarchicalClustering(df, colNameList, distance, linkage);
 }

--- a/packages/Dendrogram/src/package.ts
+++ b/packages/Dendrogram/src/package.ts
@@ -264,7 +264,7 @@ export class PackageFunctions {
     df: DG.DataFrame,
     colNameList: DG.ColumnList,
     @grok.decorators.param({type: 'string', options: {initialValue: 'euclidean', choices:['euclidean', 'manhattan']}}) distance: DistanceMetric = DistanceMetric.Euclidean,
-    @grok.decorators.param({options: {initialValue: 'ward', choices:['single', 'complete', 'average', 'weighted', 'centroid', 'median', 'ward']}})linkage: string,
+    @grok.decorators.param({options: {initialValue: 'ward', choices:['single', 'complete', 'average', 'weighted', 'median', 'ward']}})linkage: string,
   ): Promise<void> {
     const names = Array.isArray(colNameList) ? (colNameList as unknown as DG.Column[]).map((a) => a.name) : colNameList.names();
     await hierarchicalClusteringUI(df, names, distance, linkage);

--- a/packages/Dendrogram/src/utils/hierarchical-clustering.ts
+++ b/packages/Dendrogram/src/utils/hierarchical-clustering.ts
@@ -52,7 +52,10 @@ export async function hierarchicalClusteringDialog(getDefaultCoulumn: (t: DG.Dat
   const columnsInputDiv = ui.div([columnsInput]);
 
   const distanceInput = ui.input.choice('Distance', {value: DistanceMetric.Euclidean, items: Object.values(DistanceMetric)});
-  const linkageInput = ui.input.choice('Linkage', {value: LinkageMethod.Ward, items: Object.values(LinkageMethod)});
+  // Centroid linkage is excluded: the underlying fastcluster WASM routine for centroid
+  // performs an out-of-bounds heap access on real-world inputs (memory access out of bounds).
+  const linkageInput = ui.input.choice('Linkage', {value: LinkageMethod.Ward,
+    items: Object.values(LinkageMethod).filter((method) => method !== LinkageMethod.Centroid)});
 
   const verticalDiv = ui.divV([
     tableInput.root,
@@ -86,6 +89,13 @@ export async function hierarchicalClusteringUI(
   neighborWidth: number = 300,
   options?: {tableView?: DG.TableView}
 ): Promise<void> {
+  // Centroid linkage crashes the fastcluster WASM routine (out-of-bounds heap access) on
+  // real-world data, leaving the clustering progress indicator hanging. Bail out before any
+  // compute/loader is started so callers get a clear message instead of a silent infinite spinner.
+  if (linkage === LinkageMethod.Centroid) {
+    grok.shell.warning('Centroid linkage is currently unavailable for hierarchical clustering.');
+    return;
+  }
   const linkageCode = Object.values(LinkageMethod).findIndex((method) => method === linkage);
 
   const colNameSet: Set<string> = new Set(colNameList);


### PR DESCRIPTION
## GROK-19595 — Dendrogram: Hierarchical Clustering hangs with a WASM 'memory access out of bounds' error on 'centroid' linkage

### Summary
Running Hierarchical Clustering with **Linkage = centroid** on numeric columns throws a WASM `RuntimeError: memory access out of bounds` and leaves the `grok-loader` progress indicator spinning forever, never producing a dendrogram. This PR removes the broken `centroid` option from the linkage choices and guards the programmatic clustering entry point so the failing path can no longer be reached.

### Root cause
The crash originates in the fastcluster WASM routine invoked from `Dendrogram/src/utils/hierarchical-clustering.ts` (`getClusterMatrixWorker` → `getDendrogram`, error surfaced at `hierarchical-clustering.ts:217`). I reproduced it deterministically by replaying Dendrogram's exact euclidean distance pipeline on real `demog.csv` data and calling the actual `wasmCluster.wasm`: the **centroid** method (`generic_linkage<METHOD_METR_CENTROID>`) throws `memory access out of bounds` at n=463/1000/5097, while every other method — single, complete, average, weighted, **median**, ward — succeeds on the identical distance matrix. Passing squared distances (the canonical fastcluster convention for geometric linkages) did not help; centroid still trapped. The defect is therefore an out-of-bounds heap access inside the centroid branch of the compiled fastcluster WASM, which lives in `public/libraries/math` (outside this package).

### Fix
Since the WASM binary cannot be changed from this package, the fix stops `centroid` from being routed into the broken routine at all three entry points:
- `hierarchical-clustering.ts`: the Linkage dialog dropdown no longer lists `centroid`.
- `package.ts` (and regenerated `package.g.ts`): the `hierarchicalClustering` function's `linkage` choices no longer include `centroid`.
- `hierarchicalClusteringUI(...)`: an early return with a clear warning for any direct programmatic caller that still passes `'centroid'`, before any loader or compute is started (so no infinite spinner).

### Known limitation / follow-up
This removes the (non-functional) centroid linkage rather than repairing it. A proper fix belongs in the fastcluster WASM centroid implementation under `public/libraries/math/.../hierarchical-clustering/wasm` (out of scope for this package-level change) and should be tracked separately; once the WASM is fixed, the option can be re-enabled.

### Testing
- Reproduced the original `memory access out of bounds` against the unmodified `wasmCluster.wasm` using the real demog distance pipeline; confirmed only the centroid method traps.
- `npm run build` exits 0 for the Dendrogram package.
- See the JIRA ticket for the reproduction screenshots/video.
