### PR TITLE
[ticket] GROK-19904: PowerGrid: Resolve Color cell color from gridCell.value instead of the row-bound gridCell.cell.valueString

### DIFF
--- a/packages/PowerGrid/CHANGELOG.md
+++ b/packages/PowerGrid/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Pie chart sparkline: Filter null columns in hit-test so hovering with stale/missing column names no longer throws
 * Forms cell renderer: Scoped per-cell scene via WeakMap keyed on grid (removes cross-grid contamination) and debounced tooltip shows (no more flicker)
 * Vlaaivis manager: Migrated drop handler to the new `doDrop(args)` signature in `ui.makeDroppable`
+* GROK-19904: Color cell renderer: Resolve color from `gridCell.value` instead of the row-bound table cell, so viewer legends/labels render each category's own color
 
 ## 1.8.1 (2026-03-17)
 

--- a/packages/PowerGrid/src/cell-types/color-cell-renderer.ts
+++ b/packages/PowerGrid/src/cell-types/color-cell-renderer.ts
@@ -26,10 +26,7 @@ export class ColorCellRenderer extends DG.GridCellRenderer {
     x: number, y: number, w: number, h: number,
     gridCell: DG.GridCell, cellStyle: DG.GridCellStyle
   ) {
-    if (gridCell.cell.isNone())
-      return;
-
-    const color = gridCell.cell.valueString.trim();
+    const color = (gridCell.value ?? '').toString().trim();
     if (!color || !isValidColor(color))
       return;
 
@@ -43,9 +40,7 @@ export class ColorCellRenderer extends DG.GridCellRenderer {
   }
 
   onMouseMove(gridCell: DG.GridCell, e: MouseEvent): void {
-    if (gridCell.cell.isNone())
-      return;
-    const color = gridCell.cell.valueString.trim();
+    const color = (gridCell.value ?? '').toString().trim();
     if (color)
       ui.tooltip.show(color, e.x + 16, e.y + 16);
   }


### PR DESCRIPTION
## GROK-19904: PowerGrid — Color cell renderer shows wrong color in viewer legends/labels

**Bug.** When a column has the 'Color' cell renderer applied, the grid renders each row's color correctly, but inside viewer legend/label contexts (e.g. a Pie chart legend categorized on that column) every swatch renders the *first row's* color instead of each category's own color.

**Root cause.** `ColorCellRenderer.render` / `onMouseMove` in `public/packages/PowerGrid/src/cell-types/color-cell-renderer.ts` read the color from `gridCell.cell.valueString` — the *row-bound table cell*. In a legend/label context the GridCell isn't bound to a data row; the platform sets the per-category value on `gridCell.value` (via `onPrepareCell`). Reading `.cell.valueString` therefore falls back to row 0's value, producing a mono-color legend.

**Fix.** Resolve the color from `gridCell.value`, which the js-api documents as the authoritative grid-cell value reflecting `onPrepareCell` overrides (grid.ts:582-585). This value is correct in both the row-bound grid path and the row-unbound legend/label path, so it fixes the legend without regressing the grid. The redundant `isNone()` early-return (which consulted the misleading row-bound cell) was removed — it is subsumed by the existing empty/invalid-color guard.

**Tested.** `npm run build` in `public/packages/PowerGrid` exits 0. Reproduction evidence and screenshots are attached to the JIRA ticket GROK-19904.