### PR TITLE
UsageAnalysis 2.6.1: fix Main ticket label match

### DIFF
--- a/packages/UsageAnalysis/CHANGELOG.md
+++ b/packages/UsageAnalysis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Usage Analysis changelog
 
+## 2.6.1 (2026-07-16)
+
+* Release: Tickets — match the "Main" label case-insensitively (was looking for "MAIN", so the MAIN panel was always empty)
+
 ## 2.6.0 (2026-07-16)
 
 * Release: Added a global Environment (instance) picker to the dashboard ribbon that persists across all tabs and filters Overview and Tests to builds run on the selected instance (replaces the per-tab Tests instance input)

--- a/packages/UsageAnalysis/package.json
+++ b/packages/UsageAnalysis/package.json
@@ -5,7 +5,7 @@
     "email": "oserhiienko@datagrok.ai"
   },
   "friendlyName": "Usage Analysis",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Platform usage analysis system",
   "repository": {
     "type": "git",

--- a/packages/UsageAnalysis/src/release/tickets.ts
+++ b/packages/UsageAnalysis/src/release/tickets.ts
@@ -8,7 +8,7 @@ import {defaultNextVersion, JIRA_BROWSE, ReleaseContext, openInWorkspaceIcon} fr
 
 interface JiraIssue { key: string; fields: Record<string, any>; }
 
-export const MAIN_LABEL = 'MAIN';
+export const MAIN_LABEL = 'Main';
 
 /** Builds the JiraConnect filter object for the next-release fixVersion (equality-only JQL builder). */
 export function fixVersionFilter(version: string): Record<string, string> {
@@ -26,9 +26,10 @@ export function isActionable(issue: JiraIssue): boolean {
   return status !== 'Done' && status !== 'Won\'t Fix' && res !== 'Done' && res !== 'Won\'t Fix';
 }
 
-/** True when the ticket carries the MAIN label. */
+/** True when the ticket carries the "Main" label (case-insensitive). */
 export function hasMainLabel(issue: JiraIssue): boolean {
-  return (issue.fields.labels || []).includes(MAIN_LABEL);
+  const target = MAIN_LABEL.toLowerCase();
+  return (issue.fields.labels || []).some((l: string) => (l ?? '').toLowerCase() === target);
 }
 
 // Grid cell backgrounds (ARGB — grid cells take numeric colors, not design tokens).


### PR DESCRIPTION
Patch: the tickets MAIN split matched all-caps "MAIN" but the Jira label is "Main", so it was always empty. Now case-insensitive (verified: 18 Main tickets, 12 open for 1.28.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)