### PR TITLE
fix(connectors): patch vulnerable transitive deps in grok_connect (2.7.1)

### DIFF
--- a/connectors/CHANGELOG.md
+++ b/connectors/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Grok Connect changelog
 
+# 2.7.1
+
+* GROK-18695: Security — added a `<dependencyManagement>` block forcing patched, Java-8-compatible versions of vulnerable transitive dependencies: netty-bom 4.1.135.Final (transitive `netty-codec-http2`/`resolver-dns`/`redis`/…), jackson-bom 2.18.8, protobuf-java 3.25.5, commons-compress 1.26.2, commons-io 2.16.1, commons-beanutils 1.11.0, json-smart 2.5.1, plexus-utils 3.6.1, hadoop-yarn-server-common 3.3.2.
+
 # 2.7.0 (2026-07-07)
 
 * Athena: Fixed "No suitable driver found" when connecting with temporary/STS session credentials (register JDBC driver before the direct DriverManager path)

--- a/connectors/grok_connect/pom.xml
+++ b/connectors/grok_connect/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>grok_connect</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -23,6 +23,66 @@
         <mockito.version>4.11.0</mockito.version>
         <testcontainers.version>1.21.4</testcontainers.version>
     </properties>
+
+    <!-- Security overrides for vulnerable transitive dependencies (GROK-18695).
+         Force patched, still-Java-8-compatible versions of the CVE-flagged libs.
+         The jackson/netty BOMs manage the transitive artifacts (netty-codec-http2,
+         netty-resolver-dns, netty-codec-redis, jackson-annotations, ...) that the
+         direct jackson/netty deps below don't cover; the rest are pinned
+         individually. jena (needs Java 11) and jline (major bump) are left as-is. -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.18.8</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.135.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.25.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.26.2</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.16.1</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>1.11.0</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.5.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>3.6.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-server-common</artifactId>
+                <version>3.3.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>


### PR DESCRIPTION
Patches the **44 HIGH** CVEs in `datagrok/grok_connect` — nearly all transitive Java deps pulled by the JDBC drivers.

master already fixed the *direct* jackson (2.18.8) and netty (4.1.135) deps, but the transitive `netty-codec-http2` / `netty-resolver-dns` / `netty-codec-redis` / `jackson-annotations` / protobuf / commons / etc. were still old (and the published 2.7.0 image predates even the direct fixes). This adds a `<dependencyManagement>` block that forces patched, **Java-8-compatible** versions:

| Override | Version | Clears |
|---|---|---|
| `io.netty:netty-bom` | 4.1.135.Final | ~10 transitive netty HIGHs |
| `com.fasterxml.jackson:jackson-bom` | 2.18.8 | transitive jackson HIGHs |
| `protobuf-java` | 3.25.5 | 5 |
| `commons-compress` | 1.26.2 | 4 |
| `commons-io` / `commons-beanutils` / `json-smart` / `plexus-utils` / `hadoop-yarn-server-common` | 2.16.1 / 1.11.0 / 2.5.1 / 3.6.1 / 3.3.2 | 1 each |

Version bumped **2.7.0 → 2.7.1** so the CI republishes. Left as-is (can't fix cleanly on Java 8): `jena` (needs Java 11), `jline` (major bump), `ion-java` / `jetty-http` (no fix published). Part of GROK-18695.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
