### PR TITLE
Tools: grok test — make --record screen recording optional (ffmpeg ENOENT); bump 6.4.5

### DIFF
--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datagrok-tools changelog
 
+## 6.4.5 (2026-06-23)
+
+* `grok test` — screen recording (`--record`) is now optional: if `page.screencast()` can't start (e.g. `ffmpeg` is missing on the runner, `spawnSync ffmpeg ENOENT`), the run warns and continues instead of failing the whole Puppeteer pass with 0 tests executed.
+
 ## 6.4.4 (2026-06-22)
 
 * `grok publish` — fixed every publish failing with a silent `exit 1` after a successful upload: a stray `fs.unlinkSync('zip')` threw `ENOENT` (the archive is streamed in-memory, no `zip` file is ever written), and the surrounding `catch` only logged under `--verbose`. The errant unlink is removed and publish errors are now always surfaced.

--- a/tools/bin/utils/test-utils.ts
+++ b/tools/bin/utils/test-utils.ts
@@ -277,7 +277,12 @@ export async function loadTestsList(packages: string[], core: boolean = false, r
       const logsDir = `./load-test-console-output${suffix}.log`;
       const recordDir = `./load-test-record${suffix}.mp4`;
 
-      recorder = await page.screencast({path: recordDir as `${string}.mp4`});
+      try {
+        recorder = await page.screencast({path: recordDir as `${string}.mp4`});
+      } catch (e: any) {
+        recorder = null;
+        color.warn(`Screen recording disabled: ${e?.message || e}`);
+      }
       await page.exposeFunction('addLogsToFile', addLogsToFile);
 
       fs.writeFileSync(logsDir, ``);
@@ -698,8 +703,15 @@ export async function runBrowser(
     const recordDir = `./test-record-${currentBrowserNum}.mp4`;
 
     if (browserOptions.record && !existingBrowserSession) {
-      // Only set up recording on initial browser creation, not on retry
-      recorder = await page.screencast({path: recordDir as `${string}.mp4`});
+      // Only set up recording on initial browser creation, not on retry.
+      // Recording is an optional diagnostic — if it can't start (e.g. ffmpeg is
+      // missing on the runner), warn and keep testing instead of failing the pass.
+      try {
+        recorder = await page.screencast({path: recordDir as `${string}.mp4`});
+      } catch (e: any) {
+        recorder = null;
+        color.warn(`Screen recording disabled: ${e?.message || e}`);
+      }
       await page.exposeFunction('addLogsToFile', addLogsToFile);
 
       fs.writeFileSync(logsDir, ``);

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datagrok-tools",
-  "version": "6.4.4",
+  "version": "6.4.5",
   "description": "Utility to upload and publish packages to Datagrok",
   "homepage": "https://github.com/datagrok-ai/public/tree/master/tools#readme",
   "dependencies": {


### PR DESCRIPTION
## Problem

The **Packages** workflow's `Test Package` step (`grok test --record ...`) fails with exit 1 and **0 tests executed** — e.g. [EDA run #82910377591](https://github.com/datagrok-ai/public/actions/runs/27952363891/job/82910377591):

```
Puppeteer pass failed: spawnSync ffmpeg ENOENT
Passed tests:  0
Failed tests:  1
```

`--record` starts a Puppeteer `page.screencast()`, which spawns `ffmpeg`. On a runner without ffmpeg this throws `spawnSync ffmpeg ENOENT`; the exception bubbles out of `runTesting`, and the `catch` in `test.ts` marks the **entire** Puppeteer pass failed before any test runs.

(This surfaced only after the publish fix in #3864 let the job get past `Publish package to Datagrok`.)

## Fix

Recording is an optional diagnostic, not a test prerequisite. Wrap the `page.screencast()` start in `try/catch` at both call sites in `test-utils.ts` (main test pass + load-test pass): on failure, `color.warn(...)` and continue testing without a recording (`recorder` stays null; the existing `recorder?.stop()` is already null-safe).

Bumps `datagrok-tools` 6.4.4 → 6.4.5 (published by `tools.yml` on merge; CI installs `@latest`).

Note: if recordings are actually wanted in CI, ffmpeg still needs to be present on the runner (or bundle `ffmpeg-static`) — that's a separate, additive change. This PR only stops a missing ffmpeg from failing the whole suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)