### PR TITLE
GROK-18671: PowerGrid: Resolve form-referenced columns by their backing grid column instead of by data-column name in FormCellRenderer.makeScene

### DIFF
--- a/packages/PowerGrid/CHANGELOG.md
+++ b/packages/PowerGrid/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Tags cell renderer: Fixed missing return in `getColor` that left first render of a new tag with an undefined color
 * Pie chart sparkline: Filter null columns in hit-test so hovering with stale/missing column names no longer throws
 * Forms cell renderer: Scoped per-cell scene via WeakMap keyed on grid (removes cross-grid contamination) and debounced tooltip shows (no more flicker)
+* GROK-18671: Forms cell renderer: Resolve referenced columns by their backing grid column so renaming a column via the grid header no longer breaks the form (red error cells); labels now follow the grid display name
 * Vlaaivis manager: Migrated drop handler to the new `doDrop(args)` signature in `ui.makeDroppable`
 
 ## 1.8.1 (2026-03-17)

--- a/packages/PowerGrid/src/forms/forms.ts
+++ b/packages/PowerGrid/src/forms/forms.ts
@@ -82,7 +82,18 @@ export class FormCellRenderer extends DG.GridCellRenderer {
     const df = gridCell.grid.dataFrame;
     const settings: FormSettings = getSettings(gridCell.gridColumn);
     const row = gridCell.cell.row.idx;
-    let cols = df.columns.byNames(settings.columnNames).filter((c) => c != null);
+    // Resolve each referenced data column to its grid column's display name: a grid-header
+    // rename sets GridColumn.customName without renaming the data column, so the data name is
+    // no longer a valid key for grid.cell() / GridColumnList.byName().
+    const gridColNameByData = new Map<string, string>();
+    const referenced = new Set(settings.columnNames);
+    for (let i = 0; i < gridCell.grid.columns.length && gridColNameByData.size < referenced.size; i++) {
+      const gc = gridCell.grid.columns.byIndex(i);
+      const dataName = gc?.column?.name;
+      if (dataName != null && referenced.has(dataName))
+        gridColNameByData.set(dataName, gc!.name);
+    }
+    let cols = df.columns.byNames(settings.columnNames).filter((c) => c != null && gridColNameByData.has(c.name));
     b ??= gridCell.bounds.inflate(-2, -2);
     const scene = new Scene(b);
 
@@ -95,7 +106,8 @@ export class FormCellRenderer extends DG.GridCellRenderer {
       const mode = settings.showColumnNames ?? 'Auto';
       const shouldShowMolLabels = mode === 'Always' || (mode === 'Auto' && molCols.length > 1);
       for (let i = 0; i < molCols.length; i++) {
-        const cell = gridCell.grid.cell(molCols[i].name, gridCell.gridRow);
+        const dispName = gridColNameByData.get(molCols[i].name)!;
+        const cell = gridCell.grid.cell(dispName, gridCell.gridRow);
         let r = molCols.length === 1 ? molBox :
           new DG.Rect(molBox.x, molBox.y + (i * molBox.height / molCols.length), molBox.width, molBox.height / molCols.length);
         if (shouldShowMolLabels && r.height > 30) {
@@ -103,12 +115,12 @@ export class FormCellRenderer extends DG.GridCellRenderer {
           const fontSize = Math.min(11, Math.floor(labelHeight * 0.9));
           const labelR = r.getTop(labelHeight);
           const font = `${fontSize}px Roboto, Roboto Local`;
-          scene.elements.push(new LabelElement(labelR, fontSize, molCols[i].name, {horzAlign: 'center', color: 'lightgrey', font: font}));
+          scene.elements.push(new LabelElement(labelR, fontSize, dispName, {horzAlign: 'center', color: 'lightgrey', font: font}));
           r = r.cutTop(labelHeight);
         }
         const molEl = new GridCellElement(r, cell);
         if (!shouldShowMolLabels)
-          molEl.style!.tooltip = `${molCols[i].name}: ${molEl.style!.tooltip}`;
+          molEl.style!.tooltip = `${dispName}: ${molEl.style!.tooltip}`;
         scene.elements.push(molEl);
       }
     }
@@ -150,14 +162,15 @@ export class FormCellRenderer extends DG.GridCellRenderer {
 
     for (let i = 0; i < cols.length; i++) {
       const col = cols[i];
-      const cell = gridCell.grid.cell(col.name, gridCell.gridRow);
+      const dispName = gridColNameByData.get(col.name)!;
+      const cell = gridCell.grid.cell(dispName, gridCell.gridRow);
       cell.style.backColor = gridCell.grid.props.backColor;
       cell.style.textColor = getRenderColor(settings, gridCell.grid.props.cellTextColor, {column: col, colIdx: i, rowIdx: row});
 
       if (b.height < cols.length * 20 * 0.4 && !isTwoColumn) {
         const r = b.getLeftPart(cols.length, i);
         const e = new GridCellElement(r, cell);
-        e.style!.tooltip = `${col.name}: ${e.style!.tooltip}`;
+        e.style!.tooltip = `${dispName}: ${e.style!.tooltip}`;
         scene.elements.push(e);
       } else {
         const layoutColIndex = Math.floor(i / rowsPerCol);
@@ -172,7 +185,7 @@ export class FormCellRenderer extends DG.GridCellRenderer {
         const isBoolTag = col.type === DG.TYPE.BOOL && boolMode === BoolColumnMode.Tags;
         if (showColumnNames && !isBoolTag) {
           const labelRect = new DG.Rect(intX, intY, columnNamesWidth, intH);
-          scene.elements.push(new LabelElement(labelRect, fontSize * 0.6, col.name,
+          scene.elements.push(new LabelElement(labelRect, fontSize * 0.6, dispName,
             {horzAlign: 'right', color: 'lightgrey', font: font}));
         }
 
@@ -185,7 +198,7 @@ export class FormCellRenderer extends DG.GridCellRenderer {
         const valueX = intX + columnNamesWidth + leftMargin;
         if (isBoolTag) {
           const tagRect = new DG.Rect(intX + 5, intY, effectiveWidth - 5, intH);
-          const tagText = `✓ ${col.name}`;
+          const tagText = `✓ ${dispName}`;
           scene.elements.push(new LabelElement(tagRect, fontSize * 0.6, tagText,
             {horzAlign: 'left', color: 'gray', font: font}));
         } else {
@@ -195,7 +208,7 @@ export class FormCellRenderer extends DG.GridCellRenderer {
             valueRect = new DG.Rect(valueX, intY - 5, showColumnNames ? 20 : effectiveWidth, intH);
           const valEl = new GridCellElement(valueRect, cell);
           if (!showColumnNames)
-            valEl.style!.tooltip = `${col.name}: ${valEl.style!.tooltip}`;
+            valEl.style!.tooltip = `${dispName}: ${valEl.style!.tooltip}`;
           scene.elements.push(valEl);
         }
       }


### PR DESCRIPTION
## GROK-18671: Forms cell renderer breaks when a referenced column is renamed via the grid header

**Bug.** Add a Designed-form (Smart Form) summary column referencing some columns (e.g. AGE/SEX/RACE), then rename one of those columns through the grid header. Every form cell turns into a red error X. PowerGrid's `FormCellRenderer.makeScene` (`public/packages/PowerGrid/src/forms/forms.ts`) resolves each referenced column's grid cell with `grid.cell(col.name, row)`, keyed on the *data* column name. A grid-header rename sets `GridColumn.customName` without renaming the underlying data column, so `GridColumnList.byName(dataName)` no longer matches; the resulting null `GridColumn` is dereferenced in `GridCell.gridCell` (d4 `grid_cell.dart:124`), throwing `NullError: method not found: 'column' on null`.

**Fix.** In `makeScene`, build a map from data-column name to the grid column's display name (scanning grid columns once, bounded to the referenced set), and resolve cells and field labels through that display name. This works for both rename paths and degrades gracefully: a referenced column with no grid column is now skipped instead of crashing. Field labels/tooltips also follow the grid display name, so the form reflects the rename.

The fix is scoped to the affected component rather than the core `GridColumn.name` setter: the data column is not renamed by a header rename, so there is nothing to sync, and making the setter emit `onColumnNameChanged` would misinform every other consumer of that event.

Crash site: `PowerGrid` / `src/forms/forms.ts` / `FormCellRenderer.makeScene`. Error pattern: `NullError: method not found: 'column' on null`.

**Tested.** `npm run build` exits 0 for PowerGrid (webpack compiled successfully). The renderer is canvas/grid-bound, so no unit test was added.

**Known limitation.** If a referenced column has no grid column at all (removed from the grid), that field is now omitted from the form rather than rendered — previously it crashed the whole form cell.