### PR TITLE
GROK-18695: Connectors: bump vulnerable dependencies

### DIFF
--- a/connectors/grok_connect/pom.xml
+++ b/connectors/grok_connect/pom.xml
@@ -362,12 +362,12 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.124.Final</version>
+            <version>4.1.135.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>4.1.124.Final</version>
+            <version>4.1.135.Final</version>
         </dependency>
         <dependency>
             <groupId>com.sparkjava</groupId>
@@ -393,7 +393,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.15.3</version>
+            <version>2.18.8</version>
+        </dependency>
+        <dependency> <!-- remediating vulnerabilities in versions pulled by spark/snowflake/redshift/databricks drivers -->
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.18.8</version>
         </dependency>
         <dependency>
             <groupId>com.healthmarketscience.jackcess</groupId>
@@ -446,7 +451,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>12.8.1.jre8</version>
+            <version>12.8.2.jre8</version>
         </dependency>
 
         <dependency>
@@ -675,7 +680,7 @@
         <dependency> <!-- remediating vulnerability -->
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.124.Final</version>
+            <version>4.1.135.Final</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
@@ -690,7 +695,22 @@
         <dependency> <!-- remediating vulnerability -->
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>2.5.1</version>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency> <!-- remediating vulnerabilities in versions pulled by hadoop/hive -->
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.25.9</version>
+        </dependency>
+        <dependency> <!-- remediating vulnerabilities in versions pulled by hadoop/avro -->
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
+        </dependency>
+        <dependency> <!-- remediating vulnerability CVE in 3.5.1 -->
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.6.1</version>
         </dependency>
         <dependency> <!-- remediating vulnerability -->
             <groupId>com.nimbusds</groupId>
@@ -735,7 +755,7 @@
         <dependency> <!-- remediating vulnerability CVE-2024-36114 -->
             <groupId>io.airlift</groupId>
             <artifactId>aircompressor</artifactId>
-            <version>0.27</version>
+            <version>2.0.3</version>
         </dependency>
         <!--Hive1-->
         <dependency>
@@ -790,7 +810,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.29</version>
+            <version>3.28.0</version>
         </dependency>
         <dependency>
             <groupId>javassist</groupId>


### PR DESCRIPTION
Part of the CVE remediation sweep (GROK-18695). Bumps the vulnerable Java dependencies flagged by the GCP Container Analysis scan of datagrok/grok_connect:2.6.5 (81 HIGH findings, ~30 of them in the app jar's own dependency tree).

- netty-handler/netty-codec/netty-all 4.1.124.Final → 4.1.135.Final — clears ~20 HIGHs across the netty codec family (http, http2, smtp, redis, dns, haproxy, sctp)
- jackson-core 2.15.3 → 2.18.8 + new explicit jackson-databind 2.18.8 pin — overrides the vulnerable 2.13–2.16 copies pulled transitively by spark-core, snowflake, redshift and databricks drivers (~10 HIGHs)
- protobuf-java 3.25.9, commons-compress 1.28.0, plexus-utils 3.6.1 — transitive overrides (hadoop/hive/avro)
- json-smart 2.5.1 → 2.5.2, aircompressor 0.27 → 2.0.3 (Java 8 bytecode verified), mssql-jdbc 12.8.1 → 12.8.2.jre8, snowflake-jdbc 3.13.29 → 3.28.0

Not addressed (documented in the scan analysis): jetty 9.4 (no fix — arrives via sparkjava), amazon-neptune-jdbc-driver fat jar (35 HIGHs, upstream abandoned at 3.0.3), Athena/Impala vendor driver jars.

Validation: `mvn package` against datagrok/openjdk:8; DBTests package run on dev planned after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)