### PR TITLE
fix(connectors): bump reactor version to 2.7.1 (publish grok_connect CVE fix)

### DIFF
--- a/connectors/grok_connect/pom.xml
+++ b/connectors/grok_connect/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>connectors</groupId>
         <artifactId>build</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.1</version>
     </parent>
 
     <properties>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>connectors</groupId>
     <artifactId>build</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/connectors/serialization/pom.xml
+++ b/connectors/serialization/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>connectors</groupId>
         <artifactId>build</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.1</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Follow-up to #3897. That PR fixed the transitive-dep CVEs and bumped the grok_connect *module* version, but the CI tags the image from the **reactor (root) pom version** — so it published `2.7.0-<commit>` instead of a clean `2.7.1`. This bumps the root `connectors/pom.xml` and the grok_connect/serialization parent refs to 2.7.1 so the fixed image publishes as **grok_connect:2.7.1** and the VEX index reflects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)