### PR TITLE
[ticket] GROK-19652: Chem: Set V2000 counts-line chiral flag in _convertMolNotation when the structure has defined absolute stereo

### DIFF
--- a/packages/Chem/CHANGELOG.md
+++ b/packages/Chem/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* GROK-19652: Chem: SMILES→Molfile V2000 now sets the chiral flag for defined absolute stereocenters, so opening the sketcher from a molecule preview no longer drops/racemizes stereochemistry
 * GROK-20239: Chem: OCL renderer: Structures do not appear in labels in some visualisations
 * Scaffold Tree: Colors/labels columns are now named `<molColumn> colors/labels (<id>)` using a persisted per-viewer id instead of the editable title, avoiding column-name collisions when viewers share a title
 

--- a/packages/Chem/src/tests/notation-converter-tests.ts
+++ b/packages/Chem/src/tests/notation-converter-tests.ts
@@ -63,6 +63,19 @@ category('converters', async () => {
   test('Molfile V2000 to V3000', async () => {
     _testConvert(DG.chem.Notation.MolBlock, DG.chem.Notation.V3KMolBlock);
   });
+  test('SMILES with absolute stereo to Molfile V2000 keeps chiral flag', async () => {
+    const chiralSmiles = 'CNC1=NC=NC2=C(NN=C12)C3=CN=C(N=C3)N4CC[C@H](C4)C(O)=O';
+    const molBlock = _convertMolNotation(chiralSmiles, DG.chem.Notation.Smiles,
+      DG.chem.Notation.MolBlock, PackageFunctions.getRdKitModule());
+    const countsLine = molBlock.replaceAll('\r', '').split('\n')[3];
+    expect(countsLine.substring(12, 15), '  1', `expected chiral flag 1 in counts line, got "${countsLine}"`);
+
+    const achiralSmiles = 'CN1C(=O)CN=C(C2CCCCC2)c2ccccc21';
+    const achiralMolBlock = _convertMolNotation(achiralSmiles, DG.chem.Notation.Smiles,
+      DG.chem.Notation.MolBlock, PackageFunctions.getRdKitModule());
+    const achiralCountsLine = achiralMolBlock.replaceAll('\r', '').split('\n')[3];
+    expect(achiralCountsLine.substring(12, 15), '  0', `expected chiral flag 0 for achiral, got "${achiralCountsLine}"`);
+  });
   test('Molfile V3000 to SMARTS', async () => {
     _testConvert(DG.chem.Notation.V3KMolBlock, DG.chem.Notation.Smarts);
   });

--- a/packages/Chem/src/utils/convert-notation-utils.ts
+++ b/packages/Chem/src/utils/convert-notation-utils.ts
@@ -36,6 +36,27 @@ Malformed
   0  0  0  0  0  0            999 V3000
 M  END`;
 
+/** True when the molecule has a defined absolute tetrahedral stereocenter (CIP R/S). */
+export function hasDefinedStereo(mol: RDMol): boolean {
+  try {
+    return /\([RrSs]\)/.test(mol.get_stereo_tags());
+  } catch (e) {
+    return false;
+  }
+}
+
+// Sets the V2000 counts-line chiral flag so absolute stereo is not loaded as racemate by OCL/Ketcher.
+export function setMolBlockChiralFlag(molBlock: string, chiral: boolean): string {
+  if (!chiral)
+    return molBlock;
+  const eol = molBlock.includes('\r\n') ? '\r\n' : '\n';
+  const lines = molBlock.split(/\r?\n/);
+  if (lines.length < 4 || !lines[3].includes('V2000'))
+    return molBlock;
+  lines[3] = lines[3].substring(0, 12) + '  1' + lines[3].substring(15);
+  return lines.join(eol);
+}
+
 /**
  * Convert between the following notations: SMILES, SMARTS, Molfile V2000 and Molfile V3000
  *
@@ -77,7 +98,7 @@ export function _convertMolNotation(
             mol.add_hs_in_place();
           } catch (e) {}
         }
-        result = mol.get_molblock();
+        result = setMolBlockChiralFlag(mol.get_molblock(), hasDefinedStereo(mol));
       }
       if (targetNotation === MolNotation.Smiles)
         result = mol.get_smiles();


### PR DESCRIPTION
## GROK-19652: Chem: stereochemistry changes when opening the sketcher from a molecule preview

RDKit's get_molblock() emits a V2000 chiral flag of 0 even for defined absolute stereocenters, so OCL/Ketcher load them as racemate and drop @/@@ on export. Fixed at the shared producer _convertMolNotation by setting the counts-line chiral flag to 1 for structures with a CIP R/S stereocenter. npm run build passes; added a regression test.