### PR TITLE
UsageAnalysis: release 2.6.0

### DIFF
--- a/packages/UsageAnalysis/CHANGELOG.md
+++ b/packages/UsageAnalysis/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Usage Analysis changelog
 
-## v.next
+## 2.6.0 (2026-07-16)
 
 * Release: Added a global Environment (instance) picker to the dashboard ribbon that persists across all tabs and filters Overview and Tests to builds run on the selected instance (replaces the per-tab Tests instance input)
 * Release: Tests tab — per-row mute icon (🔔/🔕) mutes a test for the current release version; version-bound mutes are stored in a dedicated ReleaseMutes sticky-meta schema and drop the test out of the failing/unstable/needs-attention counts for that version

--- a/packages/UsageAnalysis/package.json
+++ b/packages/UsageAnalysis/package.json
@@ -5,7 +5,7 @@
     "email": "oserhiienko@datagrok.ai"
   },
   "friendlyName": "Usage Analysis",
-  "version": "2.5.4",
+  "version": "2.6.0",
   "description": "Platform usage analysis system",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version bump 2.5.4 -> 2.6.0 and changelog finalization for the release-dashboard work (env picker, global refresh, version-bound + stale muting, carry-forward, accurate latest-CI-run counts, box plot, ticket color-coding/MAIN split) + JiraConnect /search/jql migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)