### PR TITLE
ci: reduce GitHub Actions usage (concurrency, timeouts, fewer billed larger-runner minutes)

### DIFF
--- a/.github/workflows/docusaurus.yaml
+++ b/.github/workflows/docusaurus.yaml
@@ -13,6 +13,9 @@ on:
           - 'no'
         default: 'no'
   push:
+    branches:
+      - master
+      - 'release/**'
     paths:
       - 'help/**/*.md'
       - 'help/**/*.mdx'
@@ -48,6 +51,10 @@ on:
       - 'python-api/**'
       - 'help/deploy/releases/plugins/**'
       - 'packages/*/CHANGELOG.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/') }}
 
 jobs:
   common-check:

--- a/.github/workflows/grok_connect.yaml
+++ b/.github/workflows/grok_connect.yaml
@@ -2,11 +2,18 @@ name: Grok Connect
 on:
   workflow_dispatch: { }
   push:
+    branches:
+      - master
+      - 'release/**'
     paths:
       - 'connectors/**'
   pull_request:
     paths:
       - 'connectors/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/') }}
 
 jobs:
   common-check:
@@ -18,7 +25,11 @@ jobs:
   build:
     name: Build maven
     needs: common-check
-    runs-on: ubuntu-latest-m
+    # Standard public runners are 4-core/16GB — enough for the maven build+tests, and
+    # free (larger runners are billed even on public repos). Revert to ubuntu-latest-m
+    # if the connector test suite starts OOMing.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 40
     if: needs.common-check.outputs.continue == 'true'
     permissions:
       checks: write

--- a/.github/workflows/js-api.yml
+++ b/.github/workflows/js-api.yml
@@ -3,11 +3,19 @@ on:
   workflow_dispatch: { }
 
   push:
+    branches:
+      - master
+      - 'release/**'
     paths:
       - 'js-api/**'
   pull_request:
     paths:
       - 'js-api/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/') }}
+
 jobs:
   common-check:
     name: Common checks

--- a/.github/workflows/libraries.yaml
+++ b/.github/workflows/libraries.yaml
@@ -7,11 +7,18 @@ on:
         required: true
         type: string
   push:
+    branches:
+      - master
+      - 'release/**'
     paths:
       - 'libraries/**'
   pull_request:
     paths:
       - 'libraries/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/') }}
 
 jobs:
   common-check:

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -2,8 +2,15 @@ name: Lint
 on:
   workflow_dispatch: { }
   push:
+    branches:
+      - master
+      - 'release/**'
   pull_request:
     types: [ opened, edited, synchronize, reopened ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/') }}
 
 jobs:
   common-check:

--- a/.github/workflows/misc.yaml
+++ b/.github/workflows/misc.yaml
@@ -7,11 +7,18 @@ on:
         required: true
         type: string
   push:
+    branches:
+      - master
+      - 'release/**'
     paths:
       - 'misc/**'
   pull_request:
     paths:
       - 'misc/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/') }}
 
 jobs:
   common-check:

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -7,11 +7,18 @@ on:
         required: true
         type: string
   push:
+    branches:
+      - master
+      - 'release/**'
     paths:
       - 'packages/**'
   pull_request:
     paths:
       - 'packages/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/') }}
 
 jobs:
   common-check:
@@ -117,11 +124,13 @@ jobs:
                 fi
               fi
               runner='ubuntu-22.04'
-              if [[ "${job_test_env}" == *"JKG"* ]] || \
+              # Only reserve the (billed) larger runner when tests actually run — a
+              # build-only chem/admetica-dependent package fits the free standard runner.
+              if [ -n "${job_test_env}" ] && { [[ "${job_test_env}" == *"JKG"* ]] || \
                  [[ "$(tr '[:upper:]' '[:lower:]' <<<${PACKAGE})" == "admetica" ]] || \
                  [[ "$(tr '[:upper:]' '[:lower:]' <<<${PACKAGE})" == "chem" ]] || \
                  [[ "$(tr '[:upper:]' '[:lower:]' <<<${grok_deps})" == *"chem"* ]] || \
-                 [[ "$(tr '[:upper:]' '[:lower:]' <<<${grok_deps})" == *"admetica"* ]]; then
+                 [[ "$(tr '[:upper:]' '[:lower:]' <<<${grok_deps})" == *"admetica"* ]]; }; then
                 runner='ubuntu-latest-m'
               fi
 
@@ -208,6 +217,7 @@ jobs:
       - common-check
     if: needs.matrix.outputs.publish == 'yes' && needs.common-check.outputs.continue == 'true'
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 75
     env:
       HOST: GitHubAction
     strategy:
@@ -628,7 +638,7 @@ jobs:
         with:
           name: ${{ matrix.package }}.test-results
           path: packages/${{ matrix.package }}/test-*
-          retention-days: 14
+          retention-days: 7
           if-no-files-found: warn
       - name: Create error notification
         if: failure() && (steps.test-package.outcome == 'failure' || steps.docker-wait.outcome == 'failure')
@@ -719,7 +729,7 @@ jobs:
         with:
           path: /tmp/${{ matrix.package }}.docker.tar
           name: ${{ matrix.package }}.docker.tar
-          retention-days: 14
+          retention-days: 3
           if-no-files-found: warn
 
       - name: Publish package Docker image

--- a/.github/workflows/slack_sender.yaml
+++ b/.github/workflows/slack_sender.yaml
@@ -2,8 +2,19 @@ name: Report job failure
 on:
   workflow_dispatch: { }
   workflow_run:
+    # Scoped to the CI/build workflows whose failures warrant a Slack ping, instead of
+    # '*' which fired once per completed run of EVERY workflow (mostly skipped no-ops).
     workflows:
-      - '*'
+      - Packages
+      - Libraries
+      - JS API
+      - Grok Connect
+      - Tools Package
+      - Docusaurus
+      - Python API
+      - misc
+      - Lint
+      - IaC
     types:
       - completed
 

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -2,11 +2,18 @@ name: Tools Package
 on:
   workflow_dispatch: { }
   push:
+    branches:
+      - master
+      - 'release/**'
     paths:
       - 'tools/**'
   pull_request:
     paths:
       - 'tools/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/') }}
 
 jobs:
   common-check:


### PR DESCRIPTION
## Why

`datagrok-ai/public` is a **public repo**, so standard `ubuntu-22.04` runners are **free** (I confirmed the billing API reports 0 billable ms; 0 self-hosted runners). The **only GitHub-billed compute** is hosted **larger runners** (`ubuntu-latest-m`, `group='default larger runners'`), used in just two places:

- **Packages** — chem-family Build/test jobs
- **Grok Connect** — `Build maven`

### The problem this fixes

A single PR branch (`claude/GROK-18695`) was pushed **7 times in ~12 min**. With **no concurrency cancellation**, all 7 ran; with **no job-level timeout**, ~20 chem jobs each hung for **240–255 min**. That one branch = **~37,000 larger-runner minutes (~$600) in one afternoon — 98% of all larger-runner minutes** I sampled. Steady-state baseline is only ~8k min/mo; the uncapped runaway events are the real cost.

Volume context (30d): Packages 677 runs, Lint 878 (runs on every push to every branch), Docusaurus 354, "Report job failure" 2292 (fires per-completion of every workflow).

## Changes

1. **Concurrency cancellation** on non-protected refs — `packages, libraries, js-api, tools, misc, grok_connect, linter, docusaurus`. Would have killed 6 of the 7 GROK-18695 runs.
2. **Job timeouts** — `packages` publish `timeout-minutes: 75`, `grok_connect` build `40`. Hard ceiling on runaway jobs.
3. **`push` only on `master` + `release/**`** (PRs still run) — ends the `push`+`pull_request` double-run and WIP-branch builds.
4. **Grok Connect `Build maven` → `ubuntu-22.04`** (free) instead of the billed larger runner (~24 min every push).
5. **Packages matrix**: build-only chem/admetica-dependent packages use the free standard runner; the larger runner is reserved for jobs that actually run tests.
6. **Artifact retention**: docker tarballs 14→3d, test-results 14→7d.
7. **`Report job failure`** scoped from `'*'` (fires per-completion of every workflow) to the CI workflows whose failures warrant a Slack ping.

## Validation

- All 9 files pass `yaml.safe_load`; the narrowed runner-selection bash was unit-tested (build-only → standard, test → large).
- ⚠️ **Two changes can't be exercised by this workflow-only PR** (they need a connector/chem change to run) — please watch the first real run after merge:
  - **#4** Grok Connect maven on a 4-core/16GB standard runner — revert `runs-on` to `ubuntu-latest-m` if the connector test suite OOMs (comment left in file).
  - **#5** build-only chem-dependent packages on the standard runner.

Standard-runner workflows are free, so this does **not** aim to reduce those — the savings are concentrated on larger-runner minutes and on preventing runaway events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
