### PR TITLE
UsageAnalysis Release: stale-test alert + separate mute

### DIFF
--- a/packages/UsageAnalysis/CHANGELOG.md
+++ b/packages/UsageAnalysis/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Release: Tests tab — per-row mute icon (🔔/🔕) mutes a test for the current release version; version-bound mutes are stored in a dedicated ReleaseMutes sticky-meta schema and drop the test out of the failing/unstable/needs-attention counts for that version
 * Release: Tickets tab — the tickets grid now fills the page
 * Release: Tests tab — when a test didn't run in the latest build, its last known result is carried forward (shown dimmed) and used for the failing/pass-rate counts
+* Release: Added a "not run for 7+ days" stale-test alert (Overview + a stale_days column), with a separate per-row mute independent of the failing mute; ReleaseTests now returns each test's last run date over a 14-day lookback
 * Release: Added a global Refresh button to the dashboard ribbon that reloads every tab
 * Release: ReleaseTests now counts the latest CI/CD run per test (like TestsDashboard) instead of every test_run — retried-then-passed tests no longer count as failing and non-CI runs are excluded, so the failing counts stop being inflated by reruns
 * Release: Tests tab — the detail grid now fills the page; per-build status cells show `+` (passed) / `−` (failed) / `·` (skipped)

--- a/packages/UsageAnalysis/queries/release_tests.sql
+++ b/packages/UsageAnalysis/queries/release_tests.sql
@@ -35,7 +35,15 @@ latest_runs AS (
     AND r.build_name IN (SELECT build_name FROM recent)
 ),
 active_tests AS (
-  SELECT DISTINCT test_name FROM latest_runs WHERE rn = 1 AND passed IS NOT NULL
+  -- Tests that ran on this instance in the last 14 days, with their most recent CI run date.
+  -- Broadened beyond the build window so tests that recently STOPPED running are still surfaced
+  -- (for the "not run for >= N days" staleness alert); last_run drives that check client-side.
+  SELECT r.test_name, MAX(r.date_time) AS last_run
+  FROM test_runs r
+  WHERE NOT r.stress_test AND NOT r.benchmark AND r.ci_cd AND r.passed IS NOT NULL
+    AND r.instance LIKE 'https://' || @instanceFilter || '.datagrok.ai'
+    AND r.date_time >= now() - interval '14 days'
+  GROUP BY r.test_name
 )
 SELECT
   COALESCE(p.name, t.package) AS package,
@@ -46,6 +54,7 @@ SELECT
   b.commit AS build_commit,
   b.build_date,
   r.instance,
+  act.last_run,
   CASE WHEN r.passed IS NULL THEN 'did not run'
        WHEN r.skipped THEN 'skipped'
        WHEN r.passed THEN 'passed'
@@ -58,6 +67,7 @@ FROM tests t
 CROSS JOIN indexed_builds b
 LEFT JOIN latest_runs r
   ON r.test_name = t.name AND r.build_name = b.build_name AND r.rn = 1
+LEFT JOIN active_tests act ON act.test_name = t.name
 LEFT JOIN published_packages p ON p.name = t.package AND p.is_current
 WHERE t.type <> 'manual'
   AND t.name IN (SELECT test_name FROM active_tests)

--- a/packages/UsageAnalysis/src/release/data.ts
+++ b/packages/UsageAnalysis/src/release/data.ts
@@ -28,35 +28,50 @@ export class ReleaseContext {
 // Version-bound test muting. A test is muted for a specific release version; the mute list lives in its
 // own sticky-meta schema (semtype=autotest) so it never touches the shared 'Autotests' schema.
 export const RELEASE_MUTES_SCHEMA = 'ReleaseMutes';
-export const MUTED_VERSIONS = 'mutedVersions';
+export const MUTED_VERSIONS = 'mutedVersions';           // failing-alert mute (version-bound)
+export const STALE_MUTED_VERSIONS = 'staleMutedVersions'; // stale-alert mute (version-bound, independent)
 export const MUTE_ON = '🔕';  // muted for this release
 export const MUTE_OFF = '🔔'; // active (click to mute)
+export const STALE_DAYS = 7;  // "not run for a week or more"
 let _mutesSchemaPromise: Promise<any> | null = null;
 
-/** The release-mute sticky-meta schema, created on first use. Promise-cached so the Overview and Tests
- * tabs (which both fetch on load) can't race into two createSchema calls; recovers if one loses the race. */
+/** The release-mute sticky-meta schema (fields: mutedVersions, staleMutedVersions), created/migrated on
+ * first use. Promise-cached so the Overview and Tests tabs (both fetch on load) can't race into two
+ * createSchema calls; recovers if one loses the race, and adds staleMutedVersions to a pre-existing schema. */
 export function getReleaseMutesSchema(): Promise<any> {
   _mutesSchemaPromise ??= (async () => {
     let schemas = await grok.dapi.stickyMeta.getSchemas();
     let schema = schemas.find((s) => s.name === RELEASE_MUTES_SCHEMA);
     if (schema)
-      return schema;
+      return await ensureStaleField(schema);
     try {
       // Entity-type name must be globally unique across schemas (the shared 'Autotests' schema owns
       // 'autotest'), so use a distinct name while still matching the same autotest-semtype column.
       return await grok.dapi.stickyMeta.createSchema(RELEASE_MUTES_SCHEMA,
-        [{name: 'releaseMuteAutotest', matchBy: 'semtype=autotest'}], [{name: MUTED_VERSIONS, type: DG.TYPE.STRING}]);
+        [{name: 'releaseMuteAutotest', matchBy: 'semtype=autotest'}],
+        [{name: MUTED_VERSIONS, type: DG.TYPE.STRING}, {name: STALE_MUTED_VERSIONS, type: DG.TYPE.STRING}]);
     } catch (e) {
       // A concurrent caller created it first — re-fetch before giving up.
       schemas = await grok.dapi.stickyMeta.getSchemas();
       schema = schemas.find((s) => s.name === RELEASE_MUTES_SCHEMA);
       if (schema)
-        return schema;
+        return await ensureStaleField(schema);
       _mutesSchemaPromise = null; // allow a later retry on a genuine failure
       throw e;
     }
   })();
   return _mutesSchemaPromise;
+}
+
+/** Adds the staleMutedVersions property to a pre-existing ReleaseMutes schema (migration). */
+async function ensureStaleField(schema: any): Promise<any> {
+  if (schema.properties.some((p: any) => p.name === STALE_MUTED_VERSIONS))
+    return schema;
+  try {
+    schema.properties = [...schema.properties, DG.EntityProperty.create(STALE_MUTED_VERSIONS, DG.TYPE.STRING)];
+    await grok.dapi.stickyMeta.saveSchema(schema);
+  } catch (_) { /* field may already exist from a concurrent migration — safe to ignore */ }
+  return schema;
 }
 
 /** Extracts the release version (e.g. '1.28.0') from a build name like '2026-07-15-1.28.0.BE-3'. */
@@ -153,9 +168,11 @@ export interface TestAlerts {
   flaky: number;
   slower: number;
   passRate: number; // 0..100 over the latest build: passed / (passed + failed), excluding skipped & did-not-run
+  stale: number; // tests not run for >= STALE_DAYS (unmuted)
   failingByPkg: Record<string, string[]>;
   slowerByPkg: Record<string, string[]>;
   flakyByPkg: Record<string, string[]>;
+  staleByPkg: Record<string, string[]>;
 }
 
 function pushByPkg(map: Record<string, string[]>, pkg: string, test: string): void {
@@ -271,6 +288,21 @@ export async function fetchReleaseTests(instanceFilter: string, lastBuildsNum: n
     if (Number(biCol.get(i)) === latest) { latestBuildName = buildCol.get(i) ?? ''; break; }
   const version = versionFromBuild(latestBuildName);
 
+  // Most recent run date per test (ms) → staleness. last_run is constant per test in the raw result.
+  const nowMs = Date.now();
+  const lastRunByTest = new Map<string, number>();
+  const rawTestCol = raw.getCol('test');
+  const rawLastRun = raw.columns.byName('last_run');
+  if (rawLastRun) {
+    for (let i = 0; i < raw.rowCount; i++) {
+      const t = rawTestCol.get(i);
+      if (!lastRunByTest.has(t)) {
+        const v: any = rawLastRun.get(i);
+        lastRunByTest.set(t, v == null ? NaN : (v.valueOf ? Number(v.valueOf()) : Number(v)));
+      }
+    }
+  }
+
   const schemas = await grok.dapi.stickyMeta.getSchemas();
   const schema = schemas.find((s) => s.name === 'Autotests');
   pivot.getCol('test').semType = 'autotest';
@@ -303,6 +335,24 @@ export async function fetchReleaseTests(instanceFilter: string, lastBuildsNum: n
   pivot.columns.addNewBool('needs_attention')
     .init((i) => pivot.get('failing', i) && !pivot.get('muted', i));
 
+  // Staleness: tests not run for >= STALE_DAYS. Its mute is separate (staleMutedVersions) from the failing mute.
+  const testColP = pivot.getCol('test');
+  const smvCol = mutes.col(STALE_MUTED_VERSIONS);
+  if (smvCol)
+    pivot.columns.add(smvCol);
+  const staleMutedVersionsCol = pivot.columns.byName(STALE_MUTED_VERSIONS);
+  pivot.columns.addNewInt('stale_days').init((i) => {
+    const lr = lastRunByTest.get(testColP.get(i));
+    return (lr == null || isNaN(lr)) ? 0 : Math.floor((nowMs - lr) / 86400000);
+  });
+  pivot.columns.addNewBool('stale').init((i) => pivot.get('stale_days', i) >= STALE_DAYS);
+  pivot.columns.addNewBool('staleMutedForVersion').init((i) => isMutedForVersion(staleMutedVersionsCol?.get(i), version));
+  pivot.columns.addNewBool('stale_alert')
+    .init((i) => pivot.get('stale', i) === true && pivot.get('staleMutedForVersion', i) !== true);
+  // Toggle glyph only for stale tests (blank otherwise).
+  pivot.columns.addNewString('staleMute')
+    .init((i) => pivot.get('stale', i) !== true ? '' : (pivot.get('staleMutedForVersion', i) === true ? MUTE_ON : MUTE_OFF));
+
   pivot.name = 'Release tests';
   return {df: pivot, buildIndexes, latest, statusCols, durationCols, successCols, resultCols, version};
 }
@@ -311,7 +361,7 @@ export async function fetchReleaseTests(instanceFilter: string, lastBuildsNum: n
 export function computeTestAlerts(p: ReleasePivot): TestAlerts {
   const df = p.df;
   const a: TestAlerts = {total: 0, passed: 0, failed: 0, skipped: 0, notRun: 0, flaky: 0, slower: 0,
-    passRate: 0, failingByPkg: {}, slowerByPkg: {}, flakyByPkg: {}};
+    passRate: 0, stale: 0, failingByPkg: {}, slowerByPkg: {}, flakyByPkg: {}, staleByPkg: {}};
   const testCol = df.getCol('test');
   const pkgCol = df.getCol('package');
   const mutedCol = df.columns.byName('muted');
@@ -332,10 +382,13 @@ export function computeTestAlerts(p: ReleasePivot): TestAlerts {
       pushByPkg(a.flakyByPkg, pkg, test);
     if (df.get('slower', i) === true && !muted)
       pushByPkg(a.slowerByPkg, pkg, test);
+    if (df.get('stale_alert', i) === true)
+      pushByPkg(a.staleByPkg, pkg, test);
   }
   a.failed = countGroups(a.failingByPkg);
   a.flaky = countGroups(a.flakyByPkg);
   a.slower = countGroups(a.slowerByPkg);
+  a.stale = countGroups(a.staleByPkg);
   // Success rate excludes skipped and did-not-run: passed / (passed + failed).
   // floor so it never rounds up to 100% while any test is failing.
   const ran = a.passed + rawFailed;

--- a/packages/UsageAnalysis/src/release/overview.ts
+++ b/packages/UsageAnalysis/src/release/overview.ts
@@ -5,7 +5,7 @@ import {UaView} from '../tabs/ua';
 import {UaToolbox} from '../ua-toolbox';
 import {queries} from '../package-api';
 import {fetchVexIndex, criticalHighCount, toDashboardImages, vexReleaseDelta} from '../tabs/vulnerabilities';
-import {fetchReleaseTests, computeTestAlerts, stressRegression, defaultNextVersion, ReleaseContext} from './data';
+import {fetchReleaseTests, computeTestAlerts, stressRegression, defaultNextVersion, ReleaseContext, STALE_DAYS} from './data';
 import {fetchReleaseTickets} from './tickets';
 
 type Band = 'green' | 'orange' | 'red' | 'info';
@@ -95,6 +95,8 @@ export class ReleaseOverviewView extends UaView {
           tab: 'Tests', groups: a.slowerByPkg});
       if (a.flaky > 0)
         alerts.push({label: `${a.flaky} unstable/flaky tests`, band: 'orange', tab: 'Tests', groups: a.flakyByPkg});
+      if (a.stale > 0)
+        alerts.push({label: `${a.stale} tests not run for ${STALE_DAYS}+ days`, band: 'orange', tab: 'Tests', groups: a.staleByPkg});
     } else {
       this.setCard('Tests', 'n/a', 'info');
     }

--- a/packages/UsageAnalysis/src/release/tests.ts
+++ b/packages/UsageAnalysis/src/release/tests.ts
@@ -6,7 +6,8 @@ import {UaView} from '../tabs/ua';
 import {UaToolbox} from '../ua-toolbox';
 import {fetchReleaseTests, computeTestAlerts, ReleasePivot, ReleaseContext, JENKINS_TEST_JOB, colorStatusCell,
   COLOR_FAIL_TEXT, DIM_STATUS_BACK, COLOR_DIM_TEXT, NOT_RUN_BACK, waitForWidth, openInWorkspaceIcon,
-  getReleaseMutesSchema, MUTED_VERSIONS, MUTE_ON, MUTE_OFF, parseMutedVersions, isMutedForVersion} from './data';
+  getReleaseMutesSchema, MUTED_VERSIONS, STALE_MUTED_VERSIONS, MUTE_ON, MUTE_OFF,
+  parseMutedVersions, isMutedForVersion} from './data';
 
 export class TestsView extends UaView {
   private lastBuildsInput!: DG.InputBase;
@@ -152,8 +153,12 @@ export class TestsView extends UaView {
       // The 'mute' column value already holds the 🔔/🔕 glyph (kept aligned per row); click toggles it.
     });
     grid.onCellClick.subscribe((gc) => {
-      if (gc.isTableCell && gc.gridColumn.name === 'mute')
+      if (!gc.isTableCell)
+        return;
+      if (gc.gridColumn.name === 'mute')
         this.toggleMute(df, gc.cell.rowIndex, p);
+      else if (gc.gridColumn.name === 'staleMute' && df.get('stale', gc.cell.rowIndex) === true)
+        this.toggleStaleMute(df, gc.cell.rowIndex, p);
     });
     df.onCurrentRowChanged.subscribe(() => {
       if (df.currentRowIdx >= 0)
@@ -175,12 +180,14 @@ export class TestsView extends UaView {
       // Show only these, in this order: test → package → passing history (sparkline + per-build status
       // cells) → duration sparkline → flags. `setVisible` whitelists + orders in one deterministic call.
       const visible = ['mute', 'test', 'package', 'passing', ...p.statusCols, 'duration',
-        'needs_attention', 'flaky', 'slower', 'owner', 'ignore?', 'ignoreReason'].filter((n) => grid.col(n) != null);
+        'needs_attention', 'stale_days', 'staleMute', 'flaky', 'slower', 'owner', 'ignore?', 'ignoreReason']
+        .filter((n) => grid.col(n) != null);
       grid.columns.setVisible(visible);
       grid.columns.setOrder(visible);
 
       const widths: Record<string, number> = {mute: 40, test: 340, package: 130, passing: 100, duration: 100,
-        needs_attention: 92, flaky: 54, slower: 54, owner: 110, 'ignore?': 54, ignoreReason: 150};
+        needs_attention: 92, stale_days: 64, staleMute: 46, flaky: 54, slower: 54, owner: 110, 'ignore?': 54,
+        ignoreReason: 150};
       for (const name of Object.keys(widths)) {
         const c = grid.col(name);
         if (c)
@@ -270,10 +277,31 @@ export class TestsView extends UaView {
     await this.persistReleaseMutes(df);
   }
 
-  /** Persists the mutedVersions column back to the ReleaseMutes sticky-meta schema (coalesced). */
+  /** Toggles the current release version in the clicked test's STALE-mute list (independent of the failing mute). */
+  private async toggleStaleMute(df: DG.DataFrame, row: number, p: ReleasePivot): Promise<void> {
+    if (!p.version)
+      return;
+    const smvCol = df.columns.byName(STALE_MUTED_VERSIONS) ?? df.columns.addNewString(STALE_MUTED_VERSIONS);
+    const versions = parseMutedVersions(smvCol.get(row));
+    const at = versions.indexOf(p.version);
+    if (at >= 0)
+      versions.splice(at, 1);
+    else
+      versions.push(p.version);
+    smvCol.set(row, versions.join(';'));
+    const staleMuted = isMutedForVersion(smvCol.get(row), p.version);
+    df.getCol('staleMutedForVersion').set(row, staleMuted);
+    df.getCol('stale_alert').set(row, df.get('stale', row) === true && !staleMuted);
+    df.getCol('staleMute').set(row, df.get('stale', row) !== true ? '' : (staleMuted ? MUTE_ON : MUTE_OFF));
+    this.grid?.invalidate();
+    await this.persistReleaseMutes(df);
+  }
+
+  /** Persists mutedVersions + staleMutedVersions back to the ReleaseMutes sticky-meta schema (coalesced). */
   private async persistReleaseMutes(df: DG.DataFrame): Promise<void> {
     const mvCol = df.columns.byName(MUTED_VERSIONS);
-    if (!mvCol)
+    const smvCol = df.columns.byName(STALE_MUTED_VERSIONS);
+    if (!mvCol && !smvCol)
       return;
     if (this.persistingMutes) {
       this.pendingMutes = true;
@@ -285,10 +313,12 @@ export class TestsView extends UaView {
       const n = df.rowCount;
       do {
         this.pendingMutes = false;
-        const values = DG.DataFrame.fromColumns([
-          DG.Column.fromStrings(MUTED_VERSIONS, Array.from({length: n}, (_, i) => mvCol.get(i) ?? '')),
-        ]);
-        await grok.dapi.stickyMeta.setAllValues(schema, df.getCol('test'), values);
+        const cols: DG.Column[] = [];
+        if (mvCol)
+          cols.push(DG.Column.fromStrings(MUTED_VERSIONS, Array.from({length: n}, (_, i) => mvCol.get(i) ?? '')));
+        if (smvCol)
+          cols.push(DG.Column.fromStrings(STALE_MUTED_VERSIONS, Array.from({length: n}, (_, i) => smvCol.get(i) ?? '')));
+        await grok.dapi.stickyMeta.setAllValues(schema, df.getCol('test'), DG.DataFrame.fromColumns(cols));
       } while (this.pendingMutes);
     } finally {
       this.persistingMutes = false;


### PR DESCRIPTION
Adds a "not run for 7+ days" stale alert (Overview + Tests stale_days column) with a separate per-row mute, independent of the failing mute. ReleaseTests returns each test's last CI run over a 14-day lookback (validated ad-hoc: 54,384 rows, last_run present). Client degrades gracefully until the query lands on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)