### PR TITLE
GROK-19013: Bio: Gate Bio/Peptide sequence viewers and tree viewers in the Add Viewer gallery by required column/tag, so they grey out on incompatible data

### DIFF
--- a/packages/PowerPack/CHANGELOG.md
+++ b/packages/PowerPack/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* GROK-19013: Viewers Gallery: Bio/Peptide sequence viewers (WebLogo, VdRegions, Peptides viewers) and tree viewers (Dendrogram, PhylocanvasGL) are now disabled for incompatible datasets in the Add Viewer dialog
 * Add New Column dialog: Fixed autocomplete popup closing when clicking its scrollbar
 * Add New Column dialog: Fixed TypeError when typing into the Name or Type input before CodeMirror finishes its async init
 

--- a/packages/PowerPack/src/viewers-gallery.ts
+++ b/packages/PowerPack/src/viewers-gallery.ts
@@ -82,6 +82,37 @@ const BIOCHEM_VIEWERS_TEST_DATA: {[key: string] : ViewersTestData} = {
     tooltip: 'Chem Similarity Search viewer needs at least 1 sequence column'},
   'Sequence Diversity Search': {checkFunc: (table) => table.columns.bySemType(DG.SEMTYPE.MACROMOLECULE) !== null,
     tooltip: 'Chem Diversity Search viewer needs at least 1 sequence column'},
+  'WebLogo': {checkFunc: (table) => table.columns.bySemType(DG.SEMTYPE.MACROMOLECULE) !== null,
+    tooltip: 'WebLogo viewer needs at least 1 macromolecule column'},
+  'VdRegions': {checkFunc: (table) => table.columns.bySemType(DG.SEMTYPE.MACROMOLECULE) !== null,
+    tooltip: 'VdRegions viewer needs at least 1 macromolecule column'},
+  'Sequence Variability Map': {checkFunc: (table) => table.columns.bySemType(DG.SEMTYPE.MACROMOLECULE) !== null &&
+    [...table.columns.numerical].length >= 1,
+    tooltip: 'Sequence Variability Map viewer needs a macromolecule and a numeric column'},
+  'Most Potent Residues': {checkFunc: (table) => table.columns.bySemType(DG.SEMTYPE.MACROMOLECULE) !== null &&
+    [...table.columns.numerical].length >= 1,
+    tooltip: 'Most Potent Residues viewer needs a macromolecule and a numeric column'},
+  'Sequence Mutation Cliffs': {checkFunc: (table) => table.columns.bySemType(DG.SEMTYPE.MACROMOLECULE) !== null &&
+    [...table.columns.numerical].length >= 1,
+    tooltip: 'Sequence Mutation Cliffs viewer needs a macromolecule and a numeric column'},
+  'Sequence Position Statistics': {checkFunc: (table) => table.columns.bySemType(DG.SEMTYPE.MACROMOLECULE) !== null &&
+    [...table.columns.numerical].length >= 1,
+    tooltip: 'Sequence Position Statistics viewer needs a macromolecule and a numeric column'},
+  'Logo Summary Table': {checkFunc: (table) => table.columns.bySemType(DG.SEMTYPE.MACROMOLECULE) !== null &&
+    [...table.columns.numerical].length >= 1 &&
+    ([...table.columns.numerical].length >= 2 || [...table.columns.categorical].length >= 2),
+    tooltip: 'Logo Summary Table viewer needs a macromolecule, a numeric, and a numeric or categorical column'},
+  'Active peptide selection': {checkFunc: (table) => table.columns.bySemType(DG.SEMTYPE.MACROMOLECULE) !== null &&
+    [...table.columns.numerical].length >= 1 &&
+    ([...table.columns.numerical].length >= 2 || [...table.columns.categorical].length >= 2),
+    tooltip: 'Active peptide selection viewer needs a macromolecule, a numeric, and a numeric or categorical column'},
+};
+
+const TREE_VIEWERS_TEST_DATA: {[key: string] : ViewersTestData} = {
+  'Dendrogram': {checkFunc: (table) => table.columns.bySemType(DG.SEMTYPE.NEWICK) !== null || table.getTag('.newick') != null,
+    tooltip: 'Dendrogram viewer needs a phylogenetic tree (a Newick column or tree tag)'},
+  'PhylocanvasGL': {checkFunc: (table) => table.columns.bySemType(DG.SEMTYPE.NEWICK) !== null || table.getTag('.newick') != null,
+    tooltip: 'PhylocanvasGL viewer needs a phylogenetic tree (a Newick column or tree tag)'},
 };
 
 const CURVES_VIEWERS_TEST_DATA: {[key: string] : ViewersTestData} = {
@@ -234,8 +265,10 @@ function getJsViewers(jsViewers: { [v: string]: { [k: string]: any } }, table: D
       }
       else
         isViewerEnabled = false;
-    } else if ((v.package.name === 'Chem' || v.package.name === 'Bio') && BIOCHEM_VIEWERS_TEST_DATA[v.friendlyName])
+    } else if ((v.package.name === 'Chem' || v.package.name === 'Bio' || v.package.name === 'Peptides') && BIOCHEM_VIEWERS_TEST_DATA[v.friendlyName])
       isViewerEnabled = BIOCHEM_VIEWERS_TEST_DATA[v.friendlyName].checkFunc(table);
+    else if ((v.package.name === 'Dendrogram' || v.package.name === 'PhyloTreeViewer') && TREE_VIEWERS_TEST_DATA[v.friendlyName])
+      isViewerEnabled = TREE_VIEWERS_TEST_DATA[v.friendlyName].checkFunc(table);
     else if (v.package.name === 'Curves' && CURVES_VIEWERS_TEST_DATA[v.friendlyName])
       isViewerEnabled = CURVES_VIEWERS_TEST_DATA[v.friendlyName].checkFunc(table);
     else {
@@ -248,7 +281,8 @@ function getJsViewers(jsViewers: { [v: string]: { [k: string]: any } }, table: D
         enabled: isViewerEnabled,
         tooltip: isViewerEnabled ? '' : CHARTS_VIEWERS_TEST_DATA[v.friendlyName] ?
           CHARTS_VIEWERS_TEST_DATA[v.friendlyName].tooltip : BIOCHEM_VIEWERS_TEST_DATA[v.friendlyName] ?
-          BIOCHEM_VIEWERS_TEST_DATA[v.friendlyName].tooltip : CURVES_VIEWERS_TEST_DATA[v.friendlyName] ?
+          BIOCHEM_VIEWERS_TEST_DATA[v.friendlyName].tooltip : TREE_VIEWERS_TEST_DATA[v.friendlyName] ?
+          TREE_VIEWERS_TEST_DATA[v.friendlyName].tooltip : CURVES_VIEWERS_TEST_DATA[v.friendlyName] ?
           CURVES_VIEWERS_TEST_DATA[v.friendlyName].tooltip : 'Viewer cannot be created from viewer gallery',
         icon: (v.options['icon'] != undefined) ? `${v.package.webRoot.endsWith('/') ?
           v.package.webRoot : v.package.webRoot + '/'}${v.options['icon']}` : 'svg-project',


### PR DESCRIPTION
## GROK-19013: Add Viewer dialog: Bio/Peptide and tree viewers can be added to incompatible datasets

In the **Add Viewer** gallery, Bio/Peptide sequence viewers (WebLogo, VdRegions, and the Peptides viewers) and the tree viewers (Dendrogram, PhylocanvasGL) rendered as fully enabled/clickable cards even on datasets they cannot visualize (e.g. `System:DemoFiles/demog.csv`, which has no Macromolecule or Newick column). They should be greyed-out/disabled, the same way the Chem/Sequence Similarity & Diversity viewers already are after GROK-19005.

### Cause
`getJsViewers()` in `PowerPack/src/viewers-gallery.ts` only runs a compatibility `checkFunc` for viewers whose `friendlyName` is a key in a hardcoded per-package map. Viewers not covered fall through to the `else` branch where `isViewerEnabled` stays `true`, so their cards never receive the `disabled` class. The crash-site package in triage was `Bio`, but the enablement decision is owned entirely by the PowerPack gallery — there is no viewer-registration-level hook the gallery consults (`DG.Viewer.canVisualize` covers only core viewers).

### Fix
Following the reviewer-accepted GROK-19005 pattern (commit `da8c4c3e48`):
- Added `WebLogo`, `VdRegions`, and the Peptides viewers to `BIOCHEM_VIEWERS_TEST_DATA` (require a `Macromolecule` column) and added `'Peptides'` to that branch's package filter.
- Added a `TREE_VIEWERS_TEST_DATA` map for `Dendrogram` and `PhylocanvasGL`, enabled only when the table has a `Newick` column or a `.newick` tree tag.
- Threaded the new map into the disabled-card tooltip chain.

No existing branch is modified, so Chem/Charts/Curves and `showInGallery` behavior is unchanged.

### Testing
- `npm run build` in `packages/PowerPack` exits 0 (webpack compiled successfully).
- Verified against the reproduction recipe: on `demog.csv` every added `checkFunc` returns false, so the affected viewers receive the `disabled` class.

### Notes / scope
- The genuine root cause and only viable fix site is `PowerPack/src/viewers-gallery.ts`; `triage.required_packages` did not list PowerPack (a default platform plugin), so a reviewer should confirm scope.

See JIRA ticket GROK-19013 for reproduction evidence and screenshots.