### PR TITLE
Sci-comp: NCA Fixed λz best-fit window-selection

### DIFF
--- a/libraries/sci-comp/CHANGELOG.md
+++ b/libraries/sci-comp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # sci-comp changelog
 
+## 0.9.1 (2026-07-16)
+
+Non-Compartmental Analysis — λz best-fit window-selection fix (VAL-01-LZ-R019):
+
+* `lambdaZBestFit` now uses PKNCA / WinNonlin's best-fit rule: among windows whose
+  adjusted R² is within `adjRSquaredFactor` of the global-maximum adjusted R², keep the
+  one with the most points. The prior additive score (`adjRSquared + adjRSquaredFactor·n`)
+  over-selected long windows. **This changes computed λz / t½ / Vz / %AUCextrap on affected
+  profiles.** Verified against PKNCA 0.12.1 (rat-IV R019: n=8→n=4, λz 0.23494→0.24047); all
+  reference-suite fixtures unchanged. `factor=0` now breaks exact ties toward more points.
+
 ## 0.9.0 (2026-06-15)
 
 Non-Compartmental Analysis — sparse / destructive-sampling NCA (UC-04 / FR-301..306):

--- a/libraries/sci-comp/package-lock.json
+++ b/libraries/sci-comp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datagrok-libraries/sci-comp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datagrok-libraries/sci-comp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "jstat": "^1.9.6"

--- a/libraries/sci-comp/package.json
+++ b/libraries/sci-comp/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "license": "MIT",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "friendlyName": "Scientific Computing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libraries/sci-comp/src/nca/CLAUDE.md
+++ b/libraries/sci-comp/src/nca/CLAUDE.md
@@ -15,7 +15,7 @@ src/nca/
     auc.ts                          # AUC: 3 methods × {naive, Neumaier-compensated} = 6 + neumaierSum + aucExtrapolateToInfinity
     aumc.ts                         # AUMC first-moment: 3 methods × {naive, compensated} = 6 + two-term aumcExtrapolateToInfinity
     cmax.ts                         # findCmax — first-occurrence Cmax/Tmax
-    lambda-z.ts                     # lambdaZBestFit (auto subset, adj-R² + tie-break) + lambdaZManual; centered-sum OLS
+    lambda-z.ts                     # lambdaZBestFit (auto subset; PKNCA/WinNonlin flat-tolerance adj-R² tie-break — most points within adjRSquaredFactor of the global-max adj-R²) + lambdaZManual; centered-sum OLS
     c0.ts                           # estimateC0 + insertC0 — IV bolus back-extrapolation;
     derived.ts                      # halfLifeFromLambdaZ, clearance, volumeTerminal, pctExtrapolated, meanResidenceTime, volumeSteadyState, pctExtrapolatedAumc, tlag
     compute-nca.ts                  # computeNca orchestrator — full pipeline

--- a/libraries/sci-comp/src/nca/README.md
+++ b/libraries/sci-comp/src/nca/README.md
@@ -9,7 +9,7 @@ Operates on plain `Float64Array` / `Uint8Array` inputs.
 | **Routes**     | IV bolus (with `c0` back-extrapolation), IV infusion, extravascular (PO/SC/IM treated uniformly) |
 | **AUC methods** | linear, log-linear, linear-up/log-down — each as both naive Float64 and Neumaier-compensated summation |
 | **BLQ rules**  | `set-zero`, `set-half-lloq`, `exclude`, `missing` — per-phase configurable (`preFirstMeasurable`, `embedded`, `afterLast`, `consecutiveAfterLast`) |
-| **λz**         | auto best-fit (subset search by adjusted R² `adjRSquaredFactor` tie-breaking) + manual point selection |
+| **λz**         | auto best-fit (subset search; PKNCA/WinNonlin flat-tolerance tie-break — most points within `adjRSquaredFactor` of the global-max adjusted R²) + manual point selection |
 
 ## Quickstart
 

--- a/libraries/sci-comp/src/nca/core/__tests__/lambda-z.test.ts
+++ b/libraries/sci-comp/src/nca/core/__tests__/lambda-z.test.ts
@@ -137,6 +137,51 @@ describe('lambdaZBestFit', () => {
     expect(Math.abs(r.lambdaZ - k)).toBeLessThan(0.05);
   });
 
+  it('PKNCA flat-tolerance window selection: real rat-IV R019 profile → n=4 (VAL-01-LZ-R019)', () => {
+    // Regression for the additive-vs-flat adjRSquaredFactor bug. Ground truth from
+    // PKNCA 0.12.1 (auc.method="lin up/log down", min.hl.points=3, min.hl.r.squared=0.85,
+    // allow.tmax.in.half.life=FALSE, min.span.ratio=2) on rat dataset 03 subject R019:
+    //   lambda.z = 0.2404699, half.life = 2.88247, lambda.z.n.points = 4, window t=[6,24].
+    // Per-window adj-R² peaks at n=4 (0.998164); every longer window is > 1e-4 below it,
+    // so PKNCA's FLAT tolerance keeps n=4. The prior additive score `adjR²+1e-4·n` instead
+    // peaked at n=8 (adjR²=0.997855, score 0.998655 > n=4's 0.998564) → λz=0.23494, 2.3% off
+    // (exceeds NFR-05's 0.5%). This test fails on the additive rule, passes on the flat rule.
+    const time = Float64Array.of(0.0, 0.083, 0.25, 0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 12.0, 24.0);
+    const conc = Float64Array.of(5656.92, 4937.10, 5405.76, 4160.80, 3382.91, 2474.69,
+      1591.91, 1177.43, 646.56, 289.48, 14.85);
+    const blqMask = new Uint8Array(time.length);
+    const strategy: LambdaZStrategy = {
+      mode: 'auto-best-fit', minPoints: 3, minRSquared: 0.85, excludeCmax: true,
+      adjRSquaredFactor: 1e-4, // PKNCA default — where additive and flat diverge
+    };
+    // Cmax is the t=0 IV-bolus point (index 0); excludeCmax drops it.
+    const r = lambdaZBestFit(time, conc, blqMask, 0, strategy)!;
+    expect(r).not.toBeNull();
+    expect(Array.from(r.pointsUsed)).toEqual([7, 8, 9, 10]); // t = 6, 8, 12, 24
+    expect(r.tStart).toBe(6);
+    expect(r.tEnd).toBe(24);
+    expect(Math.abs(r.lambdaZ - 0.2404699) / 0.2404699).toBeLessThan(5e-4); // within PKNCA 0.5%
+    expect(Math.abs(Math.LN2 / r.lambdaZ - 2.88247)).toBeLessThan(0.01); // t½ within 0.01 h
+  });
+
+  it('factor=0 tie-break: on exact adjR² ties, the window with MORE points wins (PKNCA convention)', () => {
+    // A perfect exponential makes every candidate window fit with adjR² = 1 (an exact,
+    // bit-level tie). With adjRSquaredFactor unset (factor=0), the flat-tolerance rule
+    // keeps the MOST points among the tied windows — PKNCA's documented "ties → more
+    // points" direction (half.life.R: n.points == max(n.points[mask_best])). The prior
+    // additive score kept the FIRST/smallest window on exact ties; this locks the corrected
+    // direction so it can't silently regress.
+    const k = 0.25;
+    const {time, conc} = exponential(10, k, 1); // indices 0..9, clean decay from t=0
+    const blqMask = new Uint8Array(10);
+    // cmaxIdx=0, excludeCmax=true → eligible = indices 1..9 (9 points); every window adjR²=1.
+    const r = lambdaZBestFit(time, conc, blqMask, 0, DEFAULT_STRATEGY)!;
+    expect(r).not.toBeNull();
+    expect(r.pointsUsed.length).toBe(9); // most points wins the exact tie, not the shortest
+    expect(Array.from(r.pointsUsed)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(Math.abs(r.lambdaZ - k)).toBeLessThan(1e-10);
+  });
+
   it('reports tStart, tEnd, pointsUsed, intercept consistently', () => {
     const k = 0.2;
     const c0 = 50;

--- a/libraries/sci-comp/src/nca/core/lambda-z.ts
+++ b/libraries/sci-comp/src/nca/core/lambda-z.ts
@@ -3,11 +3,13 @@ import type {LambdaZResult, LambdaZStrategy} from './types';
 /**
  * Auto best-fit terminal slope (lambda_z).
  *
- * PKNCA-compatible algorithm: iterate over subsets of the last `k` eligible
- * post-Cmax points, fit a log-linear OLS regression on each subset, and
- * pick the candidate that maximises adjusted R². A point is **eligible**
- * when it is post-Cmax (or Cmax itself, if `excludeCmax` is `false`),
- * measurable (`blqMask[i] === 0`), positive, and finite.
+ * The WINDOW-SELECTION tie-break matches PKNCA / WinNonlin's documented best-fit rule:
+ * iterate over subsets of the last `k` eligible post-Cmax points, fit a log-linear OLS
+ * regression on each, and pick the subset with the MOST points whose adjusted R² is
+ * within `adjRSquaredFactor` of the maximum adjusted R² across candidates (see the loop
+ * below and {@link LambdaZStrategy.adjRSquaredFactor}). A point is **eligible** when it
+ * is post-Cmax (or Cmax itself, if `excludeCmax` is `false`), measurable
+ * (`blqMask[i] === 0`), positive, and finite.
  *
  * A subset is **valid** when:
  * - it has at least `options.minPoints` points;
@@ -15,6 +17,20 @@ import type {LambdaZResult, LambdaZStrategy} from './types';
  * - `adjRSquared >= options.minRSquared`.
  *
  * Returns the best valid candidate, or `null` if none qualifies.
+ *
+ * **Scope of the PKNCA claim (deliberate divergence, NOT full parity).** Only the
+ * tie-break above matches PKNCA. Two guards are sci-comp-specific and STRICTER than
+ * PKNCA, and — unlike PKNCA — they drop candidates BEFORE the maximum adjusted R² is
+ * computed (peer review R1, VAL-01-LZ-R019):
+ * - `minRSquared` has **no** PKNCA equivalent — `pk.calc.half.life` carries no adj-R²
+ *   floor parameter; it is an intentional sci-comp guardrail.
+ * - PKNCA computes its adj-R² maximum over the sign-**unfiltered** candidate set and
+ *   rejects `lambda.z <= 0` only at the final selection mask, so a spurious high-R²,
+ *   wrong-signed short window can raise PKNCA's ceiling enough that no window survives →
+ *   PKNCA declines to auto-select (NA / manual review). sci-comp drops such windows
+ *   before the max and so always auto-selects the best VALID window instead.
+ * These stricter guards are by design; aligning the max-over-unfiltered ordering (and a
+ * PKNCA-style degenerate-2-point-fit warning) is tracked as a follow-up, not fixed here.
  *
  * Reference: <https://billdenney.github.io/pknca/articles/Selection-of-Calculation-Intervals.html>
  *
@@ -40,20 +56,40 @@ export function lambdaZBestFit(
   if (eligible.length < options.minPoints) return null;
 
   const factor = options.adjRSquaredFactor ?? 0;
-  let best: LambdaZResult | null = null;
-  let bestScore = -Infinity;
+  // PKNCA / WinNonlin "best fit" window selection: fit every eligible terminal
+  // window, then pick the one with the MOST points whose adjusted R² is within
+  // `factor` of the MAXIMUM adjusted R² across all candidates. This is a FLAT
+  // tolerance measured off the single global maximum — NOT an additive per-point
+  // bonus.
+  //
+  // The previous implementation scored each window as `adjRSquared + factor·n`
+  // and took the max. That accumulates the bonus with window length, so a longer
+  // window only has to sit within `factor·Δn` of the best adj-R² to win — it
+  // diverges from PKNCA on any profile with a candidate between (max − factor)
+  // and (max − factor·Δn). Verified against PKNCA 0.12.1 on rat-IV R019
+  // (VAL-01-LZ-R019): adj-R² peaks at n=4 (0.998164); every longer window is
+  // >1e-4 below it, so PKNCA picks n=4 (λz=0.24047). The additive rule picked
+  // n=8 (adjR²=0.997855, score 0.998655 > n=4's 0.998564) → λz=0.23494, off 2.3%.
+  const candidates: {fit: LambdaZResult; n: number}[] = [];
+  let maxAdjRSquared = -Infinity;
   for (let k = options.minPoints; k <= eligible.length; k++) {
     const subset = eligible.slice(eligible.length - k);
     const fit = fitLogLinear(time, conc, subset);
     if (fit === null) continue;
     if (fit.lambdaZ <= 0) continue;
     if (fit.adjRSquared < options.minRSquared) continue;
-    // Score favours larger subsets when adj-R² values are close
-    // (PKNCA convention; factor = 1e-4 in their defaults).
-    const score = fit.adjRSquared + factor * subset.length;
-    if (score > bestScore) {
+    candidates.push({fit, n: k});
+    if (fit.adjRSquared > maxAdjRSquared) maxAdjRSquared = fit.adjRSquared;
+  }
+  // Among windows within `factor` of the global-max adj-R², keep the most points.
+  // `factor = 0` collapses to "pick the window with the maximum adj-R², ties →
+  // more points" — PKNCA's behaviour with tie-breaking disabled.
+  let best: LambdaZResult | null = null;
+  let bestN = -1;
+  for (const {fit, n} of candidates) {
+    if (fit.adjRSquared >= maxAdjRSquared - factor && n > bestN) {
       best = fit;
-      bestScore = score;
+      bestN = n;
     }
   }
   return best;

--- a/libraries/sci-comp/src/nca/core/types.ts
+++ b/libraries/sci-comp/src/nca/core/types.ts
@@ -121,11 +121,15 @@ export interface LambdaZStrategy {
   /** When true, the Cmax point is excluded from the lambda_z candidate window. */
   readonly excludeCmax: boolean;
   /**
-   * PKNCA-style tie-breaking factor for adj-R². When two candidate subsets
-   * have adj-R² within this distance, the one with more points wins.
-   * Implemented as an additive score `adjRSquared + adjRSquaredFactor * n`.
-   * PKNCA default is `1e-4`. Set to `0` to disable tie-breaking and use
-   * strict max adj-R² (then the smaller subset wins on ties).
+   * PKNCA-style tie-breaking factor for adj-R². The best-fit search picks the
+   * window with the MOST points whose adj-R² is within this FLAT distance of the
+   * maximum adj-R² across all candidate windows (the PKNCA / WinNonlin best-fit
+   * rule). PKNCA default is `1e-4`. Set to `0` to disable tie-breaking and use
+   * strict max adj-R² (ties → more points).
+   *
+   * NB: this is a flat tolerance off the single global maximum, NOT an additive
+   * `adjRSquared + factor·n` score — the additive form accumulates the bonus with
+   * window length and over-selects long windows (see VAL-01-LZ-R019 in lambda-z.ts).
    */
   readonly adjRSquaredFactor?: number;
   /** Indices of selected points (manual-points mode). */


### PR DESCRIPTION
Non-Compartmental Analysis - λz best-fit window-selection fix (VAL-01-LZ-R019):

* `lambdaZBestFit` now uses PKNCA / WinNonlin's best-fit rule: among windows whose
  adjusted R² is within `adjRSquaredFactor` of the global-maximum adjusted R², keep the
  one with the most points. The prior additive score (`adjRSquared + adjRSquaredFactor·n`)
  over-selected long windows. **This changes computed λz / t½ / Vz / %AUCextrap on affected
  profiles.** Verified against PKNCA 0.12.1 (rat-IV R019: n=8→n=4, λz 0.23494→0.24047); all
  reference-suite fixtures unchanged. `factor=0` now breaks exact ties toward more points.