### PR TITLE
Tools: fix grok publish silent exit 1 (stray unlinkSync); bump to 6.4.4

### DIFF
--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datagrok-tools changelog
 
+## 6.4.4 (2026-06-22)
+
+* `grok publish` — fixed every publish failing with a silent `exit 1` after a successful upload: a stray `fs.unlinkSync('zip')` threw `ENOENT` (the archive is streamed in-memory, no `zip` file is ever written), and the surrounding `catch` only logged under `--verbose`. The errant unlink is removed and publish errors are now always surfaced.
+
 ## 6.4.3 (2026-06-22)
 
 * `grok api` — numeric IVP model inputs are now generated with `nullable: false`, so an emptied input field fails form validation instead of running the solver with a null.

--- a/tools/bin/commands/publish.ts
+++ b/tools/bin/commands/publish.ts
@@ -469,9 +469,9 @@ export async function processPackage(debug: boolean, rebuild: boolean, host: str
     }
     if (debug)
       timestamps = checkData;
-  } catch (error) {
-    if (utils.isConnectivityError(error))
-      color.error(`Server is possibly offline: ${host}`);
+  } catch (error: any) {
+    color.error(utils.isConnectivityError(error) ? `Server is possibly offline: ${host}`
+      : `Failed to validate package on ${host}: ${error?.message ?? error}`);
     if (color.isVerbose())
       console.error(error);
     return 1;
@@ -603,7 +603,6 @@ export async function processPackage(debug: boolean, rebuild: boolean, host: str
     });
     const log = JSON.parse(await body.text());
 
-    fs.unlinkSync('zip');
     if (log != undefined) {
       if (log['#type'] === 'ApiError') {
         color.error(log['message']);
@@ -616,9 +615,9 @@ export async function processPackage(debug: boolean, rebuild: boolean, host: str
         color.success(`✓ Published to ${hostAlias || new URL(host).hostname}`);
       }
     }
-  } catch (error) {
-    if (utils.isConnectivityError(error))
-      color.error(`Server is possibly offline: ${url}`);
+  } catch (error: any) {
+    color.error(utils.isConnectivityError(error) ? `Server is possibly offline: ${url}`
+      : `Publish failed: ${error?.message ?? error}`);
     if (color.isVerbose())
       console.error(error);
     return 1;

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datagrok-tools",
-  "version": "6.4.3",
+  "version": "6.4.4",
   "description": "Utility to upload and publish packages to Datagrok",
   "homepage": "https://github.com/datagrok-ai/public/tree/master/tools#readme",
   "dependencies": {


### PR DESCRIPTION
## Problem

The **Packages** workflow's `Publish package to Datagrok` step (`grok publish GitHubAction --release`) fails with **exit 1 and a completely blank log**, retrying 5× identically — e.g. [EDA run #82707268862](https://github.com/datagrok-ai/public/actions/runs/27950625545/job/82707268862).

The deploy actually **succeeds** server-side (`POST [200] /packages/dev/admin/@datagrok/eda`), yet the client reports failure with no diagnostic.

## Root cause

`processPackage` in `tools/bin/commands/publish.ts` streams the package archive **in-memory** (`archiver` → `chunks`), but still ran `fs.unlinkSync('zip')` after upload. No `zip` file is ever written, so the unlink throws `ENOENT: no such file or directory, unlink 'zip'` on **every successful publish**. That landed in a `catch` that only prints under `--verbose`, then `return 1` → CI sees exit 1 with no output.

Reproduced locally against a `bleeding-edge` stand: a built package publishes (`POST [200]`, body is valid JSON `""`), then `grok publish` exits 1; with `--verbose` the thrown error is `ENOENT … unlink 'zip'` at the line removed here.

## Fix

* Remove the errant `fs.unlinkSync('zip')` (`fs` is still used elsewhere).
* Harden both `catch` blocks to **always** surface the error message (not only under `--verbose`), so a swallowed exception can never again be invisible in CI.
* Bump `datagrok-tools` 6.4.3 → 6.4.4 so CI's `npm install -g datagrok-tools@latest` picks up the fix (published by `tools.yml` on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)