### PR TITLE
UsageAnalysis release dashboard (env picker, muting, accurate counts) + JiraConnect /search/jql migration

### DIFF
--- a/packages/JiraConnect/CHANGELOG.md
+++ b/packages/JiraConnect/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Jira Connect changelog
 
+## 1.2.4 (2026-07-15)
+
+* Migrated issue search from the removed `/rest/api/3/search` endpoint (HTTP 410) to the enhanced, token-paginated `/rest/api/3/search/jql`; fixed a null-response crash ("Cannot read properties of null (reading 'errorMessages')")
+
 ## 1.2.3 (2025-08-28)
 
 Added ability to detect few tickets in one cell

--- a/packages/JiraConnect/package-lock.json
+++ b/packages/JiraConnect/package-lock.json
@@ -54,6 +54,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -655,7 +656,6 @@
       "integrity": "sha512-3ZG500+ZeLql8rE0hjfhkycJjDj0pI/btEh3L9IkWUYcOrgP0xCNRq3HbtbqOPbvDhFaAWD88pDFtlLv8ns8gA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
@@ -1140,6 +1140,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1176,6 +1177,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1592,7 +1594,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
@@ -1619,7 +1620,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -1631,7 +1631,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
@@ -1666,7 +1665,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -1779,6 +1777,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -1936,7 +1935,6 @@
       "integrity": "sha512-rlUzQ4WzIAWdIbY/viPShhZU2n21CxDUgazXVbw4Hu1MwaeUSEksSeM6DqPgpRjCLXRk702AVRxJxoOz0dw4OA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "mitt": "^3.0.1",
         "zod": "^3.24.1"
@@ -2438,7 +2436,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz",
       "integrity": "sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/datagrok-tools/node_modules/glob": {
       "version": "11.1.0",
@@ -3936,6 +3935,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4421,6 +4421,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -4547,7 +4548,6 @@
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -4619,7 +4619,6 @@
       "integrity": "sha512-yl25C59gb14sOdIiSnJ08XiPP+O2RjuyZmEG+RjYmCXO7au0jcLf7fRiyii96dXGUBW7Zwei/mVKfxMx/POeFw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.10.10",
         "chromium-bidi": "9.1.0",
@@ -5145,7 +5144,6 @@
       "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -5161,7 +5159,6 @@
       "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -5262,6 +5259,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5395,8 +5393,7 @@
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -5404,6 +5401,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5566,8 +5564,7 @@
       "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.6.tgz",
       "integrity": "sha512-mlGndEOA9yK9YAbvtxaPTqdi/kaCWYYfwrZvGzcmkr/3lWM+tQj53BxtpVd6qbC6+E5OnHXgCcAhre6AkXzxjA==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -5582,6 +5579,7 @@
       "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -5628,6 +5626,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -5709,6 +5708,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5959,7 +5959,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/JiraConnect/package.json
+++ b/packages/JiraConnect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@datagrok/jiraconnect",
   "friendlyName": "Jira Connect",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Pakcages for Jira integration into Datagrok",
   "author": {
     "name": "Dmytro Kovalyov",

--- a/packages/JiraConnect/src/api/data.ts
+++ b/packages/JiraConnect/src/api/data.ts
@@ -37,40 +37,45 @@ export async function loadIssuesBulk(host: string, creds: AuthCreds, issueIdsOrK
     return await invokeApiFetch(url, requestOptions);
 }
 
-export async function loadIssues(host: string, creds: AuthCreds, index: number = 0, count: number = 50, filterObject?: object, keys?: string[]): Promise<JiraIssuesList> {
-    let url = `https://${host}/rest/api/3/search?startAt=${index}&maxResults=${count}`;
-    
-    if (filterObject || keys) {
-        let trimmedKeys = keys?.map(key => key.trim());
-        let keysParams = trimmedKeys?.join('+OR+key+=+')?.trim();
-        let keysJQL = `key+=+${keysParams}`;
-        
-        let filterData = [];
-        for (let filterKey of Object.keys(filterObject ?? {})) {
-            filterData.push(`${filterKey}+=+${(filterObject as Record<string, any>)[filterKey]}`);
-        }
-        let resultJQL = [];
-        if (filterObject)
-            resultJQL.push(filterData.join('+AND+'));
-        if (keysParams)
-            resultJQL.push(keysJQL);
-
-        url = `${url}&jql=${resultJQL.join('+and+')}`;
+function buildJql(filterObject?: object, keys?: string[]): string {
+    const parts: string[] = [];
+    if (filterObject) {
+        const f = Object.keys(filterObject)
+            .map((k) => `${k} = ${(filterObject as Record<string, any>)[k]}`).join(' AND ');
+        if (f)
+            parts.push(f);
     }
-    let requestOptions = buildRequestOptions(url, creds);
-    let issues: JiraIssuesList | ErrorMessageResponse = await invokeApiFetch(url, requestOptions);
-
-    if ((issues as ErrorMessageResponse).errorMessages) {
-        issues = { maxResults: count, startAt: index, issues: [], total: 0 }
-        for (let issue of keys ?? []) {
-            let issueData = await loadIssueData(host, creds, issue)
-            if (issueData && (issueData as JiraIssue).key) {
-                issues.issues.push(issueData as JiraIssue);
-                issues.total = issues.total + 1;
-            }
-        }
+    if (keys && keys.length) {
+        const k = keys.map((x) => x.trim()).filter((x) => x).join(', ');
+        if (k)
+            parts.push(`key in (${k})`);
     }
-    return issues as JiraIssuesList;
+    return parts.join(' AND ');
+}
+
+// Uses the enhanced JQL search (/rest/api/3/search/jql). The legacy /rest/api/3/search was removed by
+// Atlassian (returns HTTP 410). Token-paginated: fetches all pages and returns them as a JiraIssuesList.
+export async function loadIssues(host: string, creds: AuthCreds, filterObject?: object, keys?: string[],
+    count: number = 100, fields?: string[]): Promise<JiraIssuesList> {
+    const jql = buildJql(filterObject, keys);
+    const fieldsParam = fields && fields.length ? fields.join(',') : '*navigable';
+    const issues: JiraIssue[] = [];
+    let token: string | undefined = undefined;
+    let guard = 0;
+    do {
+        let url = `https://${host}/rest/api/3/search/jql?maxResults=${count}&fields=${encodeURIComponent(fieldsParam)}`;
+        if (jql)
+            url += `&jql=${encodeURIComponent(jql)}`;
+        if (token)
+            url += `&nextPageToken=${encodeURIComponent(token)}`;
+        const resp = await invokeApiFetch(url, buildRequestOptions(url, creds));
+        if (!resp || (resp as ErrorMessageResponse).errorMessages)
+            break;
+        if (Array.isArray(resp.issues))
+            issues.push(...resp.issues);
+        token = resp.isLast ? undefined : resp.nextPageToken;
+    } while (token && ++guard < 100);
+    return {maxResults: count, startAt: 0, total: issues.length, issues};
 }
 
 export async function loadIssueData(host: string, creds: AuthCreds, issueName: string): Promise<JiraIssue | null | ErrorMessageResponse> {

--- a/packages/JiraConnect/src/jira-grid-cell-handler.ts
+++ b/packages/JiraConnect/src/jira-grid-cell-handler.ts
@@ -214,7 +214,7 @@ class JiraTicketGridCellRenderer extends BatchCellRenderer<JiraIssue> {
             const keysToLoad = keys.slice(index, index + chunkSize);
             try {
                 const loadedIssues = await loadIssues(jiraCreds.host, new AuthCreds(jiraCreds.userName, jiraCreds.authKey),
-                    0, chunkSize, undefined, keysToLoad);
+                    undefined, keysToLoad);
                 for (let issue of loadedIssues?.issues ?? []) {
                     result.set(issue.key, issue);
                 }

--- a/packages/JiraConnect/src/package-api.ts
+++ b/packages/JiraConnect/src/package-api.ts
@@ -28,6 +28,9 @@ export namespace funcs {
     return await grok.functions.call('JiraConnect:IssueData', { issueKey });
   }
 
+  /**
+  Fetches a field value from Jira for each ticket key in a column
+  */
   export async function getJiraField(ticketColumn: DG.Column , field: string ): Promise<DG.Column> {
     return await grok.functions.call('JiraConnect:GetJiraField', { ticketColumn, field });
   }

--- a/packages/JiraConnect/src/package.g.ts
+++ b/packages/JiraConnect/src/package.g.ts
@@ -28,8 +28,10 @@ export async function issueData(issueKey: string) : Promise<any> {
   return await PackageFunctions.issueData(issueKey);
 }
 
-//input: column<string> ticketColumn 
-//input: string field 
+//name: Get Jira Field
+//description: Fetches a field value from Jira for each ticket key in a column
+//input: column<string> ticketColumn { description: Column of Jira ticket keys (e.g. PROJ-123) }
+//input: string field { description: Field path to extract, colon-separated for nested fields (e.g. status:name) }
 //output: column result
 //meta.vectorFunc: true
 export async function getJiraField(ticketColumn: DG.Column, field: string) : Promise<any> {

--- a/packages/JiraConnect/src/package.ts
+++ b/packages/JiraConnect/src/package.ts
@@ -97,7 +97,7 @@ export class PackageFunctions {
       const keysToLoad = ticketKeys.slice(index, index + chunkSize);
       try {
         const loadedIssues = await loadIssues(jiraCreds.host, new AuthCreds(jiraCreds.userName, jiraCreds.authKey),
-          0, chunkSize, undefined, keysToLoad);
+          undefined, keysToLoad);
 
         upperFor:
         for (let i = 0; i < (loadedIssues?.issues.length ?? 0); i++) {
@@ -137,23 +137,8 @@ export class PackageFunctions {
     const jiraCreds = await getJiraCreds();
     if (!jiraCreds)
       return [];
-    let result: JiraIssue[] = [];
-    let total = -1;
-    const chunkSize = 100;
-    let startAt = 0;
-    while (true) {
-      const loadedIssues = await loadIssues(jiraCreds.host, new AuthCreds(jiraCreds.userName, jiraCreds.authKey),
-        startAt, chunkSize, filter, undefined);
-      if (loadedIssues != null) {
-        total = loadedIssues.total;
-        result = [...result, ...loadedIssues.issues]
-      }
-
-      if (total <= startAt)
-        break;
-      startAt += chunkSize;
-    }
-    return result;
+    const loaded = await loadIssues(jiraCreds.host, new AuthCreds(jiraCreds.userName, jiraCreds.authKey), filter, undefined);
+    return loaded.issues;
   }
 
   @grok.decorators.func({outputs: [{name: 'result', type: 'object'}]})

--- a/packages/UsageAnalysis/CHANGELOG.md
+++ b/packages/UsageAnalysis/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Release: Added a global Environment (instance) picker to the dashboard ribbon that persists across all tabs and filters Overview and Tests to builds run on the selected instance (replaces the per-tab Tests instance input)
 * Release: Tests tab — per-row mute icon (🔔/🔕) mutes a test for the current release version; version-bound mutes are stored in a dedicated ReleaseMutes sticky-meta schema and drop the test out of the failing/unstable/needs-attention counts for that version
 * Release: Tickets tab — the tickets grid now fills the page
+* Release: Tests tab — when a test didn't run in the latest build, its last known result is carried forward (shown dimmed) and used for the failing/pass-rate counts
 * Release: Added a global Refresh button to the dashboard ribbon that reloads every tab
 * Release: ReleaseTests now counts the latest CI/CD run per test (like TestsDashboard) instead of every test_run — retried-then-passed tests no longer count as failing and non-CI runs are excluded, so the failing counts stop being inflated by reruns
 * Release: Tests tab — the detail grid now fills the page; per-build status cells show `+` (passed) / `−` (failed) / `·` (skipped)

--- a/packages/UsageAnalysis/CHANGELOG.md
+++ b/packages/UsageAnalysis/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## v.next
 
+* Release: Added a global Environment (instance) picker to the dashboard ribbon that persists across all tabs and filters Overview and Tests to builds run on the selected instance (replaces the per-tab Tests instance input)
+* Release: Tests tab — per-row mute icon (🔔/🔕) mutes a test for the current release version; version-bound mutes are stored in a dedicated ReleaseMutes sticky-meta schema and drop the test out of the failing/unstable/needs-attention counts for that version
+* Release: Tickets tab — the tickets grid now fills the page
+* Release: Added a global Refresh button to the dashboard ribbon that reloads every tab
+* Release: ReleaseTests now counts the latest CI/CD run per test (like TestsDashboard) instead of every test_run — retried-then-passed tests no longer count as failing and non-CI runs are excluded, so the failing counts stop being inflated by reruns
+* Release: Tests tab — the detail grid now fills the page; per-build status cells show `+` (passed) / `−` (failed) / `·` (skipped)
+* Release: Stress tab — replaced the last-build scatter plot with a box plot of duration by thread count (zero-padded `threads_string` category for numeric ordering, logarithmic ms axis); fixed charts being clipped by the fixed-height panel host
+
+## 2.5.4 (2026-07-15)
+
+* Release: Beautified the Tests grid — per-test passing history across the last 5 builds (color-coded status cells + a passing sparkline) and a duration sparkline, sorted to surface failing/flaky/slower tests first (mirrors the Overview alerts)
+* Release: Fixed the success rate rounding up to 100% while tests were failing (now floored); the Tests card sub shows "N passed, M failing"
+
+## 2.5.3 (2026-07-15)
+
+* Release: Overview alerts pane fills the view and groups a second level by package (category → package → test); the success rate excludes skipped and did-not-run tests (passed / passed+failed, floored)
+
+## 2.5.2 (2026-07-15)
+
+* Release: Added a dev-only `/release` release-readiness dashboard (Overview + Tests + Manual + Stress + Vulnerabilities + Tickets) — reuses the Stress/Vulnerabilities tabs, adds a per-package Tests tab (unit/integration/package tests, success & duration sparklines, sticky-meta muting, raw+Jenkins drilldown), a Manual (Test Track batches) tab, and a Jira fixVersion Tickets tab, with an Overview of traffic-light status cards and computed alerts. Vulnerabilities show bleeding-edge core scans (release-channel core excluded)
+* Release: Overview alerts are a navigable tree (categories → individual tests, click to open the tab); the vulnerabilities alert compares bleeding-edge vs the previously released image (new critical/high only); the test speed-regression check uses only passed runs; every grid has a '+' to open it as a table in the workspace; the Vulnerabilities grid is sorted by category
+* Release: Fixed a "Wrong range" grid error on the Tests tab by deferring sparkline columns until the grid is laid out
 * Vulnerabilities: Added a tab showing the published VEX scan results (data.datagrok.ai/vex) — per-image severity summary with drill-down to the per-CVE report
 * Stress: Added a tab with per-build stress metrics (median duration by build split by threads, full metrics grid) and a last-build scatter plot (threads vs duration, colored by pass/fail)
 * Metrics: Fixed app registration url ('/' → '/metrics') that shadowed all Usage Analysis deep links — any /apps/usage/<tab> URL used to land on Metrics

--- a/packages/UsageAnalysis/CLAUDE.md
+++ b/packages/UsageAnalysis/CLAUDE.md
@@ -9,3 +9,5 @@ events, sessions, errors, and operational health.
   [src/tabs/TABS.md](src/tabs/TABS.md)
 - Metrics tab (operational-health dashboard; storage snapshot job and disk stats):
   [src/tabs/METRICS.md](src/tabs/METRICS.md)
+- Release-readiness dashboard (dev-only `/release` app; Tests/Stress/Vulnerabilities/Tickets + overview):
+  [src/release/RELEASE.md](src/release/RELEASE.md)

--- a/packages/UsageAnalysis/css/usage_analysis.css
+++ b/packages/UsageAnalysis/css/usage_analysis.css
@@ -291,6 +291,32 @@ button.ui-btn.ui-btn-raised.ua-metrics-btn-secondary {
 .ua-metrics-red { color: var(--red-3); }
 .ua-metrics-info { color: var(--grey-5); }
 
+.ua-release-ribbon-refresh {
+  cursor: pointer;
+  color: var(--grey-5);
+  padding: 0 6px;
+}
+.ua-release-ribbon-refresh:hover { color: var(--blue-1); }
+
+.ua-release-open {
+  cursor: pointer;
+  color: var(--grey-5);
+  margin-left: 8px;
+}
+.ua-release-open:hover { color: var(--blue-1); }
+.ua-release-alert-tree { padding: 4px 0; }
+
+.ua-release-alerts {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.ua-release-alerts > .ua-metrics-grid-host {
+  flex: 1;
+  overflow: auto;
+}
+
 .ua-metrics-panel {
   border: 1px solid var(--grey-2);
   border-radius: 4px;
@@ -363,6 +389,37 @@ button.ui-btn.ui-btn-raised.ua-metrics-btn-secondary {
 
 .ua-metrics-grid-host.ua-metrics-queries-host {
   height: 240px;
+}
+
+/* Full-height tab layout: the opted-in panel/host grows to eat the remaining vertical space
+   (used by the Tests tab so its detail grid fills the page instead of the fixed 200px). */
+.ua-metrics-fill {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.ua-metrics-fill > .ua-metrics-root {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+}
+
+.ua-metrics-panel-grow {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.ua-metrics-panel-grow > .ua-metrics-grid-host {
+  height: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Chart hosts must not clip: charts render taller than the fixed 200px grid host (Stress line/box). */
+.ua-metrics-chart-host {
+  height: auto;
+  overflow: visible;
 }
 
 .ua-metrics-tables-row {

--- a/packages/UsageAnalysis/package.json
+++ b/packages/UsageAnalysis/package.json
@@ -5,7 +5,7 @@
     "email": "oserhiienko@datagrok.ai"
   },
   "friendlyName": "Usage Analysis",
-  "version": "2.5.1",
+  "version": "2.5.4",
   "description": "Platform usage analysis system",
   "repository": {
     "type": "git",

--- a/packages/UsageAnalysis/queries/release_tests.sql
+++ b/packages/UsageAnalysis/queries/release_tests.sql
@@ -1,0 +1,113 @@
+--name: ReleaseTests
+--friendlyName: Release | Tests
+--connection: System:Datagrok
+--input: string instanceFilter = "dev" {choices: ["dev", "release", "public", "release-ec2"]}
+--input: int lastBuildsNum = 5
+WITH recent AS (
+  SELECT b.name AS build_name, b.build_date, b.commit
+  FROM builds b
+  WHERE EXISTS (
+    SELECT 1 FROM test_runs r
+    JOIN tests t ON r.test_name = t.name
+    WHERE t.type = 'package'
+      AND r.build_name = b.name
+      AND NOT r.stress_test
+      AND NOT r.benchmark
+      AND r.instance LIKE 'https://' || @instanceFilter || '.datagrok.ai'
+  )
+  ORDER BY b.build_date DESC
+  LIMIT @lastBuildsNum
+),
+indexed_builds AS (
+  SELECT build_name, build_date, commit,
+         CAST(row_number() OVER (ORDER BY build_date) AS int) AS build_index
+  FROM recent
+),
+latest_runs AS (
+  -- One row per (test, build): the newest CI/CD run on the selected instance. Collapsing retries/reruns
+  -- here (rn = 1) is what keeps a retried-then-passed test from being counted as failed, and drops
+  -- non-CI (local/ad-hoc) runs — matching the correctness TestsDashboard.
+  SELECT r.*,
+         ROW_NUMBER() OVER (PARTITION BY r.test_name, r.build_name ORDER BY r.date_time DESC) AS rn
+  FROM test_runs r
+  WHERE NOT r.stress_test AND NOT r.benchmark AND r.ci_cd
+    AND r.instance LIKE 'https://' || @instanceFilter || '.datagrok.ai'
+    AND r.build_name IN (SELECT build_name FROM recent)
+),
+active_tests AS (
+  SELECT DISTINCT test_name FROM latest_runs WHERE rn = 1 AND passed IS NOT NULL
+)
+SELECT
+  COALESCE(p.name, t.package) AS package,
+  t.name AS test,
+  t.owner,
+  b.build_index,
+  b.build_name AS build,
+  b.commit AS build_commit,
+  b.build_date,
+  r.instance,
+  CASE WHEN r.passed IS NULL THEN 'did not run'
+       WHEN r.skipped THEN 'skipped'
+       WHEN r.passed THEN 'passed'
+       WHEN NOT r.passed THEN 'failed'
+       ELSE 'unknown' END AS status,
+  r.result,
+  CAST(r.duration AS int) AS duration,
+  COALESCE(r.params->>'flaking', 'false')::bool AS flaking
+FROM tests t
+CROSS JOIN indexed_builds b
+LEFT JOIN latest_runs r
+  ON r.test_name = t.name AND r.build_name = b.build_name AND r.rn = 1
+LEFT JOIN published_packages p ON p.name = t.package AND p.is_current
+WHERE t.type <> 'manual'
+  AND t.name IN (SELECT test_name FROM active_tests)
+  AND t.name NOT LIKE '%Unhandled exceptions: Exception'
+  AND t.name <> ': : '
+ORDER BY b.build_index, package, t.name
+--end
+
+--name: ReleaseManualTests
+--friendlyName: Release | Manual Tests
+--connection: System:Datagrok
+--input: int lastBatchesNum = 5
+--meta.cache: all
+--meta.cache.invalidateOn: 0 0 * * *
+WITH recent_batches AS (
+  SELECT r.batch_name, MAX(r.date_time) AS latest_batch_run
+  FROM test_runs r
+  JOIN tests t ON t.name = r.test_name
+  WHERE t.type = 'manual' AND r.batch_name IS NOT NULL AND r.batch_name <> '' AND r.passed IS NOT NULL
+  GROUP BY r.batch_name
+  ORDER BY latest_batch_run DESC
+  LIMIT @lastBatchesNum
+),
+indexed AS (
+  SELECT batch_name, latest_batch_run,
+         CAST(row_number() OVER (ORDER BY latest_batch_run DESC) AS int) AS batch_index
+  FROM recent_batches
+),
+active_manual AS (
+  SELECT DISTINCT test_name FROM test_runs
+  WHERE batch_name IN (SELECT batch_name FROM indexed) AND passed IS NOT NULL
+)
+SELECT
+  b.batch_name,
+  b.batch_index,
+  t.name AS test,
+  CASE WHEN r.passed IS NULL THEN 'did not run'
+       WHEN r.skipped THEN 'skipped'
+       WHEN r.passed THEN 'passed'
+       WHEN NOT r.passed THEN 'failed'
+       ELSE 'unknown' END AS status,
+  r.result
+FROM tests t
+CROSS JOIN indexed b
+LEFT JOIN test_runs r ON r.test_name = t.name AND r.batch_name = b.batch_name
+  AND r.date_time = (SELECT MAX(_r.date_time) FROM test_runs _r
+                     WHERE _r.test_name = t.name AND _r.batch_name = b.batch_name)
+WHERE t.type = 'manual'
+  AND t.name IN (SELECT test_name FROM active_manual)
+  AND t.name NOT LIKE '%Unhandled exceptions: Exception'
+  AND t.name <> ': : '
+ORDER BY b.batch_index, t.name
+--end

--- a/packages/UsageAnalysis/src/package-api.ts
+++ b/packages/UsageAnalysis/src/package-api.ts
@@ -392,6 +392,14 @@ export namespace queries {
     return await grok.data.query('UsageAnalysis:ProjectsList', {});
   }
 
+  export async function releaseTests(instanceFilter: string , lastBuildsNum: number ): Promise<DG.DataFrame> {
+    return await grok.data.query('UsageAnalysis:ReleaseTests', { instanceFilter, lastBuildsNum });
+  }
+
+  export async function releaseManualTests(lastBatchesNum: number ): Promise<DG.DataFrame> {
+    return await grok.data.query('UsageAnalysis:ReleaseManualTests', { lastBatchesNum });
+  }
+
   export async function userReports(date: string ): Promise<DG.DataFrame> {
     return await grok.data.query('UsageAnalysis:UserReports', { date });
   }
@@ -554,8 +562,24 @@ export namespace funcs {
     return await grok.functions.call('UsageAnalysis:UsageAnalysisApp', { path, date, groups, packages, tags, categories, projects });
   }
 
+  export async function releaseDashboardApp(path?: string ): Promise<DG.View> {
+    return await grok.functions.call('UsageAnalysis:ReleaseDashboardApp', { path });
+  }
+
   export async function getTicketsVerdict(ticketColumn: DG.Column , resultColumn: DG.Column ): Promise<void> {
     return await grok.functions.call('UsageAnalysis:GetTicketsVerdict', { ticketColumn, resultColumn });
+  }
+
+  export async function vexImages(): Promise<DG.DataFrame> {
+    return await grok.functions.call('UsageAnalysis:VexImages', {});
+  }
+
+  export async function stressSummaryDashboard(): Promise<DG.DataFrame> {
+    return await grok.functions.call('UsageAnalysis:StressSummaryDashboard', {});
+  }
+
+  export async function stressRawDashboard(): Promise<DG.DataFrame> {
+    return await grok.functions.call('UsageAnalysis:StressRawDashboard', {});
   }
 
   export async function metricsApp(): Promise<DG.View> {

--- a/packages/UsageAnalysis/src/package.g.ts
+++ b/packages/UsageAnalysis/src/package.g.ts
@@ -39,6 +39,15 @@ export function usageAnalysisApp(path?: string, date?: string, groups?: string, 
   return PackageFunctions.usageAnalysisApp(path, date, groups, packages, tags, categories, projects);
 }
 
+//name: Release
+//input: string path { optional: true; meta.url: true }
+//output: view result
+//meta.role: adminApp,app
+//meta.url: /release
+export function releaseDashboardApp(path?: string) : any {
+  return PackageFunctions.releaseDashboardApp(path);
+}
+
 //input: column<string> ticketColumn 
 //input: column<string> resultColumn 
 //meta.vectorFunc: true

--- a/packages/UsageAnalysis/src/package.ts
+++ b/packages/UsageAnalysis/src/package.ts
@@ -19,6 +19,8 @@ import {initTestStickyMeta} from './test-analysis/sticky-meta-initialization';
 import {TestDashboardWidget} from './viewers/ua-test-dashboard-viewer';
 import {ClickEventsWidget} from './widgets/click-events-widget';
 import {fetchVexDashboardImages, vexImagesToDataFrame} from './tabs/vulnerabilities';
+import {ReleaseHandler} from './release/release-handler';
+import {isDevHost} from './release/data';
 
 export const _package = new DG.Package();
 export let _properties: any;
@@ -113,6 +115,23 @@ export class PackageFunctions {
     const handler = new ViewHandler();
     handler.view.parentCall = grok.functions.getCurrentCall();
     handler.init(date, groups, packages, tags, categories, projects, path);
+    return handler.view;
+  }
+
+  // Release-readiness dashboard. Dev-only: available and visible on dev.datagrok.ai; a no-op elsewhere.
+  @grok.decorators.app({
+    'url': '/release',
+    'name': 'Release',
+    'meta': {'role': 'adminApp'},
+  })
+  static releaseDashboardApp(
+    @grok.decorators.param({'options': {'optional': true, 'meta.url': true}}) path?: string): DG.ViewBase | null {
+    if (!isDevHost()) {
+      grok.shell.warning('The Release dashboard is available on dev.datagrok.ai only.');
+      return null;
+    }
+    const handler = new ReleaseHandler(path);
+    handler.view.parentCall = grok.functions.getCurrentCall();
     return handler.view;
   }
 

--- a/packages/UsageAnalysis/src/release/RELEASE.md
+++ b/packages/UsageAnalysis/src/release/RELEASE.md
@@ -1,0 +1,96 @@
+# Release-Readiness Dashboard (`/release`)
+
+A single, focused screen that answers "is the next version good to ship?". Lives in the
+UsageAnalysis package as a **second app entry** next to the 10-tab Usage Analysis admin app.
+
+## Entry point & dev-only gating
+
+`UsageAnalysis:releaseDashboardApp` (`src/package.ts`) — `@grok.decorators.app`, url `/release`,
+`meta.role: adminApp`.
+
+It is **dev-only**: `isDevHost()` (`src/release/data.ts`) checks `grok.dapi.root` (falling back to
+`window.location.hostname`) against `dev.datagrok.ai`. On any other server the app warns and returns
+`null`, so it is available and usable only on dev. (Function metadata is static, so the launcher entry
+still exists off-dev; the runtime guard makes it a no-op there. To hide it entirely elsewhere, publish
+UsageAnalysis with this app only to dev.)
+
+## Structure
+
+`ReleaseHandler` (`src/release/release-handler.ts`) owns a `DG.MultiView` with five tabs. All tabs are
+toolbox-independent, so — unlike the main `ViewHandler` — it builds **no shared `UaToolbox`**. Each tab
+extends `UaView`; the handler calls `markToolboxReady()` (added to `src/tabs/ua.ts`) to unblock
+`initViewers()` without a toolbox, then registers a lazy factory (`addView(name, factory, false)`).
+
+| Tab            | File                        | Source                                                      |
+|----------------|-----------------------------|-------------------------------------------------------------|
+| Overview       | `src/release/overview.ts`   | Fetches all domains in parallel; status cards + alerts       |
+| Tests          | `src/release/tests.ts`      | `UsageAnalysis:ReleaseTests` query (`queries/release_tests.sql`) — unit + integration + package (non-manual) |
+| Manual         | `src/release/manual.ts`     | `UsageAnalysis:ReleaseManualTests` query — Test Track batches |
+| Stress         | `src/tabs/stress-tests.ts`  | **reused**; `StressTestsSummary`/`StressTestsRaw`            |
+| Vulnerabilities| `src/tabs/vulnerabilities.ts`| **reused**; VEX `index.json` — core shown as bleeding-edge only (`toDashboardImages`) |
+| Tickets        | `src/release/tickets.ts`    | `JiraConnect:GetJiraTicketsByFilter` (fixVersion)           |
+
+Shared, pure helpers live in `src/release/data.ts` (host check, `ReleaseTests` fetch + client-side
+pivot, alert computation, `stressRegression`) so Overview and the tabs never duplicate logic.
+
+## Global environment (instance) picker
+
+`ReleaseHandler` owns a single **Environment** choice input (`ENV_CHOICES` = `dev` / `release` /
+`public` / `release-ec2`, from `data.ts`) placed on the MultiView **ribbon**. Because `MultiView`
+overwrites its ribbon with the active child's on every tab switch — and the child tabs keep their
+controls in their own in-view header — the handler re-asserts the picker in the `onTabChanged`
+handler (and once after construction), so it stays visible on every page.
+
+The selection is shared through `ReleaseContext` (a `BehaviorSubject<string>` in `data.ts`). The two
+**env-scoped** tabs — **Overview** and **Tests** — read `ctx.env.value` when fetching `ReleaseTests`
+and subscribe to it to re-fetch on change (guarded by `initialized` so a lazy tab loads once, with the
+current env). The other tabs have no per-instance dimension in the DB, so the picker is a no-op there:
+Stress (`stress_tests` has no `instance` column — runs in a dedicated job), Manual (Test Track
+batches), Vulnerabilities (VEX docker images), Tickets (Jira fixVersion).
+
+## Tests tab
+
+`ReleaseTests` returns one row per test per build (last N builds on a chosen instance) with
+per-build `status`/`duration`/`flaking` plus `package`/`owner`. Like the correctness `TestsDashboard`,
+it collapses to the **latest CI/CD run per (test, build)** (`latest_runs` CTE, `rn = 1`) — so retried-
+then-passed tests aren't counted as failed and non-CI (local/ad-hoc) runs are excluded. Note the failing
+count spans **all** exercised suites, including the `PlaywrightPublic` E2E suite; a single package/unit
+CI job (e.g. a Jenkins `test-build`) reports fewer failures because it doesn't include E2E. `fetchReleaseTests()` pivots it
+client-side (`groupBy(['package','test','owner']).pivot('build_index')`) into one row per test, then
+derives `failing`/`stable`/`flaky`/`slower`/`needs_attention` and joins the **Autotests** sticky-meta
+schema (`ignore?`/`ignoreReason`/`lastResolved`).
+
+- **Split by package:** a per-package summary grid (pass/fail/skip/not-run + pass rate) over the detail grid.
+- **Sparklines:** two grid summary columns via `grid.columns.add({cellType:'sparkline'})` +
+  `settings.columnNames` — success (per-build 1/0) and duration (per-build ms). `build_index` is
+  ascending, so sparklines read oldest→newest left-to-right.
+- **Mute (global):** editing `ignore?`/`ignoreReason` persists back through
+  `grok.dapi.stickyMeta.setAllValues(Autotests, testColumn, values)`.
+- **Mute (version-bound):** a per-row 🔔/🔕 icon column mutes a test for the *current release version*
+  (`versionFromBuild()` of the latest build, e.g. `1.28.0`). The per-test list of muted versions lives in
+  its own `ReleaseMutes` sticky-meta schema (`mutedVersions`, `;`-separated) so it never touches the shared
+  `Autotests` schema. `muted` (= global `ignore?` OR muted-for-this-version) gates `needs_attention` and
+  every failing/flaky count; clicking the icon toggles the version, updates the counts, and persists.
+- **Drilldown:** selecting a row shows the latest raw output + a Jenkins link in the context panel.
+
+## Launch
+
+Deep link (dev only): `https://dev.datagrok.ai/apps/usage/release` (per-tab
+`/apps/usage/release/<tab>`). The tab appends its name to the app path.
+
+## Known limitations / follow-ups
+
+- **Tickets tab is blocked by a pre-existing JiraConnect bug.** `JiraConnect`'s `loadIssues`
+  (`public/packages/JiraConnect/src/api/data.ts`) calls Atlassian's `/rest/api/3/search`, which
+  Atlassian **removed** (HTTP 410 — "migrate to `/rest/api/3/search/jql`"). Until JiraConnect is
+  migrated to the token-paginated `/rest/api/3/search/jql` endpoint, `GetJiraTicketsByFilter` returns
+  nothing and the Tickets tab / Overview card show `n/a` (they degrade gracefully). Jira credentials
+  *are* configured on dev (the 410 is reached, not an auth error). `GetJiraTicketsByFilter` also builds
+  equality-only JQL, so the fix version is passed quoted (`fixVersion = "<next>"`).
+- **Jenkins deep-link** is the `test-build` job page, not the specific build — the `builds` table
+  stores no build URL. Proper fix: persist `build_url` in test ingestion
+  (`core/server/datlas/lib/src/services/action_logger_service.dart`) and surface it here.
+- **`ReleaseTests` shows only tests that actually ran** in the selected builds (`active_tests` CTE) —
+  this filters out never-run/malformed `tests.package` rows (Jupyter tracebacks, `{Average time…}`,
+  etc.). On a partial instance like `dev`, packages not exercised by the latest build show as
+  "not run"; use the `release` instance for a full release-candidate picture.

--- a/packages/UsageAnalysis/src/release/data.ts
+++ b/packages/UsageAnalysis/src/release/data.ts
@@ -1,0 +1,410 @@
+import * as DG from 'datagrok-api/dg';
+import * as grok from 'datagrok-api/grok';
+import * as ui from 'datagrok-api/ui';
+import {BehaviorSubject, Subject} from 'rxjs';
+
+import {queries} from '../package-api';
+
+export const DEV_HOST = 'dev.datagrok.ai';
+export const JIRA_BROWSE = 'https://reddata.atlassian.net/browse/';
+export const JENKINS_TEST_JOB = 'https://ops.datagrok.ai/job/test-build/';
+const SLOW_FACTOR = 1.25;
+
+/** Instances the dashboard can inspect; each maps to a `test_runs.instance` host (see release_tests.sql). */
+export const ENV_CHOICES = ['dev', 'release', 'public', 'release-ec2'];
+export const DEFAULT_ENV = 'dev';
+
+/** Dashboard-wide state shared by every tab. The ribbon env picker (ReleaseHandler) writes `env`;
+ * env-scoped tabs (Overview, Tests) read `env.value` and re-fetch when it changes. The ribbon Refresh
+ * button fires `refresh`; every tab re-fetches on it. */
+export class ReleaseContext {
+  readonly env: BehaviorSubject<string>;
+  readonly refresh = new Subject<void>();
+  constructor(env: string = DEFAULT_ENV) {
+    this.env = new BehaviorSubject(env);
+  }
+}
+
+// Version-bound test muting. A test is muted for a specific release version; the mute list lives in its
+// own sticky-meta schema (semtype=autotest) so it never touches the shared 'Autotests' schema.
+export const RELEASE_MUTES_SCHEMA = 'ReleaseMutes';
+export const MUTED_VERSIONS = 'mutedVersions';
+export const MUTE_ON = '🔕';  // muted for this release
+export const MUTE_OFF = '🔔'; // active (click to mute)
+let _mutesSchemaPromise: Promise<any> | null = null;
+
+/** The release-mute sticky-meta schema, created on first use. Promise-cached so the Overview and Tests
+ * tabs (which both fetch on load) can't race into two createSchema calls; recovers if one loses the race. */
+export function getReleaseMutesSchema(): Promise<any> {
+  _mutesSchemaPromise ??= (async () => {
+    let schemas = await grok.dapi.stickyMeta.getSchemas();
+    let schema = schemas.find((s) => s.name === RELEASE_MUTES_SCHEMA);
+    if (schema)
+      return schema;
+    try {
+      // Entity-type name must be globally unique across schemas (the shared 'Autotests' schema owns
+      // 'autotest'), so use a distinct name while still matching the same autotest-semtype column.
+      return await grok.dapi.stickyMeta.createSchema(RELEASE_MUTES_SCHEMA,
+        [{name: 'releaseMuteAutotest', matchBy: 'semtype=autotest'}], [{name: MUTED_VERSIONS, type: DG.TYPE.STRING}]);
+    } catch (e) {
+      // A concurrent caller created it first — re-fetch before giving up.
+      schemas = await grok.dapi.stickyMeta.getSchemas();
+      schema = schemas.find((s) => s.name === RELEASE_MUTES_SCHEMA);
+      if (schema)
+        return schema;
+      _mutesSchemaPromise = null; // allow a later retry on a genuine failure
+      throw e;
+    }
+  })();
+  return _mutesSchemaPromise;
+}
+
+/** Extracts the release version (e.g. '1.28.0') from a build name like '2026-07-15-1.28.0.BE-3'. */
+export function versionFromBuild(build: string): string {
+  const m = /(\d+\.\d+\.\d+)/.exec(build ?? '');
+  return m ? m[1] : '';
+}
+
+/** Parses a stored 'a;b;c' mute list into a trimmed, non-empty version array. */
+export function parseMutedVersions(raw: string | null | undefined): string[] {
+  return (raw ?? '').split(';').map((s) => s.trim()).filter((s) => s);
+}
+
+/** True when `version` is present in the stored mute list. */
+export function isMutedForVersion(raw: string | null | undefined, version: string): boolean {
+  return !!version && parseMutedVersions(raw).includes(version);
+}
+
+// Grid status-cell colors (ARGB — grid cells take numeric colors, not design tokens; see metrics.ts/errors.ts).
+export const STATUS_BACK: Record<string, number> = {passed: 0xFFE6F4EA, failed: 0xFFFDE7E7, skipped: 0xFFF3F3F3};
+export const NOT_RUN_BACK = 0xFFFAFAFA;
+export const COLOR_FAIL_TEXT = 0xFF7B2D24;
+
+/** Resolves once the element has a non-zero width (or after ~1s). Sparkline grid columns throw a
+ * layout "Wrong range" error if added before the grid is laid out — wait for a real width first. */
+export async function waitForWidth(el: HTMLElement, tries = 60): Promise<void> {
+  for (let i = 0; i < tries && el.clientWidth === 0; i++)
+    await new Promise((r) => requestAnimationFrame(r));
+}
+
+/** Tints per-build/per-batch status cells (passed/failed/skipped/did-not-run) in a results grid. */
+export function colorStatusCell(gc: DG.GridCell, statusCols: string[]): void {
+  if (!gc.isTableCell || !statusCols.includes(gc.gridColumn.name))
+    return;
+  const v = gc.cell.value as string;
+  gc.style.backColor = STATUS_BACK[v] ?? NOT_RUN_BACK;
+  if (v === 'failed')
+    gc.style.textColor = COLOR_FAIL_TEXT;
+}
+
+/** A '+' icon that opens the current dataframe as a table view in the workspace. */
+export function openInWorkspaceIcon(getDf: () => DG.DataFrame | null): HTMLElement {
+  const icon = ui.iconFA('plus', () => {
+    const df = getDf();
+    if (df && df.rowCount)
+      grok.shell.addTableView(df);
+  }, 'Open as a table in the workspace');
+  icon.classList.add('ua-release-open');
+  return icon;
+}
+
+/** The Release dashboard is dev-only. True when the current server is dev.datagrok.ai. */
+export function isDevHost(): boolean {
+  const root = (grok.dapi.root ?? '').toLowerCase();
+  if (root.includes(DEV_HOST))
+    return true;
+  return typeof window !== 'undefined' && window.location.hostname === DEV_HOST;
+}
+
+/** Default next-release version to prefill the tickets filter (current client build). */
+export function defaultNextVersion(): string {
+  return grok.shell.build?.client?.version ?? '';
+}
+
+export function median(xs: number[]): number {
+  if (xs.length === 0)
+    return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+/** One-row-per-test pivot of ReleaseTests plus the derived per-build column names. */
+export interface ReleasePivot {
+  df: DG.DataFrame;
+  buildIndexes: number[]; // ascending: first = oldest, last = latest
+  latest: number;
+  statusCols: string[];
+  durationCols: string[];
+  successCols: string[];
+  resultCols: string[];
+  version: string; // release version the latest build belongs to (for version-bound muting)
+}
+
+export interface TestAlerts {
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  notRun: number;
+  flaky: number;
+  slower: number;
+  passRate: number; // 0..100 over the latest build: passed / (passed + failed), excluding skipped & did-not-run
+  failingByPkg: Record<string, string[]>;
+  slowerByPkg: Record<string, string[]>;
+  flakyByPkg: Record<string, string[]>;
+}
+
+function pushByPkg(map: Record<string, string[]>, pkg: string, test: string): void {
+  (map[pkg] ??= []).push(test);
+}
+
+function countGroups(map: Record<string, string[]>): number {
+  return Object.values(map).reduce((n, xs) => n + xs.length, 0);
+}
+
+export interface StressRegression {
+  regressed: boolean;
+  detail: string;
+}
+
+function renameCol(df: DG.DataFrame, from: string, to: string): void {
+  const c = df.columns.byName(from);
+  if (c) {
+    c.name = to;
+    c.setTag('friendlyName', to);
+  }
+}
+
+/** Runs ReleaseTests and pivots it client-side into one row per test with per-build columns. */
+export async function fetchReleaseTests(instanceFilter: string, lastBuildsNum: number): Promise<ReleasePivot | null> {
+  const raw: DG.DataFrame = await queries.releaseTests(instanceFilter, lastBuildsNum);
+  if (raw.rowCount === 0)
+    return null;
+
+  const biCol = raw.getCol('build_index');
+  const buildIndexes = Array.from(new Set(Array.from({length: biCol.length}, (_, i) => biCol.get(i))))
+    .filter((v) => v != null).map(Number).sort((a, b) => a - b);
+  const latest = buildIndexes[buildIndexes.length - 1];
+
+  const pivot = raw.groupBy(['package', 'test', 'owner'])
+    .pivot('build_index')
+    .first('status')
+    .avg('duration')
+    .first('flaking')
+    .first('result')
+    .first('build_commit')
+    .aggregate();
+
+  // Per-build success (1 pass / 0 fail / gap for skipped & did-not-run) for the success sparkline.
+  for (const bi of buildIndexes) {
+    const sc = pivot.getCol(`${bi} first(status)`);
+    pivot.columns.addNewFloat(`${bi} ok`).init((i) => {
+      const s = sc.get(i);
+      return s === 'passed' ? 1 : s === 'failed' ? 0 : null;
+    });
+  }
+
+  const latestCommit = pivot.columns.addNewString('latest_commit');
+  latestCommit.init((i) => pivot.get(`${latest} first(build_commit)`, i) ?? '');
+  const latestResult = pivot.columns.addNewString('latest_result');
+
+  for (const bi of buildIndexes) {
+    renameCol(pivot, `${bi} first(status)`, `${bi}`);
+    renameCol(pivot, `${bi} avg(duration)`, `${bi} ms`);
+    renameCol(pivot, `${bi} first(result)`, `${bi} result`);
+    renameCol(pivot, `${bi} first(flaking)`, `${bi} flaking`);
+    pivot.columns.remove(`${bi} first(build_commit)`);
+  }
+  latestResult.init((i) => pivot.get(`${latest} result`, i) ?? '');
+
+  const statusCols = buildIndexes.map((bi) => `${bi}`);
+  const durationCols = buildIndexes.map((bi) => `${bi} ms`);
+  const successCols = buildIndexes.map((bi) => `${bi} ok`);
+  const resultCols = buildIndexes.map((bi) => `${bi} result`);
+
+  pivot.columns.addNewBool('failing').init((i) => pivot.get(`${latest}`, i) === 'failed');
+  pivot.columns.addNewBool('stable').init((i) => statusCols.every((c) => pivot.get(c, i) === 'passed'));
+  pivot.columns.addNewBool('flaky').init((i) => {
+    const statuses = statusCols.map((c) => pivot.get(c, i));
+    const flakingFlag = buildIndexes.some((bi) => pivot.get(`${bi} flaking`, i) === true);
+    return flakingFlag || (statuses.includes('passed') && statuses.includes('failed'));
+  });
+  pivot.columns.addNewBool('slower').init((i) => {
+    // Only compare speed across passed runs — a failed/skipped run's duration isn't comparable.
+    if (pivot.get(`${latest}`, i) !== 'passed')
+      return false;
+    const latestMs = Number(pivot.get(`${latest} ms`, i));
+    if (!latestMs || isNaN(latestMs))
+      return false;
+    const prior = buildIndexes.slice(0, -1)
+      .filter((bi) => pivot.get(`${bi}`, i) === 'passed')
+      .map((bi) => Number(pivot.get(`${bi} ms`, i))).filter((v) => v && !isNaN(v));
+    if (prior.length < 2)
+      return false;
+    const med = median(prior);
+    return med > 0 && latestMs > med * SLOW_FACTOR;
+  });
+
+  // Release version the latest build belongs to — mutes are bound to it.
+  const buildCol = raw.getCol('build');
+  let latestBuildName = '';
+  for (let i = 0; i < raw.rowCount; i++)
+    if (Number(biCol.get(i)) === latest) { latestBuildName = buildCol.get(i) ?? ''; break; }
+  const version = versionFromBuild(latestBuildName);
+
+  const schemas = await grok.dapi.stickyMeta.getSchemas();
+  const schema = schemas.find((s) => s.name === 'Autotests');
+  pivot.getCol('test').semType = 'autotest';
+  pivot.getCol('owner').semType = 'User';
+  pivot.getCol('owner').setTag('cell.renderer', 'User');
+  if (schema) {
+    const meta = await grok.dapi.stickyMeta.getAllValues(schema, pivot.getCol('test'));
+    for (const name of ['ignore?', 'ignoreReason', 'lastResolved']) {
+      const c = meta.col(name);
+      if (c)
+        pivot.columns.add(c);
+    }
+  }
+  // Version-bound mutes (own schema). 'mutedForVersion' drives the grid icon; 'muted' = global ignore OR
+  // muted-for-this-version and gates needs_attention and every failing/flaky count.
+  const mutesSchema = await getReleaseMutesSchema();
+  const mutes = await grok.dapi.stickyMeta.getAllValues(mutesSchema, pivot.getCol('test'));
+  const mvCol = mutes.col(MUTED_VERSIONS);
+  if (mvCol)
+    pivot.columns.add(mvCol);
+  const mutedVersionsCol = pivot.columns.byName(MUTED_VERSIONS);
+  const ignoreCol = pivot.columns.byName('ignore?');
+  pivot.columns.addNewBool('mutedForVersion')
+    .init((i) => isMutedForVersion(mutedVersionsCol?.get(i), version));
+  pivot.columns.addNewBool('muted')
+    .init((i) => (ignoreCol != null && ignoreCol.get(i) === true) || pivot.get('mutedForVersion', i) === true);
+  // Mute toggle column: the glyph is the cell's own value so it always stays aligned with its row
+  // (reading another column by grid-row index misaligns once the grid sorts). tests.ts toggles it on click.
+  pivot.columns.addNewString('mute').init((i) => pivot.get('mutedForVersion', i) === true ? MUTE_ON : MUTE_OFF);
+  pivot.columns.addNewBool('needs_attention')
+    .init((i) => pivot.get('failing', i) && !pivot.get('muted', i));
+
+  pivot.name = 'Release tests';
+  return {df: pivot, buildIndexes, latest, statusCols, durationCols, successCols, resultCols, version};
+}
+
+/** Rolls the pivot up into the counts and package-grouped alert lists the Overview needs. */
+export function computeTestAlerts(p: ReleasePivot): TestAlerts {
+  const df = p.df;
+  const latestCol = `${p.latest}`;
+  const a: TestAlerts = {total: 0, passed: 0, failed: 0, skipped: 0, notRun: 0, flaky: 0, slower: 0,
+    passRate: 0, failingByPkg: {}, slowerByPkg: {}, flakyByPkg: {}};
+  const testCol = df.getCol('test');
+  const pkgCol = df.getCol('package');
+  const mutedCol = df.columns.byName('muted');
+  let rawFailed = 0;
+  for (let i = 0; i < df.rowCount; i++) {
+    const status = df.get(latestCol, i);
+    const muted = !!(mutedCol && mutedCol.get(i) === true);
+    const pkg = pkgCol.get(i) ?? '';
+    const test = testCol.get(i);
+    a.total++;
+    if (status === 'passed') a.passed++;
+    else if (status === 'failed') rawFailed++;
+    else if (status === 'skipped') a.skipped++;
+    else a.notRun++;
+    if (status === 'failed' && !muted)
+      pushByPkg(a.failingByPkg, pkg, test);
+    if (df.get('flaky', i) === true && !muted)
+      pushByPkg(a.flakyByPkg, pkg, test);
+    if (df.get('slower', i) === true && !muted)
+      pushByPkg(a.slowerByPkg, pkg, test);
+  }
+  a.failed = countGroups(a.failingByPkg);
+  a.flaky = countGroups(a.flakyByPkg);
+  a.slower = countGroups(a.slowerByPkg);
+  // Success rate excludes skipped and did-not-run: passed / (passed + failed).
+  // floor so it never rounds up to 100% while any test is failing.
+  const ran = a.passed + rawFailed;
+  a.passRate = ran > 0 ? Math.floor((a.passed / ran) * 100) : 0;
+  return a;
+}
+
+/** One-row-per-test pivot of the Manual Tests query (Test Track batches). batch_index 1 = newest. */
+export interface ManualPivot {
+  df: DG.DataFrame;
+  chronological: number[]; // batch indexes ordered oldest -> newest (for left-to-right sparklines)
+  latest: number; // batch_index of the newest batch (= 1)
+  statusCols: string[];
+  successCols: string[];
+  latestBatchName: string;
+  passed: number;
+  failed: number;
+  total: number;
+}
+
+export async function fetchReleaseManual(lastBatches: number): Promise<ManualPivot | null> {
+  const raw: DG.DataFrame = await queries.releaseManualTests(lastBatches);
+  if (raw.rowCount === 0)
+    return null;
+  const biCol = raw.getCol('batch_index');
+  const idxs = Array.from(new Set(Array.from({length: biCol.length}, (_, i) => biCol.get(i))))
+    .filter((v) => v != null).map(Number).sort((a, b) => a - b);
+  const latest = idxs[0]; // ROW_NUMBER ... ORDER BY latest_batch_run DESC => 1 is newest
+  const chronological = [...idxs].reverse();
+  let latestBatchName = '';
+  for (let i = 0; i < raw.rowCount; i++)
+    if (Number(biCol.get(i)) === latest) { latestBatchName = raw.get('batch_name', i) ?? ''; break; }
+
+  const pivot = raw.groupBy(['test']).pivot('batch_index').first('status').first('result').aggregate();
+  for (const bi of idxs) {
+    const sc = pivot.getCol(`${bi} first(status)`);
+    pivot.columns.addNewFloat(`${bi} ok`).init((i) => { const s = sc.get(i); return s === 'passed' ? 1 : s === 'failed' ? 0 : null; });
+  }
+  const latestResult = pivot.columns.addNewString('latest_result');
+  for (const bi of idxs) {
+    renameCol(pivot, `${bi} first(status)`, `${bi}`);
+    renameCol(pivot, `${bi} first(result)`, `${bi} result`);
+  }
+  latestResult.init((i) => pivot.get(`${latest} result`, i) ?? '');
+  pivot.columns.addNewBool('failing').init((i) => pivot.get(`${latest}`, i) === 'failed');
+  pivot.getCol('test').semType = 'autotest';
+  pivot.name = 'Manual tests';
+
+  let passed = 0; let failed = 0;
+  for (let i = 0; i < pivot.rowCount; i++) {
+    const s = pivot.get(`${latest}`, i);
+    if (s === 'passed') passed++;
+    else if (s === 'failed') failed++;
+  }
+  return {df: pivot, chronological, latest, statusCols: chronological.map((bi) => `${bi}`),
+    successCols: chronological.map((bi) => `${bi} ok`), latestBatchName, passed, failed, total: pivot.rowCount};
+}
+
+/** Compares the latest build's worst-case p95 to the median of prior builds (from StressTestsSummary). */
+export function stressRegression(df: DG.DataFrame, factor = 1.2): StressRegression {
+  const n = df.rowCount;
+  if (n === 0)
+    return {regressed: false, detail: 'No stress runs reported.'};
+  const buildCol = df.getCol('build');
+  const startedCol = df.columns.byName('started') ?? df.columns.byName('build_date');
+  const p95Col = df.columns.byName('p95_ms') ?? df.columns.byName('median_ms');
+  if (!p95Col)
+    return {regressed: false, detail: 'No duration metric available.'};
+
+  const byBuild = new Map<string, {started: number, p95: number}>();
+  for (let i = 0; i < n; i++) {
+    const b = buildCol.get(i);
+    const p = Number(p95Col.get(i) ?? 0);
+    const raw = startedCol ? startedCol.get(i) : i;
+    const started = raw && (raw as any).valueOf ? (raw as any).valueOf() : Number(raw) || 0;
+    const cur = byBuild.get(b);
+    byBuild.set(b, {started: Math.max(started, cur?.started ?? 0), p95: Math.max(p, cur?.p95 ?? 0)});
+  }
+  const builds = [...byBuild.entries()].map(([build, v]) => ({build, ...v})).sort((x, y) => y.started - x.started);
+  if (builds.length < 3)
+    return {regressed: false, detail: 'Not enough stress history to compare.'};
+  const latest = builds[0];
+  const priorMed = median(builds.slice(1).map((b) => b.p95));
+  const pct = priorMed > 0 ? Math.round((latest.p95 / priorMed - 1) * 100) : 0;
+  const regressed = priorMed > 0 && latest.p95 > priorMed * factor;
+  return {regressed, detail: regressed ?
+    `Latest p95 ${Math.round(latest.p95)}ms is ${pct}% above prior median ${Math.round(priorMed)}ms` :
+    `Latest p95 within range (${pct >= 0 ? '+' : ''}${pct}% vs prior median)`};
+}

--- a/packages/UsageAnalysis/src/release/data.ts
+++ b/packages/UsageAnalysis/src/release/data.ts
@@ -79,6 +79,9 @@ export function isMutedForVersion(raw: string | null | undefined, version: strin
 export const STATUS_BACK: Record<string, number> = {passed: 0xFFE6F4EA, failed: 0xFFFDE7E7, skipped: 0xFFF3F3F3};
 export const NOT_RUN_BACK = 0xFFFAFAFA;
 export const COLOR_FAIL_TEXT = 0xFF7B2D24;
+// Dimmed palette for a carried-forward result (test didn't run in the latest build → show the last known one, muted).
+export const DIM_STATUS_BACK: Record<string, number> = {passed: 0xFFF0F7F1, failed: 0xFFF7ECEC, skipped: 0xFFF6F6F6};
+export const COLOR_DIM_TEXT = 0xFF9AA0A6;
 
 /** Resolves once the element has a non-zero width (or after ~1s). Sparkline grid columns throw a
  * layout "Wrong range" error if added before the grid is laid out — wait for a real width first. */
@@ -223,7 +226,22 @@ export async function fetchReleaseTests(instanceFilter: string, lastBuildsNum: n
   const successCols = buildIndexes.map((bi) => `${bi} ok`);
   const resultCols = buildIndexes.map((bi) => `${bi} result`);
 
-  pivot.columns.addNewBool('failing').init((i) => pivot.get(`${latest}`, i) === 'failed');
+  // Carry the last known result forward when the test didn't run in the latest build.
+  const descBuilds = [...buildIndexes].reverse(); // latest → oldest
+  pivot.columns.addNewString('effective_status').init((i) => {
+    for (const bi of descBuilds) {
+      const s = pivot.get(`${bi}`, i);
+      if (s && s !== 'did not run')
+        return s;
+    }
+    return '';
+  });
+  pivot.columns.addNewBool('carried_forward').init((i) => {
+    const latestS = pivot.get(`${latest}`, i);
+    return (latestS == null || latestS === 'did not run') && pivot.get('effective_status', i) !== '';
+  });
+
+  pivot.columns.addNewBool('failing').init((i) => pivot.get('effective_status', i) === 'failed');
   pivot.columns.addNewBool('stable').init((i) => statusCols.every((c) => pivot.get(c, i) === 'passed'));
   pivot.columns.addNewBool('flaky').init((i) => {
     const statuses = statusCols.map((c) => pivot.get(c, i));
@@ -292,7 +310,6 @@ export async function fetchReleaseTests(instanceFilter: string, lastBuildsNum: n
 /** Rolls the pivot up into the counts and package-grouped alert lists the Overview needs. */
 export function computeTestAlerts(p: ReleasePivot): TestAlerts {
   const df = p.df;
-  const latestCol = `${p.latest}`;
   const a: TestAlerts = {total: 0, passed: 0, failed: 0, skipped: 0, notRun: 0, flaky: 0, slower: 0,
     passRate: 0, failingByPkg: {}, slowerByPkg: {}, flakyByPkg: {}};
   const testCol = df.getCol('test');
@@ -300,7 +317,7 @@ export function computeTestAlerts(p: ReleasePivot): TestAlerts {
   const mutedCol = df.columns.byName('muted');
   let rawFailed = 0;
   for (let i = 0; i < df.rowCount; i++) {
-    const status = df.get(latestCol, i);
+    const status = df.get('effective_status', i) || 'did not run';
     const muted = !!(mutedCol && mutedCol.get(i) === true);
     const pkg = pkgCol.get(i) ?? '';
     const test = testCol.get(i);

--- a/packages/UsageAnalysis/src/release/manual.ts
+++ b/packages/UsageAnalysis/src/release/manual.ts
@@ -1,0 +1,96 @@
+import * as DG from 'datagrok-api/dg';
+import * as grok from 'datagrok-api/grok';
+import * as ui from 'datagrok-api/ui';
+
+import {UaView} from '../tabs/ua';
+import {UaToolbox} from '../ua-toolbox';
+import {fetchReleaseManual, ManualPivot, ReleaseContext, colorStatusCell, waitForWidth, openInWorkspaceIcon} from './data';
+
+export class ManualTestsView extends UaView {
+  private batchesInput!: DG.InputBase;
+  private gridHost!: HTMLElement;
+  private titleLabel!: HTMLElement;
+  private manualDf: DG.DataFrame | null = null;
+
+  constructor(private ctx: ReleaseContext, uaToolbox?: UaToolbox) {
+    super(uaToolbox);
+    this.name = 'Manual';
+    this.ctx.refresh.subscribe(() => { if (this.initialized) this.refresh(); });
+  }
+
+  async initViewers(): Promise<void> {
+    this.root.className = 'grok-view ui-box ua-metrics';
+    this.batchesInput = ui.input.int('Batches', {value: 5, min: 2, max: 20, onValueChanged: () => this.refresh()});
+    this.titleLabel = ui.divText('Manual test runs (Test Track batches)', 'ua-metrics-panel-title');
+    this.gridHost = ui.div([], 'ua-metrics-grid-host');
+
+    const refreshBtn = ui.bigButton('Refresh', () => this.refresh());
+    refreshBtn.prepend(ui.iconFA('sync-alt'), ' ');
+    refreshBtn.classList.add('ua-metrics-btn-secondary');
+    const header = ui.divH([this.batchesInput.root, ui.div([], {style: {flex: '1'}}), refreshBtn], 'ua-metrics-header');
+    const panel = ui.div([ui.divH([this.titleLabel, openInWorkspaceIcon(() => this.manualDf)], 'ua-metrics-panel-header'),
+      this.gridHost], 'ua-metrics-panel');
+    this.root.append(ui.div([header, panel], 'ua-metrics-root'));
+    await this.refresh();
+  }
+
+  private async refresh(): Promise<void> {
+    this.gridHost.innerHTML = '';
+    this.gridHost.append(ui.loader());
+    try {
+      const p = await fetchReleaseManual(this.batchesInput.value ?? 5);
+      if (!p) {
+        this.gridHost.innerHTML = '';
+        this.gridHost.append(ui.divText('No manual test runs reported.', 'ua-metrics-degraded'));
+        return;
+      }
+      this.titleLabel.textContent =
+        `Latest batch: ${p.latestBatchName || '—'} — ${p.passed} passed, ${p.failed} failing of ${p.total}`;
+      this.buildGrid(p);
+    } catch (e) {
+      this.gridHost.innerHTML = '';
+      this.gridHost.append(ui.divText(`Manual Tests failed: ${e}`, 'ua-metrics-degraded'));
+    }
+  }
+
+  private buildGrid(p: ManualPivot): void {
+    const df = p.df;
+    this.manualDf = df;
+    const grid = DG.Viewer.grid(df, {showColumnGridlines: false, allowBlockSelection: false, showCurrentCellOutline: false});
+    this.gridHost.innerHTML = '';
+    grid.root.style.width = '100%';
+    grid.root.style.height = '100%';
+    this.gridHost.append(grid.root);
+
+    grid.onCellPrepare((gc) => colorStatusCell(gc, p.statusCols));
+    df.onCurrentRowChanged.subscribe(() => {
+      if (df.currentRowIdx >= 0)
+        grok.shell.o = this.buildDrilldown(df, df.currentRowIdx);
+    });
+
+    // Sparkline needs the grid laid out first (see waitForWidth) — degrade gracefully otherwise.
+    waitForWidth(grid.root).then(() => {
+      try {
+        const success = grid.columns.add({gridColumnName: 'success', cellType: 'sparkline'});
+        success.settings = {columnNames: p.successCols};
+      } catch (_) { /* grid not ready for the sparkline — leave raw per-batch columns */ }
+      const order = ['test', 'success', ...p.statusCols, 'failing'];
+      grid.columns.setOrder(order.filter((n) => grid.col(n) != null));
+      for (const name of [...p.successCols, 'latest_result', ...p.chronological.map((bi) => `${bi} result`)]) {
+        const c = grid.col(name);
+        if (c)
+          c.visible = false;
+      }
+    });
+  }
+
+  private buildDrilldown(df: DG.DataFrame, i: number): HTMLElement {
+    const test = df.get('test', i);
+    const result = df.get('latest_result', i) ?? '';
+    const box = ui.div([ui.divText(result || 'No output for the latest batch.')], 'ua-metrics-degraded');
+    box.style.whiteSpace = 'pre-wrap';
+    box.style.maxHeight = '320px';
+    box.style.overflow = 'auto';
+    return ui.divV([ui.h2(test), ui.divText('Latest batch output', 'ua-metrics-panel-title'), box]);
+  }
+}

--- a/packages/UsageAnalysis/src/release/overview.ts
+++ b/packages/UsageAnalysis/src/release/overview.ts
@@ -1,0 +1,175 @@
+import * as grok from 'datagrok-api/grok';
+import * as ui from 'datagrok-api/ui';
+
+import {UaView} from '../tabs/ua';
+import {UaToolbox} from '../ua-toolbox';
+import {queries} from '../package-api';
+import {fetchVexIndex, criticalHighCount, toDashboardImages, vexReleaseDelta} from '../tabs/vulnerabilities';
+import {fetchReleaseTests, computeTestAlerts, stressRegression, defaultNextVersion, ReleaseContext} from './data';
+import {fetchReleaseTickets} from './tickets';
+
+type Band = 'green' | 'orange' | 'red' | 'info';
+const BAND_CLASS: Record<Band, string> = {
+  green: 'ua-metrics-green', orange: 'ua-metrics-orange', red: 'ua-metrics-red', info: 'ua-metrics-info'};
+
+interface Card { root: HTMLElement; value: HTMLElement; sub: HTMLElement; }
+interface AlertNode { label: string; band: Band; tab: string; groups: Record<string, string[]>; }
+
+export class ReleaseOverviewView extends UaView {
+  public switchTab: (name: string) => void = () => {};
+  private asOfLabel!: HTMLElement;
+  private cards = new Map<string, Card>();
+  private bannerHost!: HTMLElement;
+
+  constructor(private ctx: ReleaseContext, uaToolbox?: UaToolbox) {
+    super(uaToolbox);
+    this.name = 'Overview';
+    this.ctx.env.subscribe(() => { if (this.initialized) this.refresh(); });
+    this.ctx.refresh.subscribe(() => { if (this.initialized) this.refresh(); });
+  }
+
+  async initViewers(): Promise<void> {
+    this.root.className = 'grok-view ui-box ua-metrics';
+    this.asOfLabel = ui.divText('Release readiness', 'ua-metrics-asof');
+    this.bannerHost = ui.div([], 'ua-metrics-panel ua-release-alerts');
+
+    const refreshBtn = ui.bigButton('Refresh', () => this.refresh());
+    refreshBtn.prepend(ui.iconFA('sync-alt'), ' ');
+    refreshBtn.classList.add('ua-metrics-btn-secondary');
+    const header = ui.divH([this.asOfLabel, ui.div([], {style: {flex: '1'}}), refreshBtn], 'ua-metrics-header');
+
+    const cardsRow = ui.divH([
+      this.makeCard('Tests', 'pass rate', 'Tests'),
+      this.makeCard('Failing', 'unmuted', 'Tests'),
+      this.makeCard('Unstable', 'flaky tests', 'Tests'),
+      this.makeCard('Stress', 'latest build', 'Stress'),
+      this.makeCard('Vulnerabilities', 'critical + high', 'Vulnerabilities'),
+      this.makeCard('Tickets', 'unresolved', 'Tickets'),
+    ], 'ua-metrics-cards-row');
+
+    this.root.append(ui.div([header, cardsRow, this.bannerHost], 'ua-metrics-root'));
+    await this.refresh();
+  }
+
+  private makeCard(title: string, sub: string, target: string): HTMLElement {
+    const value = ui.divText('—', 'ua-metrics-card-value');
+    const subEl = ui.divText(sub, 'ua-metrics-card-sub');
+    const root = ui.div([ui.divText(title, 'ua-metrics-card-title'), value, subEl], 'ua-metrics-card');
+    root.style.cursor = 'pointer';
+    root.onclick = () => this.switchTab(target);
+    this.cards.set(title, {root, value, sub: subEl});
+    return root;
+  }
+
+  private setCard(title: string, value: string, band: Band, sub?: string): void {
+    const c = this.cards.get(title);
+    if (!c) return;
+    c.value.textContent = value;
+    c.value.className = `ua-metrics-card-value ${BAND_CLASS[band]}`;
+    if (sub != null)
+      c.sub.textContent = sub;
+  }
+
+  private async refresh(): Promise<void> {
+    this.bannerHost.innerHTML = '';
+    this.bannerHost.append(ui.loader());
+    const alerts: AlertNode[] = [];
+
+    const [testsR, stressR, vexR, ticketsR] = await Promise.allSettled([
+      fetchReleaseTests(this.ctx.env.value, 5),
+      queries.stressTestsSummary(20),
+      fetchVexIndex(),
+      fetchReleaseTickets(defaultNextVersion()),
+    ]);
+
+    if (testsR.status === 'fulfilled' && testsR.value) {
+      const a = computeTestAlerts(testsR.value);
+      this.setCard('Tests', `${a.passRate}%`, a.passRate >= 95 ? 'green' : a.passRate >= 80 ? 'orange' : 'red',
+        `${a.passed} passed, ${a.failed} failing`);
+      this.setCard('Failing', `${a.failed}`, a.failed === 0 ? 'green' : 'red');
+      this.setCard('Unstable', `${a.flaky}`, a.flaky === 0 ? 'green' : 'orange');
+      if (a.failed > 0)
+        alerts.push({label: `${a.failed} failing tests`, band: 'red', tab: 'Tests', groups: a.failingByPkg});
+      if (a.slower > 0)
+        alerts.push({label: `${a.slower} tests slower than recent median (passed runs)`, band: 'orange',
+          tab: 'Tests', groups: a.slowerByPkg});
+      if (a.flaky > 0)
+        alerts.push({label: `${a.flaky} unstable/flaky tests`, band: 'orange', tab: 'Tests', groups: a.flakyByPkg});
+    } else {
+      this.setCard('Tests', 'n/a', 'info');
+    }
+
+    if (stressR.status === 'fulfilled') {
+      const reg = stressRegression(stressR.value);
+      this.setCard('Stress', reg.regressed ? 'Slower' : 'OK', reg.regressed ? 'red' : 'green');
+      if (reg.regressed)
+        alerts.push({label: `Stress slower — ${reg.detail}`, band: 'red', tab: 'Stress', groups: {}});
+    } else {
+      this.setCard('Stress', 'n/a', 'info');
+    }
+
+    if (vexR.status === 'fulfilled') {
+      const {services, bleedingEdge} = vexR.value;
+      const {critical, high} = criticalHighCount(toDashboardImages(services, bleedingEdge));
+      this.setCard('Vulnerabilities', `${critical + high}`, critical > 0 ? 'red' : high > 0 ? 'orange' : 'green',
+        `${critical} critical, ${high} high`);
+      const delta = vexReleaseDelta(services, bleedingEdge);
+      if (delta.newCritical > 0 || delta.newHigh > 0)
+        alerts.push({label: `${delta.newCritical} new critical, ${delta.newHigh} new high vs last release`,
+          band: delta.newCritical > 0 ? 'red' : 'orange', tab: 'Vulnerabilities',
+          groups: {'': delta.images.map((x) => `${x.repo}: ${x.dCritical >= 0 ? '+' : ''}${x.dCritical} critical, ` +
+            `${x.dHigh >= 0 ? '+' : ''}${x.dHigh} high`)}});
+    } else {
+      this.setCard('Vulnerabilities', 'n/a', 'info');
+    }
+
+    if (ticketsR.status === 'fulfilled') {
+      const issues = ticketsR.value ?? [];
+      const open = issues.filter((r: any) => (r.fields?.resolution?.name ?? 'Unresolved') === 'Unresolved').length;
+      this.setCard('Tickets', `${open}`, open === 0 ? 'green' : 'info', `of ${issues.length} total`);
+    } else {
+      this.setCard('Tickets', 'n/a', 'info');
+    }
+
+    this.renderBanner(alerts);
+  }
+
+  private renderBanner(alerts: AlertNode[]): void {
+    this.bannerHost.innerHTML = '';
+    this.bannerHost.append(ui.divH([ui.divText('Alerts', 'ua-metrics-panel-title')], 'ua-metrics-panel-header'));
+    if (alerts.length === 0) {
+      this.bannerHost.append(ui.div([ui.divText('Release looks healthy — no blocking alerts.',
+        'ua-metrics-card-sub ua-metrics-green')], 'ua-metrics-grid-host'));
+      return;
+    }
+    const tree = ui.tree();
+    tree.root.classList.add('ua-release-alert-tree');
+    for (const a of alerts) {
+      const total = Object.values(a.groups).reduce((n, xs) => n + xs.length, 0);
+      if (total === 0) {
+        const leaf = tree.item(a.label);
+        leaf.captionLabel.classList.add(BAND_CLASS[a.band]);
+        leaf.root.style.cursor = 'pointer';
+        leaf.root.onclick = () => this.switchTab(a.tab);
+        continue;
+      }
+      const cat = tree.group(`${a.label} (${total})`, null, false);
+      cat.captionLabel.classList.add(BAND_CLASS[a.band]);
+      // Second level: group the tests by package (an empty package key lists items directly).
+      for (const pkg of Object.keys(a.groups).sort()) {
+        const items = a.groups[pkg];
+        if (!items.length)
+          continue;
+        const parent = pkg === '' ? cat : cat.group(`${pkg} (${items.length})`, null, false);
+        for (const it of items.slice(0, 200)) {
+          const node = parent.item(it);
+          node.root.style.cursor = 'pointer';
+          node.root.onclick = () => this.switchTab(a.tab);
+        }
+        if (items.length > 200)
+          parent.item(`… and ${items.length - 200} more`);
+      }
+    }
+    this.bannerHost.append(ui.div([tree.root], 'ua-metrics-grid-host'));
+  }
+}

--- a/packages/UsageAnalysis/src/release/release-handler.ts
+++ b/packages/UsageAnalysis/src/release/release-handler.ts
@@ -1,0 +1,68 @@
+import * as DG from 'datagrok-api/dg';
+import * as ui from 'datagrok-api/ui';
+
+import {UaView} from '../tabs/ua';
+import {StressView} from '../tabs/stress-tests';
+import {VulnerabilitiesView} from '../tabs/vulnerabilities';
+import {ReleaseOverviewView} from './overview';
+import {TestsView} from './tests';
+import {ManualTestsView} from './manual';
+import {ReleaseTicketsView} from './tickets';
+import {ReleaseContext, ENV_CHOICES, DEFAULT_ENV} from './data';
+
+// Assembles the focused /release dashboard: a MultiView of Overview + Tests + Stress +
+// Vulnerabilities + Tickets. Stress and Vulnerabilities are reused verbatim from the main app; all
+// tabs are toolbox-independent, so we skip the shared UaToolbox (markToolboxReady unblocks init).
+export class ReleaseHandler {
+  public static NAME = 'Release';
+  public view: DG.MultiView;
+  private ctx = new ReleaseContext();
+  private envInput: DG.InputBase;
+  private refreshIcon: HTMLElement;
+
+  constructor(path?: string) {
+    this.view = new DG.MultiView({viewFactories: {}});
+    this.view.name = ReleaseHandler.NAME;
+    this.view.box = true;
+
+    this.envInput = ui.input.choice('Environment', {value: this.ctx.env.value, items: ENV_CHOICES,
+      onValueChanged: () => this.ctx.env.next(this.envInput.value ?? DEFAULT_ENV)});
+    this.envInput.setTooltip('Filter builds by the instance they ran on (applies to Overview and Tests)');
+    this.refreshIcon = ui.iconFA('sync-alt', () => this.ctx.refresh.next(), 'Refresh the current data');
+    this.refreshIcon.classList.add('ua-release-ribbon-refresh');
+
+    const overview = new ReleaseOverviewView(this.ctx);
+    overview.switchTab = (name) => this.changeTab(name);
+    const views: UaView[] = [overview, new TestsView(this.ctx), new ManualTestsView(this.ctx),
+      new StressView(undefined, this.ctx), new VulnerabilitiesView(undefined, this.ctx),
+      new ReleaseTicketsView(this.ctx)];
+    for (const v of views) {
+      v.markToolboxReady();
+      this.view.addView(v.name, () => {
+        v.tryToInitViewers(path);
+        return v;
+      }, false);
+    }
+
+    // MultiView overwrites its ribbon with the active child's on every tab switch; child tabs keep their
+    // controls in their own in-view header (empty ribbon), so re-assert the global env picker each time.
+    this.view.tabs.onTabChanged.subscribe(() => {
+      this.view.path = `/${this.view.currentView.name}`.toLowerCase();
+      this.view.setRibbonPanels([[this.envInput.root, this.refreshIcon]]);
+    });
+
+    let startTab = 'Overview';
+    if (path && path.length > 1) {
+      const seg = path.split('/').filter((s) => s !== '')[0];
+      if (seg)
+        startTab = seg[0].toUpperCase() + seg.slice(1);
+    }
+    if (views.some((v) => v.name === startTab))
+      this.changeTab(startTab);
+    this.view.setRibbonPanels([[this.envInput.root, this.refreshIcon]]);
+  }
+
+  changeTab(name: string): void {
+    this.view.tabs.currentPane = this.view.tabs.getPane(name);
+  }
+}

--- a/packages/UsageAnalysis/src/release/tests.ts
+++ b/packages/UsageAnalysis/src/release/tests.ts
@@ -5,7 +5,7 @@ import * as ui from 'datagrok-api/ui';
 import {UaView} from '../tabs/ua';
 import {UaToolbox} from '../ua-toolbox';
 import {fetchReleaseTests, computeTestAlerts, ReleasePivot, ReleaseContext, JENKINS_TEST_JOB, colorStatusCell,
-  COLOR_FAIL_TEXT, waitForWidth, openInWorkspaceIcon,
+  COLOR_FAIL_TEXT, DIM_STATUS_BACK, COLOR_DIM_TEXT, NOT_RUN_BACK, waitForWidth, openInWorkspaceIcon,
   getReleaseMutesSchema, MUTED_VERSIONS, MUTE_ON, MUTE_OFF, parseMutedVersions, isMutedForVersion} from './data';
 
 export class TestsView extends UaView {
@@ -80,13 +80,12 @@ export class TestsView extends UaView {
   private buildSummary(p: ReleasePivot): void {
     const a = computeTestAlerts(p);
     const df = p.df;
-    const latestCol = `${p.latest}`;
     const packageCol = df.getCol('package');
     const mutedCol = df.columns.byName('muted');
     const perPkg = new Map<string, {passed: number, failed: number, skipped: number, notRun: number}>();
     for (let i = 0; i < df.rowCount; i++) {
       const pkg = packageCol.get(i) ?? '';
-      const s = df.get(latestCol, i);
+      const s = df.get('effective_status', i) || 'did not run';
       const muted = !!(mutedCol && mutedCol.get(i) === true);
       const row = perPkg.get(pkg) ?? {passed: 0, failed: 0, skipped: 0, notRun: 0};
       if (s === 'passed') row.passed++;
@@ -142,6 +141,13 @@ export class TestsView extends UaView {
       if (gc.isTableCell && p.statusCols.includes(gc.gridColumn.name)) {
         const v = gc.cell.value as string;
         gc.customText = v === 'passed' ? '+' : v === 'failed' ? '−' : v === 'skipped' ? '·' : '';
+      }
+      // Latest build didn't run this test → show the last known result in that cell, dimmed.
+      if (gc.isTableCell && gc.gridColumn.name === `${p.latest}` && df.get('carried_forward', gc.cell.rowIndex) === true) {
+        const eff = df.get('effective_status', gc.cell.rowIndex) as string;
+        gc.customText = eff === 'passed' ? '+' : eff === 'failed' ? '−' : eff === 'skipped' ? '·' : '';
+        gc.style.backColor = DIM_STATUS_BACK[eff] ?? NOT_RUN_BACK;
+        gc.style.textColor = COLOR_DIM_TEXT;
       }
       // The 'mute' column value already holds the 🔔/🔕 glyph (kept aligned per row); click toggles it.
     });

--- a/packages/UsageAnalysis/src/release/tests.ts
+++ b/packages/UsageAnalysis/src/release/tests.ts
@@ -1,0 +1,291 @@
+import * as DG from 'datagrok-api/dg';
+import * as grok from 'datagrok-api/grok';
+import * as ui from 'datagrok-api/ui';
+
+import {UaView} from '../tabs/ua';
+import {UaToolbox} from '../ua-toolbox';
+import {fetchReleaseTests, computeTestAlerts, ReleasePivot, ReleaseContext, JENKINS_TEST_JOB, colorStatusCell,
+  COLOR_FAIL_TEXT, waitForWidth, openInWorkspaceIcon,
+  getReleaseMutesSchema, MUTED_VERSIONS, MUTE_ON, MUTE_OFF, parseMutedVersions, isMutedForVersion} from './data';
+
+export class TestsView extends UaView {
+  private lastBuildsInput!: DG.InputBase;
+  private summaryHost!: HTMLElement;
+  private gridHost!: HTMLElement;
+  private schema: any = null;
+  private pivot: ReleasePivot | null = null;
+  private summaryDf: DG.DataFrame | null = null;
+  private detailDf: DG.DataFrame | null = null;
+  private grid: DG.Grid | null = null;
+  private persisting = false;
+  private pendingPersist = false;
+  private persistingMutes = false;
+  private pendingMutes = false;
+
+  constructor(private ctx: ReleaseContext, uaToolbox?: UaToolbox) {
+    super(uaToolbox);
+    this.name = 'Tests';
+    this.ctx.env.subscribe(() => { if (this.initialized) this.refresh(); });
+    this.ctx.refresh.subscribe(() => { if (this.initialized) this.refresh(); });
+  }
+
+  async initViewers(): Promise<void> {
+    this.root.className = 'grok-view ui-box ua-metrics ua-metrics-fill';
+    this.lastBuildsInput = ui.input.int('Builds', {value: 5, min: 2, max: 20, onValueChanged: () => this.refresh()});
+    this.summaryHost = ui.div([], 'ua-metrics-grid-host');
+    this.gridHost = ui.div([], 'ua-metrics-grid-host');
+
+    const refreshBtn = ui.bigButton('Refresh', () => this.refresh());
+    refreshBtn.prepend(ui.iconFA('sync-alt'), ' ');
+    refreshBtn.classList.add('ua-metrics-btn-secondary');
+    const header = ui.divH([
+      this.lastBuildsInput.root,
+      ui.div([], {style: {flex: '1'}}), refreshBtn,
+    ], 'ua-metrics-header');
+
+    const summaryPanel = ui.div([
+      ui.divH([ui.divText('Results by package (latest build)', 'ua-metrics-panel-title'),
+        openInWorkspaceIcon(() => this.summaryDf)], 'ua-metrics-panel-header'),
+      this.summaryHost,
+    ], 'ua-metrics-panel');
+    const gridPanel = ui.div([
+      ui.divH([ui.divText('Tests (last builds — status, success & duration sparklines)', 'ua-metrics-panel-title'),
+        openInWorkspaceIcon(() => this.detailDf)], 'ua-metrics-panel-header'),
+      this.gridHost,
+    ], 'ua-metrics-panel ua-metrics-panel-grow');
+
+    this.root.append(ui.div([header, summaryPanel, gridPanel], 'ua-metrics-root'));
+    await this.refresh();
+  }
+
+  private async refresh(): Promise<void> {
+    this.summaryHost.innerHTML = '';
+    this.summaryHost.append(ui.loader());
+    this.gridHost.innerHTML = '';
+    try {
+      this.pivot = await fetchReleaseTests(this.ctx.env.value, this.lastBuildsInput.value ?? 5);
+      if (!this.pivot) {
+        this.summaryHost.innerHTML = '';
+        this.summaryHost.append(ui.divText('No package test runs reported for this instance.', 'ua-metrics-degraded'));
+        return;
+      }
+      this.buildSummary(this.pivot);
+      this.buildGrid(this.pivot);
+    } catch (e) {
+      this.summaryHost.innerHTML = '';
+      this.summaryHost.append(ui.divText(`ReleaseTests failed: ${e}`, 'ua-metrics-degraded'));
+    }
+  }
+
+  private buildSummary(p: ReleasePivot): void {
+    const a = computeTestAlerts(p);
+    const df = p.df;
+    const latestCol = `${p.latest}`;
+    const packageCol = df.getCol('package');
+    const mutedCol = df.columns.byName('muted');
+    const perPkg = new Map<string, {passed: number, failed: number, skipped: number, notRun: number}>();
+    for (let i = 0; i < df.rowCount; i++) {
+      const pkg = packageCol.get(i) ?? '';
+      const s = df.get(latestCol, i);
+      const muted = !!(mutedCol && mutedCol.get(i) === true);
+      const row = perPkg.get(pkg) ?? {passed: 0, failed: 0, skipped: 0, notRun: 0};
+      if (s === 'passed') row.passed++;
+      else if (s === 'failed' && !muted) row.failed++;
+      else if (s === 'skipped') row.skipped++;
+      else if (s !== 'failed') row.notRun++;
+      perPkg.set(pkg, row);
+    }
+    const pkgs = [...perPkg.entries()].sort((x, y) => y[1].failed - x[1].failed || x[0].localeCompare(y[0]));
+    const summary = DG.DataFrame.fromColumns([
+      DG.Column.fromStrings('package', pkgs.map((e) => e[0])),
+      DG.Column.fromInt32Array('passed', Int32Array.from(pkgs.map((e) => e[1].passed))),
+      DG.Column.fromInt32Array('failed', Int32Array.from(pkgs.map((e) => e[1].failed))),
+      DG.Column.fromInt32Array('skipped', Int32Array.from(pkgs.map((e) => e[1].skipped))),
+      DG.Column.fromInt32Array('not run', Int32Array.from(pkgs.map((e) => e[1].notRun))),
+      DG.Column.fromInt32Array('pass rate', Int32Array.from(pkgs.map((e) => {
+        const ran = e[1].passed + e[1].failed; // success rate excludes skipped & not-run
+        return ran > 0 ? Math.floor((e[1].passed / ran) * 100) : 0;
+      }))),
+    ]);
+    summary.name = `By package — ${a.passed}/${a.total} passed, ${a.failed} failing`;
+    this.summaryDf = summary;
+    const grid = DG.Viewer.grid(summary, {showColumnGridlines: false, allowBlockSelection: false});
+    grid.onCellPrepare((gc) => {
+      if (!gc.isTableCell) return;
+      if (gc.gridColumn.name === 'failed' && (gc.cell.value ?? 0) > 0)
+        gc.style.textColor = COLOR_FAIL_TEXT;
+      if (gc.gridColumn.name === 'pass rate') {
+        const v = gc.cell.value ?? 0;
+        gc.style.textColor = v >= 95 ? 0xFF2CA02C : v >= 80 ? 0xFFFFA500 : 0xFFFF5A00;
+      }
+    });
+    this.summaryHost.innerHTML = '';
+    grid.root.style.width = '100%';
+    grid.root.style.height = '100%';
+    this.summaryHost.append(grid.root);
+  }
+
+  private buildGrid(p: ReleasePivot): void {
+    const df = p.df;
+    this.detailDf = df;
+    const grid = DG.Viewer.grid(df, {showColumnGridlines: false, allowBlockSelection: false, showCurrentCellOutline: false});
+    this.grid = grid;
+
+    this.gridHost.innerHTML = '';
+    grid.root.style.width = '100%';
+    grid.root.style.height = '100%';
+    this.gridHost.append(grid.root);
+
+    grid.onCellPrepare((gc) => {
+      colorStatusCell(gc, p.statusCols);
+      // Compact per-build status cells: '+' passed / '−' failed / '·' skipped / blank did-not-run.
+      if (gc.isTableCell && p.statusCols.includes(gc.gridColumn.name)) {
+        const v = gc.cell.value as string;
+        gc.customText = v === 'passed' ? '+' : v === 'failed' ? '−' : v === 'skipped' ? '·' : '';
+      }
+      // The 'mute' column value already holds the 🔔/🔕 glyph (kept aligned per row); click toggles it.
+    });
+    grid.onCellClick.subscribe((gc) => {
+      if (gc.isTableCell && gc.gridColumn.name === 'mute')
+        this.toggleMute(df, gc.cell.rowIndex, p);
+    });
+    df.onCurrentRowChanged.subscribe(() => {
+      if (df.currentRowIdx >= 0)
+        grok.shell.o = this.buildDrilldown(df, df.currentRowIdx, p);
+    });
+    // Persist mute edits (ignore? / ignoreReason) back to the Autotests sticky-meta schema.
+    df.onValuesChanged.subscribe(() => this.persistMute(df));
+
+    // Sparklines + ordering must wait until the grid has a real width, else the grid's layout throws
+    // a "Wrong range" error. Degrade gracefully (raw columns) if it still can't add them.
+    waitForWidth(grid.root).then(() => {
+      try {
+        const passing = grid.columns.add({gridColumnName: 'passing', cellType: 'sparkline'});
+        passing.settings = {columnNames: p.successCols};
+        const duration = grid.columns.add({gridColumnName: 'duration', cellType: 'sparkline'});
+        duration.settings = {columnNames: p.durationCols};
+      } catch (_) { /* grid not ready for sparklines — leave the raw per-build columns visible */ }
+
+      // Show only these, in this order: test → package → passing history (sparkline + per-build status
+      // cells) → duration sparkline → flags. `setVisible` whitelists + orders in one deterministic call.
+      const visible = ['mute', 'test', 'package', 'passing', ...p.statusCols, 'duration',
+        'needs_attention', 'flaky', 'slower', 'owner', 'ignore?', 'ignoreReason'].filter((n) => grid.col(n) != null);
+      grid.columns.setVisible(visible);
+      grid.columns.setOrder(visible);
+
+      const widths: Record<string, number> = {mute: 40, test: 340, package: 130, passing: 100, duration: 100,
+        needs_attention: 92, flaky: 54, slower: 54, owner: 110, 'ignore?': 54, ignoreReason: 150};
+      for (const name of Object.keys(widths)) {
+        const c = grid.col(name);
+        if (c)
+          c.width = widths[name];
+      }
+      for (const s of p.statusCols) {
+        const c = grid.col(s);
+        if (c)
+          c.width = 36;
+      }
+      // Surface the problem tests first so the grid mirrors the Overview alerts.
+      grid.sort(['needs_attention', 'flaky', 'slower', 'package', 'test'], [false, false, false, true, true]);
+    });
+  }
+
+  private buildDrilldown(df: DG.DataFrame, i: number, p: ReleasePivot): HTMLElement {
+    const test = df.get('test', i);
+    const pkg = df.get('package', i);
+    const status = df.get(`${p.latest}`, i);
+    const result = df.get('latest_result', i) ?? '';
+    const commit = df.get('latest_commit', i) ?? '';
+    const resultBox = ui.div([ui.divText(result || 'No output for the latest build.')], 'ua-metrics-degraded');
+    resultBox.style.whiteSpace = 'pre-wrap';
+    resultBox.style.maxHeight = '320px';
+    resultBox.style.overflow = 'auto';
+    return ui.divV([
+      ui.h2(test),
+      ui.tableFromMap({Package: pkg, 'Latest status': status, Commit: commit || '—'}),
+      ui.link('Open test-build in Jenkins', JENKINS_TEST_JOB),
+      ui.divText('Latest build output', 'ua-metrics-panel-title'),
+      resultBox,
+    ]);
+  }
+
+  private async persistMute(df: DG.DataFrame): Promise<void> {
+    const ignore = df.columns.byName('ignore?');
+    if (!ignore)
+      return;
+    if (this.persisting) {
+      this.pendingPersist = true; // an edit landed mid-write — coalesce into one more pass
+      return;
+    }
+    this.persisting = true;
+    try {
+      this.schema ??= (await grok.dapi.stickyMeta.getSchemas()).find((s) => s.name === 'Autotests');
+      if (!this.schema)
+        return;
+      const reason = df.columns.byName('ignoreReason');
+      const n = df.rowCount;
+      do {
+        this.pendingPersist = false;
+        const values = DG.DataFrame.fromColumns([
+          DG.Column.fromList('bool', 'ignore?', Array.from({length: n}, (_, i) => ignore.get(i) === true)),
+          DG.Column.fromStrings('ignoreReason', Array.from({length: n}, (_, i) => reason?.get(i) ?? '')),
+        ]);
+        await grok.dapi.stickyMeta.setAllValues(this.schema, df.getCol('test'), values);
+      } while (this.pendingPersist);
+    } finally {
+      this.persisting = false;
+    }
+  }
+
+  /** Toggles the current release version in the clicked test's mute list, updates derived flags, and persists. */
+  private async toggleMute(df: DG.DataFrame, row: number, p: ReleasePivot): Promise<void> {
+    if (!p.version) {
+      grok.shell.warning('No release version detected for the latest build — cannot mute.');
+      return;
+    }
+    const mvCol = df.columns.byName(MUTED_VERSIONS) ?? df.columns.addNewString(MUTED_VERSIONS);
+    const versions = parseMutedVersions(mvCol.get(row));
+    const at = versions.indexOf(p.version);
+    if (at >= 0)
+      versions.splice(at, 1);
+    else
+      versions.push(p.version);
+    mvCol.set(row, versions.join(';'));
+
+    const mutedForVersion = isMutedForVersion(mvCol.get(row), p.version);
+    const globallyIgnored = df.columns.byName('ignore?')?.get(row) === true;
+    const muted = mutedForVersion || globallyIgnored;
+    df.getCol('mutedForVersion').set(row, mutedForVersion);
+    df.getCol('muted').set(row, muted);
+    df.getCol('mute').set(row, mutedForVersion ? MUTE_ON : MUTE_OFF);
+    df.getCol('needs_attention').set(row, df.get('failing', row) === true && !muted);
+    this.grid?.invalidate(); // repaint the toggled glyph immediately
+    this.buildSummary(p); // muting changes the per-package pass/fail counts
+    await this.persistReleaseMutes(df);
+  }
+
+  /** Persists the mutedVersions column back to the ReleaseMutes sticky-meta schema (coalesced). */
+  private async persistReleaseMutes(df: DG.DataFrame): Promise<void> {
+    const mvCol = df.columns.byName(MUTED_VERSIONS);
+    if (!mvCol)
+      return;
+    if (this.persistingMutes) {
+      this.pendingMutes = true;
+      return;
+    }
+    this.persistingMutes = true;
+    try {
+      const schema = await getReleaseMutesSchema();
+      const n = df.rowCount;
+      do {
+        this.pendingMutes = false;
+        const values = DG.DataFrame.fromColumns([
+          DG.Column.fromStrings(MUTED_VERSIONS, Array.from({length: n}, (_, i) => mvCol.get(i) ?? '')),
+        ]);
+        await grok.dapi.stickyMeta.setAllValues(schema, df.getCol('test'), values);
+      } while (this.pendingMutes);
+    } finally {
+      this.persistingMutes = false;
+    }
+  }
+}

--- a/packages/UsageAnalysis/src/release/tickets.ts
+++ b/packages/UsageAnalysis/src/release/tickets.ts
@@ -1,0 +1,105 @@
+import * as DG from 'datagrok-api/dg';
+import * as grok from 'datagrok-api/grok';
+import * as ui from 'datagrok-api/ui';
+
+import {UaView} from '../tabs/ua';
+import {UaToolbox} from '../ua-toolbox';
+import {defaultNextVersion, JIRA_BROWSE, ReleaseContext, openInWorkspaceIcon} from './data';
+
+interface JiraIssue { key: string; fields: Record<string, any>; }
+
+/** Builds the JiraConnect filter object for the next-release fixVersion (equality-only JQL builder). */
+export function fixVersionFilter(version: string): Record<string, string> {
+  return {project: 'GROK', fixVersion: `"${version}"`};
+}
+
+export async function fetchReleaseTickets(version: string): Promise<JiraIssue[]> {
+  return await grok.functions.call('JiraConnect:GetJiraTicketsByFilter', {filter: fixVersionFilter(version)});
+}
+
+export function ticketsToDataFrame(issues: JiraIssue[]): DG.DataFrame {
+  const str = (get: (r: JiraIssue) => any) => issues.map((r) => `${get(r) ?? ''}`);
+  const df = DG.DataFrame.fromColumns([
+    DG.Column.fromStrings('ticket', issues.map((r) => `<a href="${JIRA_BROWSE}${r.key}" target="_blank">${r.key}</a>`)),
+    DG.Column.fromStrings('summary', str((r) => r.fields.summary)),
+    DG.Column.fromStrings('status', str((r) => r.fields.status?.name)),
+    DG.Column.fromStrings('priority', str((r) => r.fields.priority?.name)),
+    DG.Column.fromStrings('assignee', str((r) => r.fields.assignee?.displayName)),
+    DG.Column.fromStrings('resolution', issues.map((r) => r.fields.resolution?.name ?? 'Unresolved')),
+    DG.Column.fromStrings('type', str((r) => r.fields.issuetype?.name)),
+  ]);
+  df.name = 'Release tickets';
+  df.getCol('ticket').setTag('cell.renderer', 'html');
+  return df;
+}
+
+export class ReleaseTicketsView extends UaView {
+  private versionInput!: DG.InputBase;
+  private gridHost!: HTMLElement;
+  private titleLabel!: HTMLElement;
+  private ticketsDf: DG.DataFrame | null = null;
+
+  constructor(private ctx: ReleaseContext, uaToolbox?: UaToolbox) {
+    super(uaToolbox);
+    this.name = 'Tickets';
+    this.ctx.refresh.subscribe(() => { if (this.initialized) this.refresh(); });
+  }
+
+  async initViewers(): Promise<void> {
+    this.root.className = 'grok-view ui-box ua-metrics ua-metrics-fill';
+    this.versionInput = ui.input.string('Fix version', {value: defaultNextVersion(), onValueChanged: () => this.refresh()});
+    this.titleLabel = ui.divText('Tickets marked for the next release', 'ua-metrics-panel-title');
+    this.gridHost = ui.div([], 'ua-metrics-grid-host');
+
+    const refreshBtn = ui.bigButton('Refresh', () => this.refresh());
+    refreshBtn.prepend(ui.iconFA('sync-alt'), ' ');
+    refreshBtn.classList.add('ua-metrics-btn-secondary');
+    const header = ui.divH([
+      this.versionInput.root, ui.div([], {style: {flex: '1'}}), refreshBtn,
+    ], 'ua-metrics-header');
+
+    const panel = ui.div([ui.divH([this.titleLabel, openInWorkspaceIcon(() => this.ticketsDf)], 'ua-metrics-panel-header'),
+      this.gridHost], 'ua-metrics-panel ua-metrics-panel-grow');
+    this.root.append(ui.div([header, panel], 'ua-metrics-root'));
+    await this.refresh();
+  }
+
+  private async refresh(): Promise<void> {
+    const version = (this.versionInput.value ?? '').trim();
+    this.gridHost.innerHTML = '';
+    this.gridHost.append(ui.loader());
+    if (!version) {
+      this.gridHost.innerHTML = '';
+      this.gridHost.append(ui.divText('Enter the next-release fix version.', 'ua-metrics-degraded'));
+      return;
+    }
+    try {
+      const issues = await fetchReleaseTickets(version);
+      this.gridHost.innerHTML = '';
+      if (!issues || issues.length === 0) {
+        this.gridHost.append(ui.divText(
+          `No GROK tickets with fixVersion "${version}" (or JiraConnect credentials are not configured on this server).`,
+          'ua-metrics-degraded'));
+        this.titleLabel.textContent = `fixVersion "${version}" — 0 tickets`;
+        return;
+      }
+      const df = ticketsToDataFrame(issues);
+      this.ticketsDf = df;
+      const open = issues.filter((r) => (r.fields.resolution?.name ?? 'Unresolved') === 'Unresolved').length;
+      this.titleLabel.textContent = `fixVersion "${version}" — ${issues.length} tickets, ${open} unresolved`;
+      const grid = DG.Viewer.grid(df, {showColumnGridlines: false, allowBlockSelection: false});
+      grid.sort(['status', 'priority'], [true, true]);
+      const summaryCol = grid.col('summary');
+      if (summaryCol)
+        summaryCol.width = 360;
+      grid.root.style.width = '100%';
+      grid.root.style.height = '100%';
+      this.gridHost.append(grid.root);
+    } catch (e) {
+      this.gridHost.innerHTML = '';
+      this.gridHost.append(ui.divText(
+        `Could not reach JiraConnect (${e}). Install the JiraConnect package and configure Jira credentials.`,
+        'ua-metrics-degraded'));
+    }
+  }
+}

--- a/packages/UsageAnalysis/src/tabs/stress-tests.ts
+++ b/packages/UsageAnalysis/src/tabs/stress-tests.ts
@@ -4,31 +4,36 @@ import * as ui from 'datagrok-api/ui';
 import {UaToolbox} from '../ua-toolbox';
 import {UaView} from './ua';
 import {queries} from '../package-api';
+import {stressRegression, openInWorkspaceIcon, ReleaseContext} from '../release/data';
 
 const LAST_BUILDS = 20;
 
 export class StressView extends UaView {
   private byBuildHost!: HTMLElement;
   private summaryHost!: HTMLElement;
-  private scatterHost!: HTMLElement;
-  private scatterHeader!: HTMLElement;
+  private boxHost!: HTMLElement;
+  private boxHeader!: HTMLElement;
+  private regressionHost!: HTMLElement;
+  private summaryDf: DG.DataFrame | null = null;
 
-  constructor(uaToolbox?: UaToolbox) {
+  constructor(uaToolbox?: UaToolbox, ctx?: ReleaseContext) {
     super(uaToolbox);
     this.name = 'Stress';
+    ctx?.refresh.subscribe(() => { if (this.initialized) this.refresh(); });
   }
 
   async initViewers(): Promise<void> {
     this.root.className = 'grok-view ui-box ua-metrics';
-    this.byBuildHost = ui.div([], 'ua-metrics-grid-host');
+    this.byBuildHost = ui.div([], 'ua-metrics-grid-host ua-metrics-chart-host');
     this.summaryHost = ui.div([], 'ua-metrics-grid-host');
-    this.scatterHost = ui.div([], 'ua-metrics-grid-host');
-    this.scatterHeader = ui.divText('Last build', 'ua-metrics-panel-title');
+    this.boxHost = ui.div([], 'ua-metrics-grid-host ua-metrics-chart-host');
+    this.boxHeader = ui.divText('Last build', 'ua-metrics-panel-title');
 
+    this.regressionHost = ui.div([], 'ua-metrics-asof');
     const refreshBtn = ui.bigButton('Refresh', () => this.refresh());
     refreshBtn.prepend(ui.iconFA('sync-alt'), ' ');
     refreshBtn.classList.add('ua-metrics-btn-secondary');
-    const header = ui.divH([ui.div([], {style: {flex: '1'}}), refreshBtn], 'ua-metrics-header');
+    const header = ui.divH([this.regressionHost, ui.div([], {style: {flex: '1'}}), refreshBtn], 'ua-metrics-header');
 
     const byBuildPanel = ui.div([
       ui.divH([ui.divText(`Median duration by build (last ${LAST_BUILDS}, split by threads)`, 'ua-metrics-panel-title')],
@@ -36,20 +41,21 @@ export class StressView extends UaView {
       this.byBuildHost,
     ], 'ua-metrics-panel');
     const summaryPanel = ui.div([
-      ui.divH([ui.divText('Metrics by build × threads', 'ua-metrics-panel-title')], 'ua-metrics-panel-header'),
+      ui.divH([ui.divText('Metrics by build × threads', 'ua-metrics-panel-title'),
+        openInWorkspaceIcon(() => this.summaryDf)], 'ua-metrics-panel-header'),
       this.summaryHost,
     ], 'ua-metrics-panel');
-    const scatterPanel = ui.div([
-      ui.divH([this.scatterHeader], 'ua-metrics-panel-header'),
-      this.scatterHost,
+    const boxPanel = ui.div([
+      ui.divH([this.boxHeader], 'ua-metrics-panel-header'),
+      this.boxHost,
     ], 'ua-metrics-panel');
 
-    this.root.append(ui.div([header, byBuildPanel, scatterPanel, summaryPanel], 'ua-metrics-root'));
+    this.root.append(ui.div([header, byBuildPanel, boxPanel, summaryPanel], 'ua-metrics-root'));
     await this.refresh();
   }
 
   private async refresh(): Promise<void> {
-    await Promise.all([this.loadSummary(), this.loadScatter()]);
+    await Promise.all([this.loadSummary(), this.loadBox()]);
   }
 
   private static mount(host: HTMLElement, el: HTMLElement, height: string): void {
@@ -65,11 +71,15 @@ export class StressView extends UaView {
     this.summaryHost.innerHTML = '';
     try {
       const df = await queries.stressTestsSummary(LAST_BUILDS);
+      this.summaryDf = df;
       if (df.rowCount === 0) {
         this.byBuildHost.innerHTML = '';
         this.byBuildHost.append(ui.divText('No stress runs reported yet.', 'ua-metrics-degraded'));
         return;
       }
+      const reg = stressRegression(df);
+      this.regressionHost.textContent = reg.detail;
+      this.regressionHost.className = `ua-metrics-asof ${reg.regressed ? 'ua-metrics-red' : 'ua-metrics-green'}`;
       df.columns.addNewString('threads ').init((i) => `${df.get('threads', i)} threads`);
       const line = DG.Viewer.lineChart(df, {
         xColumnName: 'build',
@@ -89,28 +99,31 @@ export class StressView extends UaView {
     }
   }
 
-  private async loadScatter(): Promise<void> {
-    this.scatterHost.innerHTML = '';
-    this.scatterHost.append(ui.loader());
+  private async loadBox(): Promise<void> {
+    this.boxHost.innerHTML = '';
+    this.boxHost.append(ui.loader());
     try {
       const df = await queries.stressTestsRaw(null);
-      this.scatterHost.innerHTML = '';
+      this.boxHost.innerHTML = '';
       if (df.rowCount === 0) {
-        this.scatterHost.append(ui.divText('No stress runs in the latest build.', 'ua-metrics-degraded'));
+        this.boxHost.append(ui.divText('No stress runs in the latest build.', 'ua-metrics-degraded'));
         return;
       }
-      this.scatterHeader.textContent =
-        `Last build: duration vs threads (${df.rowCount} runs, ${df.getCol('test').categories.length} tests)`;
-      const scatter = DG.Viewer.scatterPlot(df, {
-        xColumnName: 'threads',
-        yColumnName: 'ms',
-        colorColumnName: 'passed',
-        yAxisType: 'logarithmic',
+      // Zero-padded thread count so the categorical axis sorts numerically (008 < 016 < 032).
+      const threads = df.getCol('threads');
+      df.columns.addNewString('threads_string').init((i) => `${threads.get(i) ?? ''}`.padStart(3, '0'));
+      this.boxHeader.textContent =
+        `Last build: duration distribution by threads (${df.rowCount} runs, ${df.getCol('test').categories.length} tests)`;
+      const box = DG.Viewer.boxPlot(df, {
+        valueColumnName: 'ms',
+        categoryColumnNames: ['threads_string'],
+        markerColorColumnName: 'passed',
+        axisType: 'logarithmic',
       });
-      StressView.mount(this.scatterHost, scatter.root, '360px');
+      StressView.mount(this.boxHost, box.root, '360px');
     } catch (e) {
-      this.scatterHost.innerHTML = '';
-      this.scatterHost.append(ui.divText(`StressTestsRaw failed: ${e}`, 'ua-metrics-degraded'));
+      this.boxHost.innerHTML = '';
+      this.boxHost.append(ui.divText(`StressTestsRaw failed: ${e}`, 'ua-metrics-degraded'));
     }
   }
 }

--- a/packages/UsageAnalysis/src/tabs/ua.ts
+++ b/packages/UsageAnalysis/src/tabs/ua.ts
@@ -36,6 +36,12 @@ export class UaView extends DG.ViewBase {
     this._resolveToolbox();
   }
 
+  // Unblocks initViewers() for toolbox-independent hosts (e.g. the Release app), which reuse
+  // toolbox-free tabs (Stress, Vulnerabilities, ...) without building the shared UaToolbox.
+  markToolboxReady() {
+    this._resolveToolbox();
+  }
+
   async tryToInitViewers(path?: string): Promise<void> {
     await this._toolboxReady;
     if (!this.initialized) {

--- a/packages/UsageAnalysis/src/tabs/vulnerabilities.ts
+++ b/packages/UsageAnalysis/src/tabs/vulnerabilities.ts
@@ -4,6 +4,7 @@ import * as ui from 'datagrok-api/ui';
 
 import {UaToolbox} from '../ua-toolbox';
 import {UaView} from './ua';
+import {openInWorkspaceIcon, ReleaseContext} from '../release/data';
 
 export const VEX_INDEX_URL = 'https://data.datagrok.ai/vex/index.json';
 
@@ -51,15 +52,55 @@ export async function fetchVexImages(): Promise<VexImage[]> {
   return [...(index.services ?? []), ...(index.bleeding_edge ?? [])];
 }
 
-/** Dashboard flavor: core images are represented by their bleeding-edge scan
- * (the next-release state); packages/tools keep the latest released scan. */
-export async function fetchVexDashboardImages(): Promise<VexImage[]> {
-  const resp = await grok.dapi.fetchProxy(VEX_INDEX_URL);
-  const index = await resp.json();
-  const services: VexImage[] = index.services ?? [];
-  const bleedingEdge: VexImage[] = index.bleeding_edge ?? [];
+/** Total CRITICAL and HIGH findings across the given VEX images (for the Release overview). */
+export function criticalHighCount(images: VexImage[]): {critical: number, high: number} {
+  return images.reduce((a, r) => ({critical: a.critical + (r.critical ?? 0), high: a.high + (r.high ?? 0)}),
+    {critical: 0, high: 0});
+}
+
+export interface VexDelta {
+  newCritical: number;
+  newHigh: number;
+  images: {repo: string, dCritical: number, dHigh: number}[];
+}
+
+/** CRITICAL/HIGH increase of the bleeding-edge images over their previously released version
+ * (same repo in the release channel) — i.e. what the next release would newly introduce. */
+export function vexReleaseDelta(services: VexImage[], bleedingEdge: VexImage[]): VexDelta {
+  const relByRepo = new Map<string, VexImage>();
+  for (const r of services)
+    if (!relByRepo.has(r.repo))
+      relByRepo.set(r.repo, r);
+  const d: VexDelta = {newCritical: 0, newHigh: 0, images: []};
+  for (const be of bleedingEdge) {
+    const rel = relByRepo.get(be.repo);
+    const dCritical = (be.critical ?? 0) - (rel?.critical ?? 0);
+    const dHigh = (be.high ?? 0) - (rel?.high ?? 0);
+    if (dCritical > 0 || dHigh > 0) {
+      d.newCritical += Math.max(0, dCritical);
+      d.newHigh += Math.max(0, dHigh);
+      d.images.push({repo: be.repo, dCritical, dHigh});
+    }
+  }
+  return d;
+}
+
+/** Dashboard flavor: core images are represented by their bleeding-edge scan (the next-release
+ * state) — the release-channel core scan is dropped; packages/tools keep the latest released scan. */
+export function toDashboardImages(services: VexImage[], bleedingEdge: VexImage[]): VexImage[] {
   const beRepos = new Set(bleedingEdge.map((r) => r.repo));
   return [...bleedingEdge, ...services.filter((r) => !(r.category === 'core' && beRepos.has(r.repo)))];
+}
+
+export async function fetchVexIndex(): Promise<{services: VexImage[], bleedingEdge: VexImage[]}> {
+  const resp = await grok.dapi.fetchProxy(VEX_INDEX_URL);
+  const index = await resp.json();
+  return {services: index.services ?? [], bleedingEdge: index.bleeding_edge ?? []};
+}
+
+export async function fetchVexDashboardImages(): Promise<VexImage[]> {
+  const {services, bleedingEdge} = await fetchVexIndex();
+  return toDashboardImages(services, bleedingEdge);
 }
 
 export class VulnerabilitiesView extends UaView {
@@ -69,10 +110,13 @@ export class VulnerabilitiesView extends UaView {
   private detailsHeader!: HTMLElement;
   private asOfLabel!: HTMLElement;
   private cards = new Map<string, HTMLElement>();
+  private summaryDf: DG.DataFrame | null = null;
+  private detailsDf: DG.DataFrame | null = null;
 
-  constructor(uaToolbox?: UaToolbox) {
+  constructor(uaToolbox?: UaToolbox, ctx?: ReleaseContext) {
     super(uaToolbox);
     this.name = 'Vulnerabilities';
+    ctx?.refresh.subscribe(() => { if (this.initialized) this.refresh(); });
   }
 
   async initViewers(): Promise<void> {
@@ -98,11 +142,12 @@ export class VulnerabilitiesView extends UaView {
       ['critical', 'high', 'medium', 'low'].map((s) => this.makeCard(s)), 'ua-metrics-cards-row');
 
     const summaryPanel = ui.div([
-      ui.divH([ui.divText('Scanned images (VEX)', 'ua-metrics-panel-title')], 'ua-metrics-panel-header'),
+      ui.divH([ui.divText('Scanned images (VEX)', 'ua-metrics-panel-title'),
+        openInWorkspaceIcon(() => this.summaryDf)], 'ua-metrics-panel-header'),
       this.summaryHost,
     ], 'ua-metrics-panel');
     const detailsPanel = ui.div([
-      ui.divH([this.detailsHeader], 'ua-metrics-panel-header'),
+      ui.divH([this.detailsHeader, openInWorkspaceIcon(() => this.detailsDf)], 'ua-metrics-panel-header'),
       this.detailsHost,
     ], 'ua-metrics-panel');
 
@@ -115,7 +160,7 @@ export class VulnerabilitiesView extends UaView {
     const root = ui.div([
       ui.divText(severity[0].toUpperCase() + severity.slice(1), 'ua-metrics-card-title'),
       value,
-      ui.divText('released images', 'ua-metrics-card-sub'),
+      ui.divText('scanned images', 'ua-metrics-card-sub'),
     ], 'ua-metrics-card');
     this.cards.set(severity, value);
     return root;
@@ -129,11 +174,12 @@ export class VulnerabilitiesView extends UaView {
       const index = await resp.json();
       const services: VexImage[] = index.services ?? [];
       const bleedingEdge: VexImage[] = index.bleeding_edge ?? [];
-      this.images = [...services, ...bleedingEdge];
+      // Core images: show only their bleeding-edge scan, excluding the release-channel core scan.
+      this.images = toDashboardImages(services, bleedingEdge);
       this.asOfLabel.textContent = `as of ${index.generated ?? '—'}`;
 
       for (const s of ['critical', 'high', 'medium', 'low']) {
-        const total = services.reduce((acc, r) => acc + ((r as any)[s] ?? 0), 0);
+        const total = this.images.reduce((acc, r) => acc + ((r as any)[s] ?? 0), 0);
         this.cards.get(s)!.textContent = `${total}`;
       }
 
@@ -152,6 +198,7 @@ export class VulnerabilitiesView extends UaView {
   private buildSummaryGrid(): HTMLElement {
     const rows = this.images;
     const df = vexImagesToDataFrame(rows);
+    this.summaryDf = df;
     df.onCurrentRowChanged.subscribe(() => {
       if (df.currentRowIdx >= 0)
         this.loadDetails(rows[df.currentRowIdx]);
@@ -162,7 +209,7 @@ export class VulnerabilitiesView extends UaView {
       'allowBlockSelection': false,
       'showCurrentCellOutline': false,
     });
-    grid.sort(['critical', 'high', 'medium'], [false, false, false]);
+    grid.sort(['category', 'critical', 'high'], [true, false, false]);
     const descCol = grid.col('description');
     if (descCol)
       descCol.width = 320;
@@ -207,6 +254,7 @@ export class VulnerabilitiesView extends UaView {
       }
       const df = DG.DataFrame.fromCsv(csv);
       df.name = `${image.repo}:${image.tag} CVEs`;
+      this.detailsDf = df;
       const grid = DG.Viewer.grid(df, {'showColumnGridlines': false});
       grid.root.style.width = '100%';
       grid.root.style.height = '100%';


### PR DESCRIPTION
## Summary
Consolidates the dev-only `/release` readiness dashboard in **UsageAnalysis** plus the **JiraConnect** endpoint migration it depends on. Already debug-published and verified on dev.

### UsageAnalysis — `/release` dashboard
- **Ribbon**: global Environment (instance) picker + global Refresh, shared across all tabs
- **Tests**: fill-height grid; `+`/`−` status cells; newest build on the right; per-row 🔔/🔕 **version-bound mute** (mutes a test for the current release version; stored in a dedicated `ReleaseMutes` sticky-meta schema so it never touches the shared `Autotests` schema); counts use the **latest CI/CD run per test** (fixes retry-inflated failing counts)
- **Stress**: box plot of duration by zero-padded `threads_string` (log axis); fixed clipped charts
- **Tickets**: full-page grid
- **ReleaseTests query**: `latest_runs` (rn=1) + `ci_cd` + instance filter; dropped the daily cache

### JiraConnect
- `loadIssues` migrated to the token-paginated `/rest/api/3/search/jql` (Atlassian removed the legacy `/rest/api/3/search` → HTTP 410)

## Verification (dev)
- Tests/Stress/Tickets/Overview render; env switch refreshes env-scoped cards; ribbon refresh reloads tabs
- Version-bound mute: muting a failing test drops it from the count and persists across reload
- Failing count deduped: latest build returns one row per test (no retries)
- JiraConnect: fixVersion 1.28.0 → 419 tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)