### PR TITLE
ci: build unpublished path deps (js-api) before package build

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -391,6 +391,28 @@ jobs:
       - if: ${{ matrix.unpublished_deps != '' }}
         run: grok link
         working-directory: packages/${{ matrix.package }}
+      - name: Build unpublished dependencies
+        # `grok link` above symlinks EVERY in-repo dependency to its local source, including
+        # the PUBLISHED @datagrok-libraries version deps. Those libraries ship no compiled
+        # .js/.d.ts, and js-api is not built either, so the package build fails: `datagrok-api/dg`
+        # resolves to the raw js-api/dg.ts and crashes tsc ("Debug Failure" on TS 5.9.x),
+        # library src/*.ts hit "Module parse failed", and a nested datagrok-api causes
+        # duplicate-type (TS2345) errors. Only the unpublished PATH deps (js-api) need to be
+        # local — restore the published (compiled) libraries, then build the path deps so their
+        # declarations exist before the package's webpack/ts-loader build.
+        if: ${{ matrix.unpublished_deps != '' }}
+        working-directory: packages/${{ matrix.package }}
+        run: |
+          rm -rf node_modules/@datagrok-libraries
+          npm install --no-audit --no-fund
+          for dep in ${{ matrix.unpublished_deps }}; do
+            dir="$(cd "${dep#*=}" 2>/dev/null && pwd)" || continue
+            [ -d "$dir" ] || continue
+            echo "::group::Build unpublished dependency $dir"
+            ( cd "$dir" && npm install --no-audit --no-fund && npx tsc ) \
+              || echo "::warning::Failed to build unpublished dependency $dir"
+            echo "::endgroup::"
+          done
       - name: webpack cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Problem

Every package that depends on the local **`../../js-api`** (ApiTests, Chem, Flow, Grokky, PowerPack, UsageAnalysis, Tutorials, KnimeLink) currently **fails its bleeding-edge Build/Test job** — the package doesn't even compile, so no tests run. Example: [ApiTests run 28946285320](https://github.com/datagrok-ai/public/actions/runs/28946285320).

The failure is a TypeScript compiler crash in the webpack build:

```
[webpack-cli] HookWebpackError: Debug Failure.
  at resolveExternalModule (typescript.js)
  at getTargetOfNamespaceImport ...
```

### Root cause

`grok link` (run for packages with unpublished path deps) symlinks **every** in-repo dependency to its **unbuilt local source** — including the *published* `@datagrok-libraries/*` version deps — and nothing builds them:

- **js-api** ships no compiled `.d.ts`, so `import * as DG from 'datagrok-api/dg'` resolves to the raw `js-api/dg.ts`. TS 5.9.x sets `resolvedUsingTsExtension` and then `Debug.checkDefined(tryExtractTSExtension('datagrok-api/dg'))` throws **"Debug Failure"** (the bare specifier has no `.ts` extension) → the build aborts.
- The grok-linked **libraries** ship no compiled `.js` (gitignored), so their `src/*.ts` hit **"Module parse failed"**, and a nested `datagrok-api` copy causes duplicate-type (**TS2345**) errors.

This has been broken on master for weeks (no green bleeding-edge build for any of these packages in the last 60 master runs).

## Fix

After `grok link`, restore the **published (compiled)** `@datagrok-libraries` and build only the **unpublished path deps** (js-api) with `npm install && tsc`, so `datagrok-api/dg` resolves to `dg.d.ts` before the package's webpack/ts-loader build. All eight affected packages declare `datagrok-api=../../js-api` as their **only** path dep, so they want bleeding-edge *js-api*, not bleeding-edge libraries.

## Validation

Reproduced the exact CI failure and the fix locally in a clean worktree of `master`, running the real CI sequence:

```
npm install → grok link → (this step) → npm run build -- --mode=production
```

- Without the step: `webpack ... HookWebpackError: Debug Failure` (matches CI).
- With the step: `webpack ... compiled` — clean build (exit 0), only bundle-size warnings.

## Notes

- Touches CI only (`.github/workflows/packages.yaml`); no package source changes.
- I could not run GitHub Actions myself — please sanity-check on a re-run of one affected package (e.g. ApiTests) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)