### PR TITLE
GROK-19794: Bio: Add MSA gap inputs directly to the dialog form instead of a separate ui.inputs() sub-form so they share the dialog's label alignment/width

### DIFF
--- a/packages/Bio/CHANGELOG.md
+++ b/packages/Bio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bio changelog
 
+## v.next
+
+* GROK-19794: MSA dialog: Fixed misaligned Alignment Parameters gap inputs (now share the dialog form's label alignment and width)
+
 ## 2.28.2 (2026-06-22)
 
 * Migrated to the standalone HELM Web Editor (`@datagrok-libraries/hwe`), replacing the legacy `helm-web-editor` / `js-draw-lite` dependencies; fixed HELM substructure filter editor sizing.

--- a/packages/Bio/src/utils/multiple-sequence-alignment-ui.ts
+++ b/packages/Bio/src/utils/multiple-sequence-alignment-ui.ts
@@ -83,19 +83,22 @@ export async function multipleSequenceAlignmentUI(
       kalignTerminalGap.setTooltip('Penalty for opening a gap at the beginning or end of the sequence');
       const kalignVersionDiv = ui.p(`Kalign version: ${kalignVersion}`, 'kalign-version');
 
-      const kalignParamsDiv = ui.inputs([kalignGapOpen, kalignGapExtend, kalignTerminalGap]);
-      kalignParamsDiv.hidden = true;
+      // Added to the dialog form directly (not a nested ui.inputs() form) to keep label alignment consistent.
+      const kalignGapInputs = [kalignGapOpen, kalignGapExtend, kalignTerminalGap];
+      let kalignParamsExpanded = false;
+      const updateKalignParamsVisibility = (): void => {
+        const show = state.mode === 'kalign' && kalignParamsExpanded;
+        for (const input of kalignGapInputs)
+          input.root.style.display = show ? '' : 'none';
+      };
       const kalignParamsButton = ui.button('Alignment parameters', () => {
-        kalignParamsDiv.hidden = !kalignParamsDiv.hidden;
-        [kalignGapOpen, kalignGapExtend, kalignTerminalGap].forEach((input) => {
-          input.root.style.removeProperty('max-width');
-          input.captionLabel.style.removeProperty('max-width');
-        });
+        kalignParamsExpanded = !kalignParamsExpanded;
+        updateKalignParamsVisibility();
       }, 'Adjust alignment parameters such as penalties for opening and extending gaps');
       kalignParamsButton.classList.add('msa-params-button');
       kalignParamsButton.prepend(ui.icons.settings(() => null, 'Settings'));
 
-      const kalignElements = [kalignParamsDiv, kalignParamsButton, kalignVersionDiv];
+      const kalignElements = [kalignParamsButton, kalignVersionDiv];
 
       // --- Engine UI (non-canonical sequences, dynamically discovered) ---
 
@@ -156,6 +159,7 @@ export async function multipleSequenceAlignmentUI(
           el.style.display = newMode === 'kalign' ? '' : 'none';
         for (const el of engineElements)
           el.style.display = newMode === 'engine' ? '' : 'none';
+        updateKalignParamsVisibility();
       }
 
       async function onColumnChanged(col: DG.Column<string>): Promise<void> {
@@ -309,7 +313,9 @@ export async function multipleSequenceAlignmentUI(
         .add(engineParamsButton)
         .add(engineParamsDiv)
         .add(includeHelmInput)
-        .add(kalignParamsDiv)
+        .add(kalignGapOpen)
+        .add(kalignGapExtend)
+        .add(kalignTerminalGap)
         .add(kalignParamsButton)
         .add(kalignVersionDiv)
         .add(onlySelectedInput)


### PR DESCRIPTION
## GROK-19794: MSA dialog — Alignment Parameters inputs misaligned

**Bug.** In the MSA dialog (Bio > Analyze > MSA), expanding **Alignment Parameters** showed the Gap open / Gap extend / Terminal gap inputs with left-aligned labels and full-width editors, while the standard Sequence / Clusters inputs kept right-aligned, narrow labels and ~148px editors — so the section read as misaligned.

**Root cause.** The gap inputs were wrapped in a *separate* `ui.inputs([...])` form (`kalignParamsDiv`). That nested `InputForm` auto-sizes independently and, being narrow, picks up the `ui-form-condensed` class, whose `.ui-form.ui-form-condensed > .ui-input-root > .ui-input-label { max-width:100%!important }` rule switches it to the tall layout. The standard inputs live in the dialog's main `.d4-dialog-contents.ui-form`, which is not condensed. (The pre-existing `removeProperty('max-width')` calls did not cause this — the condensed `!important` rule overrode the inline `max-width` regardless.)

**Fix.** Add the gap inputs directly to the dialog form (`dlg.add(kalignGapOpen)` etc.), exactly like Sequence/Clusters, instead of a nested sub-form. Visibility is now controlled per-input via `updateKalignParamsVisibility()`.

**Crash site.** `public/packages/Bio/src/utils/multiple-sequence-alignment-ui.ts`, `multipleSequenceAlignmentUI`.

**Testing.** `npm run build` in `packages/Bio` exits 0; mechanism confirmed against the live reproduced dialog's DOM. See JIRA for reproduction evidence.

Refs: GROK-19794.