### PR TITLE
Packages CI: install ffmpeg before Test Package (fix grok test --record ENOENT)

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -574,6 +574,17 @@ jobs:
           sudo chown root:root chrome_sandbox
           sudo chmod 4755 chrome_sandbox
           sudo cp -p chrome_sandbox /usr/local/sbin/chrome-devel-sandbox
+      - name: Install ffmpeg
+        # `grok test --record` records the run via Puppeteer page.screencast(),
+        # which spawns ffmpeg. The runner image doesn't ship it, so install it
+        # here — otherwise the whole Puppeteer pass fails with `spawnSync ffmpeg ENOENT`.
+        if: ${{ matrix.test == 'test' }}
+        run: |
+          if ! command -v ffmpeg >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq ffmpeg
+          fi
+          ffmpeg -version | head -n 1
       - name: Test Package
         if: ${{ matrix.test == 'test' }}
         continue-on-error: ${{ contains(matrix.package, 'Tests') || matrix.package == 'Chemspace' || matrix.package == 'DevTools' || matrix.package == 'ApiSamples' }}


### PR DESCRIPTION
## Problem

`Test Package` still fails after the `datagrok-tools` 6.4.5 graceful-degradation fix — e.g. [EDA run #27952363891 attempt 6](https://github.com/datagrok-ai/public/actions/runs/27952363891):

```
Puppeteer pass failed: spawnSync ffmpeg ENOENT
Passed tests:  0 / Failed tests:  1
```

`grok test --record` records via Puppeteer `page.screencast()`, which spawns **ffmpeg**. The `ubuntu-latest-m` runner has no ffmpeg, so the spawn `ENOENT`s and the whole Puppeteer pass aborts before any test runs.

The 6.4.5 fix (make recording non-fatal) doesn't help here because `npm run test` runs the package's **local** `node_modules/.bin/grok` pinned by `package-lock.json` — EDA's lock still pins `datagrok-tools@6.4.3`, so the old code runs. Updating every package's lock is slow; the runner-level fix is immediate and version-independent.

## Fix

Add an `Install ffmpeg` step before `Test Package` (gated on `matrix.test == 'test'`). This greens every package's test job at once and lets `--record` actually produce the recordings that the subsequent `Upload Artifact` step collects. Idempotent (`command -v ffmpeg` guard) for runners that already have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)