### PR TITLE
GrokConnect: Athena: fix "No suitable driver found" for STS session credentials (2.7.0)

### DIFF
--- a/connectors/CHANGELOG.md
+++ b/connectors/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Grok Connect changelog
 
+# 2.7.0 (2026-07-07)
+
+* Athena: Fixed "No suitable driver found" when connecting with temporary/STS session credentials (register JDBC driver before the direct DriverManager path)
+
 # 2.6.5 (2026-06-22)
 
 * Set default locale to C.UTF-8 for container build

--- a/connectors/grok_connect.cmd
+++ b/connectors/grok_connect.cmd
@@ -28,7 +28,7 @@
 ::
 @echo off
 set GROK_CONNECT_DIR=grok_connect
-set GROK_CONNECT=grok_connect-2.6.5.jar
+set GROK_CONNECT=grok_connect-2.7.0.jar
 set TARGET_DIR=%GROK_CONNECT_DIR%\target
 
 if "%1" == "shell" (

--- a/connectors/grok_connect.sh
+++ b/connectors/grok_connect.sh
@@ -37,7 +37,7 @@ GROK_SRC="${GROK_SRC:=$current_dir/../../}"
 
 # Base project directory and executable
 GROK_CONNECT_DIR=grok_connect
-GROK_CONNECT=grok_connect-2.6.5.jar
+GROK_CONNECT=grok_connect-2.7.0.jar
 TARGET_DIR=${GROK_CONNECT_DIR}/target
 
 set -e

--- a/connectors/grok_connect/pom.xml
+++ b/connectors/grok_connect/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>grok_connect</artifactId>
-    <version>2.6.5</version>
+    <version>2.7.0</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>connectors</groupId>
         <artifactId>build</artifactId>
-        <version>2.6.5</version>
+        <version>2.7.0</version>
     </parent>
 
     <properties>

--- a/connectors/grok_connect/src/main/java/grok_connect/providers/AthenaDataProvider.java
+++ b/connectors/grok_connect/src/main/java/grok_connect/providers/AthenaDataProvider.java
@@ -131,9 +131,15 @@ public class AthenaDataProvider extends JdbcDataProvider {
 
     @Override
     public Connection getConnection(DataConnection conn) throws SQLException, GrokConnectException {
-        return GrokConnectUtil.isNotEmpty((String) conn.credentials.parameters.getOrDefault("expires", null)) ?
-                DriverManager.getConnection(getConnectionString(conn), getProperties(conn))
-                : ConnectionPool.getConnection(getConnectionString(conn), getProperties(conn), driverClassName);
+        if (GrokConnectUtil.isEmpty((String) conn.credentials.parameters.getOrDefault("expires", null)))
+            return ConnectionPool.getConnection(getConnectionString(conn), getProperties(conn), driverClassName);
+        try {
+            Class.forName(driverClassName);
+        }
+        catch (ClassNotFoundException e) {
+            throw new GrokConnectException("JDBC driver not found: " + driverClassName, e);
+        }
+        return DriverManager.getConnection(getConnectionString(conn), getProperties(conn));
     }
 
     @Override

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>connectors</groupId>
     <artifactId>build</artifactId>
-    <version>2.6.5</version>
+    <version>2.7.0</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/connectors/serialization/pom.xml
+++ b/connectors/serialization/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>connectors</groupId>
         <artifactId>build</artifactId>
-        <version>2.6.5</version>
+        <version>2.7.0</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
## Problem

`grok_connect` fails to open Athena connections that use temporary/STS session credentials:

```
"mrtx_dlh_benchling": failed to connect:
java.sql.SQLException: No suitable driver found for jdbc:awsathena://athena.us-east-1.amazonaws.com:443;
```

## Root cause

`AthenaDataProvider.getConnection()` has two paths:

- **No `expires`** → `ConnectionPool.getConnection(...)` — HikariCP calls `setDriverClassName(...)`, which loads & registers the Simba driver. Works.
- **Has `expires`** (temporary/STS session creds) → `DriverManager.getConnection(url, props)` **directly, without `Class.forName(driverClassName)`**.

The Simba Athena jar (`AthenaJDBC42-2.0.35.1000.jar`) is `system`-scoped and supplied on the runtime classpath, not shaded into the uber-jar. On the direct-`DriverManager` path nothing force-loads the driver, so DriverManager's SPI scan doesn't register it → `No suitable driver found`. **The driver version is fine** (the jar contains a valid `META-INF/services/java.sql.Driver` and `com.simba.athena.jdbc.Driver`); no version update is needed.

The connectors guidance already notes this: *"bypass ConnectionPool for short-lived per-user tokens (use DriverManager.getConnection() directly, requires `Class.forName(driverClassName)`)."* The analogous `HiveDataProvider` already does it correctly.

## Fix

Register the driver via `Class.forName(driverClassName)` before the direct `DriverManager.getConnection()` call, mirroring `HiveDataProvider`.

## Version

Minor bump `2.6.4` → `2.7.0` across all locations: parent `pom.xml`, `grok_connect/pom.xml` (artifact + parent ref), `serialization/pom.xml` (parent ref), `grok_connect.sh`, `grok_connect.cmd`, plus a `CHANGELOG.md` entry.

## Note

`NeptuneDataProvider` has the same latent pattern (direct `DriverManager.getConnection()` with no `Class.forName`); left untouched here — can be fixed if Neptune STS connections ever fail identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
