### PR TITLE
UsageAnalysis Release Tickets: color-coding + MAIN split + actionable counts

### DIFF
--- a/packages/UsageAnalysis/CHANGELOG.md
+++ b/packages/UsageAnalysis/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Release: Tickets tab — the tickets grid now fills the page
 * Release: Tests tab — when a test didn't run in the latest build, its last known result is carried forward (shown dimmed) and used for the failing/pass-rate counts
 * Release: Added a "not run for 7+ days" stale-test alert (Overview + a stale_days column), with a separate per-row mute independent of the failing mute; ReleaseTests now returns each test's last run date over a 14-day lookback
+* Release: Tickets tab — color-coded status/priority/resolution cells; MAIN-labelled tickets shown in their own panel; the Overview Tickets card counts only actionable tickets (not Done / Won't Fix) split into MAIN vs other
 * Release: Added a global Refresh button to the dashboard ribbon that reloads every tab
 * Release: ReleaseTests now counts the latest CI/CD run per test (like TestsDashboard) instead of every test_run — retried-then-passed tests no longer count as failing and non-CI runs are excluded, so the failing counts stop being inflated by reruns
 * Release: Tests tab — the detail grid now fills the page; per-build status cells show `+` (passed) / `−` (failed) / `·` (skipped)

--- a/packages/UsageAnalysis/src/release/overview.ts
+++ b/packages/UsageAnalysis/src/release/overview.ts
@@ -6,7 +6,7 @@ import {UaToolbox} from '../ua-toolbox';
 import {queries} from '../package-api';
 import {fetchVexIndex, criticalHighCount, toDashboardImages, vexReleaseDelta} from '../tabs/vulnerabilities';
 import {fetchReleaseTests, computeTestAlerts, stressRegression, defaultNextVersion, ReleaseContext, STALE_DAYS} from './data';
-import {fetchReleaseTickets} from './tickets';
+import {fetchReleaseTickets, isActionable, hasMainLabel} from './tickets';
 
 type Band = 'green' | 'orange' | 'red' | 'info';
 const BAND_CLASS: Record<Band, string> = {
@@ -127,8 +127,10 @@ export class ReleaseOverviewView extends UaView {
 
     if (ticketsR.status === 'fulfilled') {
       const issues = ticketsR.value ?? [];
-      const open = issues.filter((r: any) => (r.fields?.resolution?.name ?? 'Unresolved') === 'Unresolved').length;
-      this.setCard('Tickets', `${open}`, open === 0 ? 'green' : 'info', `of ${issues.length} total`);
+      // Card counts only actionable tickets (not Done / Won't Fix), split by the MAIN label.
+      const open = issues.filter(isActionable).length;
+      const mainOpen = issues.filter((r: any) => isActionable(r) && hasMainLabel(r)).length;
+      this.setCard('Tickets', `${open}`, open === 0 ? 'green' : 'info', `${mainOpen} MAIN, ${open - mainOpen} other`);
     } else {
       this.setCard('Tickets', 'n/a', 'info');
     }

--- a/packages/UsageAnalysis/src/release/tickets.ts
+++ b/packages/UsageAnalysis/src/release/tickets.ts
@@ -8,6 +8,8 @@ import {defaultNextVersion, JIRA_BROWSE, ReleaseContext, openInWorkspaceIcon} fr
 
 interface JiraIssue { key: string; fields: Record<string, any>; }
 
+export const MAIN_LABEL = 'MAIN';
+
 /** Builds the JiraConnect filter object for the next-release fixVersion (equality-only JQL builder). */
 export function fixVersionFilter(version: string): Record<string, string> {
   return {project: 'GROK', fixVersion: `"${version}"`};
@@ -15,6 +17,38 @@ export function fixVersionFilter(version: string): Record<string, string> {
 
 export async function fetchReleaseTickets(version: string): Promise<JiraIssue[]> {
   return await grok.functions.call('JiraConnect:GetJiraTicketsByFilter', {filter: fixVersionFilter(version)});
+}
+
+/** A ticket still needs attention unless it's Done or Won't Fix (by either status or resolution). */
+export function isActionable(issue: JiraIssue): boolean {
+  const status = issue.fields.status?.name ?? '';
+  const res = issue.fields.resolution?.name ?? '';
+  return status !== 'Done' && status !== 'Won\'t Fix' && res !== 'Done' && res !== 'Won\'t Fix';
+}
+
+/** True when the ticket carries the MAIN label. */
+export function hasMainLabel(issue: JiraIssue): boolean {
+  return (issue.fields.labels || []).includes(MAIN_LABEL);
+}
+
+// Grid cell backgrounds (ARGB — grid cells take numeric colors, not design tokens).
+function statusColor(s: string): number {
+  const t = (s || '').toLowerCase();
+  if (t.includes('done') || t.includes('closed') || t.includes('resolved')) return 0xFFE6F4EA; // green
+  if (t.includes('progress') || t.includes('review') || t.includes('testing')) return 0xFFFFF3E0; // amber
+  return 0xFFF3F3F3; // to-do / open / backlog — grey
+}
+function priorityColor(p: string): number {
+  const t = (p || '').toLowerCase();
+  if (t.includes('blocker') || t.includes('highest') || t.includes('critical')) return 0xFFFDE7E7; // red
+  if (t === 'high') return 0xFFFCE7D6; // orange
+  if (t.includes('medium')) return 0xFFFCF7DA; // yellow
+  return 0xFFF3F3F3; // low / lowest — grey
+}
+function resolutionColor(r: string): number {
+  if (r === 'Done') return 0xFFE6F4EA;
+  if (r === 'Won\'t Fix') return 0xFFF0F0F0;
+  return 0xFFFFF3E0; // unresolved / other — amber (still actionable)
 }
 
 export function ticketsToDataFrame(issues: JiraIssue[]): DG.DataFrame {
@@ -35,8 +69,11 @@ export function ticketsToDataFrame(issues: JiraIssue[]): DG.DataFrame {
 
 export class ReleaseTicketsView extends UaView {
   private versionInput!: DG.InputBase;
-  private gridHost!: HTMLElement;
   private titleLabel!: HTMLElement;
+  private mainTitle!: HTMLElement;
+  private otherTitle!: HTMLElement;
+  private mainHost!: HTMLElement;
+  private otherHost!: HTMLElement;
   private ticketsDf: DG.DataFrame | null = null;
 
   constructor(private ctx: ReleaseContext, uaToolbox?: UaToolbox) {
@@ -47,59 +84,93 @@ export class ReleaseTicketsView extends UaView {
 
   async initViewers(): Promise<void> {
     this.root.className = 'grok-view ui-box ua-metrics ua-metrics-fill';
-    this.versionInput = ui.input.string('Fix version', {value: defaultNextVersion(), onValueChanged: () => this.refresh()});
-    this.titleLabel = ui.divText('Tickets marked for the next release', 'ua-metrics-panel-title');
-    this.gridHost = ui.div([], 'ua-metrics-grid-host');
+    this.versionInput = ui.input.string('Fix version',
+      {value: defaultNextVersion(), onValueChanged: () => this.refresh()});
+    this.titleLabel = ui.divText('Tickets marked for the next release', 'ua-metrics-asof');
+    this.mainTitle = ui.divText('MAIN', 'ua-metrics-panel-title');
+    this.otherTitle = ui.divText('Other', 'ua-metrics-panel-title');
+    this.mainHost = ui.div([], 'ua-metrics-grid-host');
+    this.otherHost = ui.div([], 'ua-metrics-grid-host');
 
     const refreshBtn = ui.bigButton('Refresh', () => this.refresh());
     refreshBtn.prepend(ui.iconFA('sync-alt'), ' ');
     refreshBtn.classList.add('ua-metrics-btn-secondary');
-    const header = ui.divH([
-      this.versionInput.root, ui.div([], {style: {flex: '1'}}), refreshBtn,
-    ], 'ua-metrics-header');
+    const header = ui.divH([this.versionInput.root, this.titleLabel,
+      ui.div([], {style: {flex: '1'}}), refreshBtn], 'ua-metrics-header');
 
-    const panel = ui.div([ui.divH([this.titleLabel, openInWorkspaceIcon(() => this.ticketsDf)], 'ua-metrics-panel-header'),
-      this.gridHost], 'ua-metrics-panel ua-metrics-panel-grow');
-    this.root.append(ui.div([header, panel], 'ua-metrics-root'));
+    // MAIN-labelled tickets are shown in their own panel, above the rest.
+    const mainPanel = ui.div([ui.divH([this.mainTitle], 'ua-metrics-panel-header'), this.mainHost], 'ua-metrics-panel');
+    const otherPanel = ui.div([ui.divH([this.otherTitle, openInWorkspaceIcon(() => this.ticketsDf)],
+      'ua-metrics-panel-header'), this.otherHost], 'ua-metrics-panel ua-metrics-panel-grow');
+    this.root.append(ui.div([header, mainPanel, otherPanel], 'ua-metrics-root'));
     await this.refresh();
   }
 
   private async refresh(): Promise<void> {
     const version = (this.versionInput.value ?? '').trim();
-    this.gridHost.innerHTML = '';
-    this.gridHost.append(ui.loader());
+    this.mainHost.innerHTML = '';
+    this.otherHost.innerHTML = '';
+    this.otherHost.append(ui.loader());
     if (!version) {
-      this.gridHost.innerHTML = '';
-      this.gridHost.append(ui.divText('Enter the next-release fix version.', 'ua-metrics-degraded'));
+      this.otherHost.innerHTML = '';
+      this.otherHost.append(ui.divText('Enter the next-release fix version.', 'ua-metrics-degraded'));
       return;
     }
     try {
       const issues = await fetchReleaseTickets(version);
-      this.gridHost.innerHTML = '';
+      this.otherHost.innerHTML = '';
       if (!issues || issues.length === 0) {
-        this.gridHost.append(ui.divText(
+        this.otherHost.append(ui.divText(
           `No GROK tickets with fixVersion "${version}" (or JiraConnect credentials are not configured on this server).`,
           'ua-metrics-degraded'));
         this.titleLabel.textContent = `fixVersion "${version}" — 0 tickets`;
         return;
       }
-      const df = ticketsToDataFrame(issues);
-      this.ticketsDf = df;
-      const open = issues.filter((r) => (r.fields.resolution?.name ?? 'Unresolved') === 'Unresolved').length;
-      this.titleLabel.textContent = `fixVersion "${version}" — ${issues.length} tickets, ${open} unresolved`;
-      const grid = DG.Viewer.grid(df, {showColumnGridlines: false, allowBlockSelection: false});
-      grid.sort(['status', 'priority'], [true, true]);
-      const summaryCol = grid.col('summary');
-      if (summaryCol)
-        summaryCol.width = 360;
-      grid.root.style.width = '100%';
-      grid.root.style.height = '100%';
-      this.gridHost.append(grid.root);
+      const main = issues.filter(hasMainLabel);
+      const other = issues.filter((r) => !hasMainLabel(r));
+      const open = issues.filter(isActionable).length;
+      const mainOpen = main.filter(isActionable).length;
+      this.titleLabel.textContent =
+        `fixVersion "${version}" — ${issues.length} tickets, ${open} open (${mainOpen} MAIN)`;
+      this.mainTitle.textContent = `MAIN — ${mainOpen} open of ${main.length}`;
+      this.otherTitle.textContent = `Other — ${open - mainOpen} open of ${other.length}`;
+      this.renderGrid(this.mainHost, main, 'No MAIN-labelled tickets.');
+      this.ticketsDf = this.renderGrid(this.otherHost, other, 'No other tickets.') ?? this.ticketsDf;
     } catch (e) {
-      this.gridHost.innerHTML = '';
-      this.gridHost.append(ui.divText(
+      this.otherHost.innerHTML = '';
+      this.otherHost.append(ui.divText(
         `Could not reach JiraConnect (${e}). Install the JiraConnect package and configure Jira credentials.`,
         'ua-metrics-degraded'));
     }
+  }
+
+  /** Builds a color-coded tickets grid into `host`; returns the dataframe (or null if empty). */
+  private renderGrid(host: HTMLElement, issues: JiraIssue[], emptyMsg: string): DG.DataFrame | null {
+    host.innerHTML = '';
+    if (issues.length === 0) {
+      host.append(ui.divText(emptyMsg, 'ua-metrics-degraded'));
+      return null;
+    }
+    const df = ticketsToDataFrame(issues);
+    const grid = DG.Viewer.grid(df, {showColumnGridlines: false, allowBlockSelection: false});
+    grid.onCellPrepare((gc) => {
+      if (!gc.isTableCell)
+        return;
+      const v = gc.cell.value as string;
+      if (gc.gridColumn.name === 'status')
+        gc.style.backColor = statusColor(v);
+      else if (gc.gridColumn.name === 'priority')
+        gc.style.backColor = priorityColor(v);
+      else if (gc.gridColumn.name === 'resolution')
+        gc.style.backColor = resolutionColor(v);
+    });
+    grid.sort(['priority', 'status'], [true, true]);
+    const summaryCol = grid.col('summary');
+    if (summaryCol)
+      summaryCol.width = 360;
+    grid.root.style.width = '100%';
+    grid.root.style.height = '100%';
+    host.append(grid.root);
+    return df;
   }
 }


### PR DESCRIPTION
Color-codes status/priority/resolution in the tickets grid, shows MAIN-labelled tickets in their own panel, and counts only actionable tickets (not Done / Won't Fix) split MAIN vs other. Verified on dev (fixVersion 1.28.0: 210 open of 420).

🤖 Generated with [Claude Code](https://claude.com/claude-code)