### PR TITLE
CI: GCP Container Analysis (OpenVEX) scan of published package Docker images

### DIFF
--- a/.github/scripts/gcp-vuln-scan.sh
+++ b/.github/scripts/gcp-vuln-scan.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GCP Container Analysis scan of ONE image -> OpenVEX + CSV -> public S3.
+# Mirrors the Jenkins Vulnerability-Scan job (GROK-18695) for use in GitHub
+# Actions at package-publish time, so a package image's VEX is available the
+# moment it is published (the weekly Jenkins job then skips it via the S3 delta).
+#
+# Requires on PATH: gcloud, jq, aws, docker (all preinstalled on GH ubuntu runners).
+# Env: GOOGLE_APPLICATION_CREDENTIALS (SA key file), AWS_ACCESS_KEY_ID/SECRET (env).
+# Usage: gcp-vuln-scan.sh <image_ref> <repo> <tag>
+#   e.g. gcp-vuln-scan.sh datagrok/admetica:1.3.1 admetica 1.3.1
+
+IMAGE_REF="${1:?image_ref required}"
+REPO="${2:?repo required}"
+TAG="${3:?tag required}"
+
+AR_LOCATION="${AR_LOCATION:-us-east4}"
+GCP_PROJECT="${GCP_PROJECT:-axial-reference-466209-j9}"
+AR_REPO="${AR_REPO:-datagrok}"
+AR_HOST="${AR_LOCATION}-docker.pkg.dev"
+AR_PREFIX="${AR_HOST}/${GCP_PROJECT}/${AR_REPO}"
+DST_REF="${AR_PREFIX}/${REPO}:${TAG}"
+
+S3_BUCKET="${S3_BUCKET:-datagrok-data}"
+S3_PREFIX="${S3_PREFIX:-vex}"
+AWS_REGION="${AWS_REGION:-us-east-2}"
+PUBLIC_BASE="${PUBLIC_BASE:-https://data.datagrok.ai/${S3_PREFIX}}"
+RUN_TS="$(date -u +%FT%TZ)"
+
+SCAN_POLL_ATTEMPTS="${SCAN_POLL_ATTEMPTS:-60}"
+SCAN_POLL_INTERVAL="${SCAN_POLL_INTERVAL:-15}"
+SCAN_EMPTY_GRACE="${SCAN_EMPTY_GRACE:-4}"
+SCAN_DESCRIBE_TIMEOUT="${SCAN_DESCRIBE_TIMEOUT:-300}"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing $1"; exit 1; }; }
+need gcloud; need jq; need aws; need docker
+
+gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIALS}" >/dev/null
+gcloud config set project "$GCP_PROJECT" >/dev/null
+gcloud auth configure-docker "${AR_HOST}" --quiet >/dev/null 2>&1
+
+# Always remove the pushed copy from GAR (delete needs --delete-tags for a tagged
+# image), incl. when `timeout` sends SIGTERM.
+cleanup() {
+  local digest
+  digest="$(gcloud artifacts docker images describe "${DST_REF}" --format='get(image_summary.digest)' 2>/dev/null || true)"
+  if [[ -n "$digest" ]]; then
+    gcloud artifacts docker images delete "${AR_PREFIX}/${REPO}@${digest}" --delete-tags --quiet || true
+  else
+    gcloud artifacts docker images delete "${DST_REF}" --delete-tags --quiet || true
+  fi
+  docker rmi -f "${DST_REF}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+trap 'exit 143' INT TERM
+
+echo "→ Pushing ${IMAGE_REF} → ${DST_REF}"
+docker image inspect "${IMAGE_REF}" >/dev/null 2>&1 || docker pull "${IMAGE_REF}"
+docker tag "${IMAGE_REF}" "${DST_REF}"
+docker push "${DST_REF}"
+
+scan_json="$(mktemp)"
+empty_confirms=0
+ok=false
+for ((i = 1; i <= SCAN_POLL_ATTEMPTS; i++)); do
+  # `describe` takes the full ref (no --location flag) and its payload can be big.
+  if timeout "${SCAN_DESCRIBE_TIMEOUT}" gcloud artifacts docker images describe "${DST_REF}" \
+       --format=json --show-package-vulnerability > "${scan_json}.tmp" 2>/dev/null; then
+    if jq -e '.discovery_summary.discovery[0].discovery.analysisStatus != "FINISHED_SUCCESS"' \
+         "${scan_json}.tmp" >/dev/null 2>&1; then
+      echo "  ⏳ scan in progress ($i/${SCAN_POLL_ATTEMPTS})"; rm -f "${scan_json}.tmp"; sleep "$SCAN_POLL_INTERVAL"; continue
+    fi
+    vc="$(jq '[.package_vulnerability_summary.vulnerabilities // {} | to_entries[] | .value[]] | length' "${scan_json}.tmp" 2>/dev/null || echo 0)"
+    if [[ "$vc" -eq 0 && "$empty_confirms" -lt "$SCAN_EMPTY_GRACE" ]]; then
+      empty_confirms=$((empty_confirms + 1)); echo "  ⏳ finished, awaiting vulnerability data (grace ${empty_confirms}/${SCAN_EMPTY_GRACE})"
+      rm -f "${scan_json}.tmp"; sleep "$SCAN_POLL_INTERVAL"; continue
+    fi
+    mv "${scan_json}.tmp" "$scan_json"; ok=true; echo "  ✔ scan complete (${vc} vulnerability entries)"; break
+  fi
+  echo "  ⏳ waiting for report ($i/${SCAN_POLL_ATTEMPTS})"; sleep "$SCAN_POLL_INTERVAL"
+done
+$ok || { echo "✖ scan did not complete for ${DST_REF}; skipping"; exit 1; }
+
+digest="$(jq -r '.image_summary.digest // ""' "$scan_json")"
+vex="$(mktemp)"; csv="$(mktemp)"
+
+# OpenVEX 0.2.0 — one statement per distinct CVE.
+jq --arg id "${PUBLIC_BASE}/${REPO}/${TAG}.json" --arg ts "$RUN_TS" \
+   --arg product "pkg:oci/${REPO}@${digest}?tag=${TAG}" '
+  [ (.package_vulnerability_summary.vulnerabilities // {} | to_entries[] | .value[]) ]
+  | map({ cve: ((.noteName // "") | split("/") | last), fix: (.vulnerability.fixAvailable // false) })
+  | map(select(.cve | startswith("CVE") or startswith("GHSA") or startswith("PYSEC")))
+  | group_by(.cve)
+  | map({ vulnerability: { name: .[0].cve }, products: [ { "@id": $product } ], status: "affected" }
+        + ( if (map(.fix) | any) then
+              { action_statement: "A fix is available in a newer package version; upgrade the affected package." }
+            else {} end ))
+  | { "@context": "https://openvex.dev/ns/v0.2.0", "@id": $id, author: "Datagrok",
+      timestamp: $ts, version: 1, statements: . }' "$scan_json" > "$vex"
+
+# CSV — one row per affected package/CVE.
+{
+  echo 'repo,tag,package,cve,severity,cvss,installed_version,fixed_version,status'
+  jq -r --arg repo "$REPO" --arg tag "$TAG" '
+    (.package_vulnerability_summary.vulnerabilities // {} | to_entries[] | .value[])
+    | . as $o | ($o.vulnerability.packageIssue // [{}])[]
+    | [ $repo, $tag, (.affectedPackage // ""), (($o.noteName // "") | split("/") | last),
+        ($o.vulnerability.effectiveSeverity // $o.vulnerability.severity // ""),
+        (($o.vulnerability.cvssScore // "") | tostring),
+        (.affectedVersion.fullName // .affectedVersion.name // ""),
+        (.fixedVersion.fullName // .fixedVersion.name // ""), "affected" ] | @csv' "$scan_json"
+} > "$csv"
+
+put() { aws s3 cp "$1" "s3://${S3_BUCKET}/${S3_PREFIX}/$2" --acl public-read --content-type "$3" --region "$AWS_REGION" >/dev/null; }
+# At publish time this version IS the newest, so refresh latest too.
+put "$vex" "${REPO}/${TAG}.json"    application/json
+put "$csv" "${REPO}/${TAG}.csv"     text/csv
+put "$vex" "${REPO}/latest.json"    application/json
+put "$csv" "${REPO}/latest.csv"     text/csv
+echo "✔ Published ${PUBLIC_BASE}/${REPO}/${TAG}.json (+ latest, + .csv)"

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -708,6 +708,41 @@ jobs:
             docker push $image
           done
 
+      # Vulnerability scan of the published package image(s). Report-only (never
+      # blocks the publish); the authoritative OpenVEX is produced by the weekly
+      # Vulnerability-Scan Jenkins job. Uses Grype, consistent with
+      # security_scan_anchore.yaml. See core/docs/VULNERABILITY_MANAGEMENT.md.
+      - name: Scan published Docker image for vulnerabilities
+        if: steps.publish-docker.outcome == 'success'
+        id: scan-docker
+        continue-on-error: true
+        run: |
+          mkdir -p vuln-reports
+          for image in $(echo -e ${{ steps.build-docker.outputs.images }}); do
+            safe=$(echo "$image" | tr '/:' '__')
+            echo "::group::Grype scan $image"
+            docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+              anchore/grype:latest "docker:$image" -o json \
+              > "vuln-reports/${safe}.grype.json" || { echo "grype failed for $image"; continue; }
+            jq -r '["CVE","Severity","Package","Installed","FixedVersion"],
+              (.matches[]? | [.vulnerability.id, .vulnerability.severity, .artifact.name,
+                .artifact.version, (.vulnerability.fix.versions | join(" "))]) | @csv' \
+              "vuln-reports/${safe}.grype.json" > "vuln-reports/${safe}.report.csv" 2>/dev/null || true
+            crit=$(jq '[.matches[]?|select(.vulnerability.severity=="Critical")]|length' "vuln-reports/${safe}.grype.json" 2>/dev/null || echo '?')
+            high=$(jq '[.matches[]?|select(.vulnerability.severity=="High")]|length' "vuln-reports/${safe}.grype.json" 2>/dev/null || echo '?')
+            echo "${image}: Critical=${crit} High=${high}"
+            echo "::endgroup::"
+          done
+
+      - name: Upload vulnerability reports
+        if: steps.scan-docker.outcome == 'success' || steps.scan-docker.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.package }}-vuln-reports
+          path: vuln-reports/
+          retention-days: 14
+          if-no-files-found: warn
+
       - name: Commit package-lock.json
         id: git
         continue-on-error: true

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -708,40 +708,32 @@ jobs:
             docker push $image
           done
 
-      # Vulnerability scan of the published package image(s). Report-only (never
-      # blocks the publish); the authoritative OpenVEX is produced by the weekly
-      # Vulnerability-Scan Jenkins job. Uses Grype, consistent with
-      # security_scan_anchore.yaml. See core/docs/VULNERABILITY_MANAGEMENT.md.
+      # Vulnerability scan of the published package image(s) via GCP Container
+      # Analysis — the same scan as the weekly Vulnerability-Scan Jenkins job
+      # (GROK-18695): push to Artifact Registry, poll the scan, publish OpenVEX +
+      # CSV to the public datagrok-data S3 bucket, then delete the GAR copy.
+      # Report-only: continue-on-error never blocks the publish.
+      # See core/docs/VULNERABILITY_MANAGEMENT.md.
       - name: Scan published Docker image for vulnerabilities
         if: steps.publish-docker.outcome == 'success'
         id: scan-docker
         continue-on-error: true
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/gcp-vuln-sa.json
+          GCP_SA_KEY: ${{ secrets.GCP_VULN_SA_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.VULN_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.VULN_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-2
         run: |
-          mkdir -p vuln-reports
+          printf '%s' "$GCP_SA_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+          chmod +x ./.github/scripts/gcp-vuln-scan.sh
           for image in $(echo -e ${{ steps.build-docker.outputs.images }}); do
-            safe=$(echo "$image" | tr '/:' '__')
-            echo "::group::Grype scan $image"
-            docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-              anchore/grype:latest "docker:$image" -o json \
-              > "vuln-reports/${safe}.grype.json" || { echo "grype failed for $image"; continue; }
-            jq -r '["CVE","Severity","Package","Installed","FixedVersion"],
-              (.matches[]? | [.vulnerability.id, .vulnerability.severity, .artifact.name,
-                .artifact.version, (.vulnerability.fix.versions | join(" "))]) | @csv' \
-              "vuln-reports/${safe}.grype.json" > "vuln-reports/${safe}.report.csv" 2>/dev/null || true
-            crit=$(jq '[.matches[]?|select(.vulnerability.severity=="Critical")]|length' "vuln-reports/${safe}.grype.json" 2>/dev/null || echo '?')
-            high=$(jq '[.matches[]?|select(.vulnerability.severity=="High")]|length' "vuln-reports/${safe}.grype.json" 2>/dev/null || echo '?')
-            echo "${image}: Critical=${crit} High=${high}"
+            repo="${image#datagrok/}"; repo="${repo%%:*}"; tag="${image##*:}"
+            echo "::group::GCP vuln scan $image"
+            ./.github/scripts/gcp-vuln-scan.sh "$image" "$repo" "$tag" || echo "scan failed for $image"
             echo "::endgroup::"
           done
-
-      - name: Upload vulnerability reports
-        if: steps.scan-docker.outcome == 'success' || steps.scan-docker.outcome == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.package }}-vuln-reports
-          path: vuln-reports/
-          retention-days: 14
-          if-no-files-found: warn
+          rm -f "$GOOGLE_APPLICATION_CREDENTIALS"
 
       - name: Commit package-lock.json
         id: git


### PR DESCRIPTION
## What

Scans each **published** package Docker image with **GCP Container Analysis** — the same flow as the weekly `Vulnerability-Scan` Jenkins job (GROK-18695) — right after it's pushed to Docker Hub:

1. Push the image to GCP Artifact Registry (`us-east4-docker.pkg.dev/axial-reference-466209-j9/datagrok`).
2. Poll the vulnerability scan.
3. Publish **OpenVEX + CSV** to the public `datagrok-data` S3 bucket at `vex/<repo>/<version>.json` and `vex/<repo>/latest.json` (+ `.csv`) — same layout/links as the Jenkins job (`https://data.datagrok.ai/vex/<repo>/latest.json`).
4. Delete the GAR copy (`--delete-tags`).

Logic lives in the self-contained `/.github/scripts/gcp-vuln-scan.sh`. **Report-only** (`continue-on-error`) — never blocks the publish. Because the VEX lands at publish time, the weekly Jenkins job's S3 delta check then skips that version.

## Required repo secrets (added)

- `GCP_VULN_SA_KEY` — service-account key JSON for `ar-vuln-reporter` (Artifact Registry repoAdmin + Container Analysis viewer on `axial-reference-466209-j9`).
- `VULN_AWS_ACCESS_KEY_ID` / `VULN_AWS_SECRET_ACCESS_KEY` — IAM user `datagrok-vuln-scan` (s3:PutObject/PutObjectAcl on `datagrok-data/vex/*`).

Both are least-privilege. `gcloud`, `aws`, `jq`, `docker` are preinstalled on the GH ubuntu runner.

See `core/docs/VULNERABILITY_MANAGEMENT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)