### PR TITLE
Proteomics: bump to 1.1.0 and add .npmignore for release

### DIFF
--- a/packages/Proteomics/.npmignore
+++ b/packages/Proteomics/.npmignore
@@ -1,0 +1,46 @@
+# Developer keys
+upload.keys.json
+
+# Dependency directories
+node_modules/
+
+# IDEs
+# VS Code (https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore)
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+.history/
+
+# Intellij IDEA/WebStorm (https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore)
+.idea/inspectionProfiles/
+.idea/**/compiler.xml
+.idea/**/encodings.xml
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+.idea/codeStyles/
+
+# vim
+[._]*.s[a-v][a-z]
+!*.svg
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+*.vim
+.netrwhist
+*~
+[._]*.un~
+
+test-report.html
+test-record.mp4
+test-report.csv
+test-console-output.log
+
+# GSD planning artifacts — not part of the published package
+.planning/

--- a/packages/Proteomics/package-lock.json
+++ b/packages/Proteomics/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datagrok/proteomics",
-  "version": "0.2.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datagrok/proteomics",
-      "version": "0.2.0",
+      "version": "1.1.0",
       "dependencies": {
         "@datagrok-libraries/bio": "^5.61.3",
         "@datagrok-libraries/math": "^1.2.6",

--- a/packages/Proteomics/package.json
+++ b/packages/Proteomics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@datagrok/proteomics",
   "friendlyName": "Proteomics",
-  "version": "0.2.0",
+  "version": "1.1.0",
   "author": {
     "name": "Ed Jaeger",
     "email": "ejaeger@datagrok.ai"


### PR DESCRIPTION
## Summary

Follow-up to #3890 (which landed the v0.2 analysis/viewer work). Reconciles the repo with what's now released on the **dev** stand.

- **Version 0.2.0 → 1.1.0** — supersedes the March **1.0.1** initial release on dev. Releasing `0.2.0` would have been a version regression (`0.2.0 < 1.0.1`), so `desiredVersion: latest` would have kept serving the old build and the Proteomics demos would not appear for other users.
- **Add `.npmignore`** — the standard grok package ignore file. `grok publish --release` requires it, and it excludes the `.planning/` GSD artifacts from the published package.

## Deployed state (dev)

Both packages are now released to **all** users on dev:
- Proteomics `1.1.0.X-4cfabad5` — v0.2 work + demo functions
- Tutorials `1.11.3.X-4cfabad5` — `DEMO_APP_HIERARCHY` includes the Proteomics category

Result: the **Differential Expression** and **Enrichment Analysis** demos now render under **Apps | Demo | Proteomics** for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)