### PR TITLE
ci: cap larger-runner steps with timeouts to bound hung jobs (GROK-18695 class)

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -317,6 +317,7 @@ jobs:
       - name: Run datagrok stand
         id: datagrok-image
         if: ${{ matrix.test == 'test' }}
+        timeout-minutes: 15
         run: |
           echo "Find grok dependencies packages"
           grok_deps="$(jq  -r '. | select( has("devDependencies") == true ).devDependencies | to_entries[] | .key | select(test("@datagrok/.*")?)' packages/${{ matrix.package }}/package.json)"
@@ -433,6 +434,7 @@ jobs:
       - name: Build package
         if: ${{ matrix.build == 'build' }}
         id: build
+        timeout-minutes: 25
         run: |
           if [[ $(jq -r '. | select( has("scripts") == true ).scripts | select( has("build") == true ).build' "package.json") == "webpack" ]]; then
             npm run build -- --mode=production
@@ -474,6 +476,7 @@ jobs:
           grok config add --default --alias ${{ steps.datagrok-image.outputs.alias }} --server '${{ steps.datagrok-image.outputs.apiUrl }}' --key "$key"
       - name: Install Grok Dependencies before package publish to Datagrok
         if: ${{ matrix.test == 'test' }}
+        timeout-minutes: 20
         run: |
           grok_deps="$(jq  -r '. | select( has("devDependencies") == true ).devDependencies | to_entries[] | .key | select(test("@datagrok/.*")?)' package.json)"
           if [ -n "$grok_deps" ]; then
@@ -501,6 +504,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
       - name: Publish package to Datagrok
         if: ${{ matrix.test == 'test' }}
+        timeout-minutes: 20
         run: |
           count=0
           retries=5


### PR DESCRIPTION
## Goal: prevent `claude/GROK-18695`-class runaway cost

That incident: a PR branch pushed **7× in ~12 min**, each run fanning out ~20 chem-family jobs on **billed `ubuntu-latest-m`** runners, each **hung ~255 min** → ~9,146 billed 4-core minutes (~$110) in a day.

### Defense in depth

| Layer | Where | Effect |
|---|---|---|
| Concurrency-cancel | **merged (#3909)** | 7 rapid PR pushes → 6 superseded runs cancelled (same `refs/pull/N/merge` group) |
| Job timeout 75m | **merged (#3909)** | hung job capped 255→75 min |
| **Per-step timeouts** | **this PR** | hung step dies in ≤25 min instead of burning the 75-min job budget |

This PR adds `timeout-minutes` to the four hang-prone steps of the Packages `publish` job (the only place that runs billed larger runners besides Grok Connect, which #3909 moved to a free runner):

- Run datagrok stand (docker compose up) — 15m
- Build package (webpack) — 25m
- Install Grok Dependencies before publish (grok publish retry loop) — 20m
- Publish package to Datagrok (grok publish retry loop) — 20m

Every step that can hang now has a timeout; the job still caps at 75m as a catch-all. Timeouts are generous vs. observed legit runs (job p90 ≈ 64 min), so no false kills.

**Net:** a repeat incident drops from ~$110 to a few $ — concurrency kills 6 of 7 runs, and the surviving run's hung jobs die in ≤25 min/step.

Validated with `yaml.safe_load`. No path filter matches this change, so only Lint runs on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
