### PR TITLE
fix(tests): patch base-image CVEs in ApiTests/CVMTests/DBTests containers

### DIFF
--- a/packages/ApiTests/CHANGELOG.md
+++ b/packages/ApiTests/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.10.3 (WIP)
 
+* Security: rebuilt `apitests-docker-test1` on `python:3.12-alpine` (+ `apk upgrade`, refreshed pip/setuptools/wheel) to clear base-OS CVEs (expat/krb5/openssl/musl) and stale Python tooling.
+
 Add `Dapi: entities.save (polymorphic)` tests covering Project and DataConnection round-trip via `grok.dapi.entities.save`.
 
 Run the Node test runner (`package-test-node`) as ESM via tsx: dynamic `startDatagrok` import, ESM `loadTestFiles`, asset/dayjs shims in `node-test-loader/`, and a shared `test-package` `_package` holder so dapi tests no longer transitively load the browser suite. New `start-node`/`stress-node` scripts.

--- a/packages/ApiTests/dockerfiles/apitests-docker-test1/Dockerfile
+++ b/packages/ApiTests/dockerfiles/apitests-docker-test1/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.18 as pip_builder
+FROM python:3.12-alpine as pip_builder
 
 ARG VIRTUAL_ENV=/app/venv
 ENV PATH "${VIRTUAL_ENV}/bin:$PATH"
@@ -6,13 +6,19 @@ ENV PATH "${VIRTUAL_ENV}/bin:$PATH"
 COPY requirements.txt ${VIRTUAL_ENV}/requirements.txt
 
 RUN python -m venv ${VIRTUAL_ENV} && \
+    pip install --no-cache-dir --upgrade pip setuptools wheel && \
     pip install --timeout 3600 --no-cache-dir --requirement ${VIRTUAL_ENV}/requirements.txt && \
     rm -rf /tmp/*
 
 
-FROM python:3.8-alpine3.18
+FROM python:3.12-alpine
 
 WORKDIR /app
+
+# Patch base-image CVEs: apk upgrade (expat/krb5/openssl/musl/sqlite) and refresh
+# the interpreter's pip/setuptools/wheel (CVE-2022-40897/2024-6345/2025-47273 etc.).
+RUN apk upgrade --no-cache && \
+    pip install --no-cache-dir --upgrade pip setuptools wheel
 
 ARG HOME_DIR=/home/grok
 ARG VIRTUAL_ENV=/app/venv

--- a/packages/ApiTests/package.json
+++ b/packages/ApiTests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@datagrok/api-tests",
   "friendlyName": "API Tests",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "author": {
     "name": "Alexander Paramonov",
     "email": "aparamonov@datagrok.ai"

--- a/packages/CVMTests/CHANGELOG.md
+++ b/packages/CVMTests/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* Security: rebuilt `cvmtests-docker-test1` (`python:3.12-alpine`) and `cvmtests-docker-test2` (`python:3.11-alpine`) on current bases (+ `apk upgrade`, refreshed pip/setuptools/wheel) to clear base-OS CVEs (expat/krb5/openssl/musl) and stale Python tooling.
 * Added datagrok-celery-task integration tests via the python/ celery worker
 
 # 1.4.0 (28-07-2025)

--- a/packages/CVMTests/dockerfiles/cvmtests-docker-test1/Dockerfile
+++ b/packages/CVMTests/dockerfiles/cvmtests-docker-test1/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.18 as pip_builder
+FROM python:3.12-alpine as pip_builder
 
 ARG VIRTUAL_ENV=/app/venv
 ENV PATH "${VIRTUAL_ENV}/bin:$PATH"
@@ -6,13 +6,19 @@ ENV PATH "${VIRTUAL_ENV}/bin:$PATH"
 COPY requirements.txt ${VIRTUAL_ENV}/requirements.txt
 
 RUN python -m venv ${VIRTUAL_ENV} && \
+    pip install --no-cache-dir --upgrade pip setuptools wheel && \
     pip install --timeout 3600 --no-cache-dir --requirement ${VIRTUAL_ENV}/requirements.txt && \
     rm -rf /tmp/*
 
 
-FROM python:3.8-alpine3.18
+FROM python:3.12-alpine
 
 WORKDIR /app
+
+# Patch base-image CVEs: apk upgrade (expat/krb5/openssl/musl/sqlite) and refresh
+# the interpreter's pip/setuptools/wheel (CVE-2022-40897/2024-6345/2025-47273 etc.).
+RUN apk upgrade --no-cache && \
+    pip install --no-cache-dir --upgrade pip setuptools wheel
 
 ARG HOME_DIR=/home/grok
 ARG VIRTUAL_ENV=/app/venv

--- a/packages/CVMTests/dockerfiles/cvmtests-docker-test2/Dockerfile
+++ b/packages/CVMTests/dockerfiles/cvmtests-docker-test2/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.18 as pip_builder
+FROM python:3.11-alpine as pip_builder
 
 ARG VIRTUAL_ENV=/app/venv
 ENV PATH "${VIRTUAL_ENV}/bin:$PATH"
@@ -6,13 +6,20 @@ ENV PATH "${VIRTUAL_ENV}/bin:$PATH"
 COPY requirements.txt ${VIRTUAL_ENV}/requirements.txt
 
 RUN python -m venv ${VIRTUAL_ENV} && \
+    pip install --no-cache-dir --upgrade pip setuptools wheel && \
     pip install --timeout 3600 --no-cache-dir --requirement ${VIRTUAL_ENV}/requirements.txt && \
     rm -rf /tmp/*
 
 
-FROM python:3.8-alpine3.18
+FROM python:3.11-alpine
 
 WORKDIR /app
+
+# Patch base-image CVEs: apk upgrade (expat/krb5/openssl/musl/sqlite) and refresh
+# the interpreter's pip/setuptools/wheel (CVE-2022-40897/2024-6345/2025-47273 etc.).
+# Python 3.11 (not 3.12) keeps the older Quart/hypercorn async stack working.
+RUN apk upgrade --no-cache && \
+    pip install --no-cache-dir --upgrade pip setuptools wheel
 
 ARG HOME_DIR=/home/grok
 ARG VIRTUAL_ENV=/app/venv

--- a/packages/CVMTests/package.json
+++ b/packages/CVMTests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@datagrok/cvm-tests",
   "friendlyName": "CVM Tests",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Oleksandra Serhiienko",
     "email": "oserhiienko@datagrok.ai"

--- a/packages/DBTests/CHANGELOG.md
+++ b/packages/DBTests/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DB Tests changelog
 
+## v.next
+
+* Security: pinned the DB test image to `postgres:17-bookworm` and added `apt-get upgrade` to clear stale Debian base CVEs (gnutls28/perl/glibc).
+
 ## 1.3.0 (2025-07-28)
 
 * Datagrok api dependency >= 1.26.0

--- a/packages/DBTests/dockerfiles/Dockerfile
+++ b/packages/DBTests/dockerfiles/Dockerfile
@@ -1,4 +1,9 @@
-FROM postgres
+FROM postgres:17-bookworm
+
+# Patch base-image CVEs: the postgres base does not apt-upgrade its Debian
+# packages, so gnutls28 / perl / glibc etc. ship stale. Refresh them.
+RUN apt-get update && apt-get -y upgrade && rm -rf /var/lib/apt/lists/*
+
 ENV POSTGRES_PASSWORD datagrok
 ENV POSTGRES_USER datagrok
 ENV POSTGRES_DB world

--- a/packages/DBTests/package.json
+++ b/packages/DBTests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@datagrok/dbtests",
   "friendlyName": "DB Tests",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Automated tests for JDBC Providers",
   "author": {
     "name": "Pavlo Polovyi",


### PR DESCRIPTION
Patches base-image CVEs in the ApiTests / CVMTests / DBTests helper docker containers, which were built on EOL bases with stale OS + Python tooling.

## Changes
| Container | Before | After |
|---|---|---|
| `apitests-docker-test1` | `python:3.8-alpine3.18` | `python:3.12-alpine` |
| `cvmtests-docker-test1` | `python:3.8-alpine3.18` | `python:3.12-alpine` |
| `cvmtests-docker-test2` | `python:3.8-alpine3.18` | `python:3.11-alpine` (keeps Quart/hypercorn) |
| `dbtests` | `FROM postgres` (unpinned) | `postgres:17-bookworm` + `apt-get upgrade` |

All python images also `apk upgrade` and refresh pip/setuptools/wheel. Fixes the CRITs (expat/krb5/openssl on alpine; gnutls28/perl/glibc on debian) plus the setuptools/wheel HIGHs.

Version bumps so the rebuilt images publish to Docker Hub: **api-tests 1.10.3**, **cvm-tests 1.5.1**, **dbtests 1.4.1**.

Verified functionally by the CVMTests / ApiTests suites once published. Part of the GROK-18695 VEX remediation program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
