### PR TITLE
UsageAnalysis 2.7.0: slow-test comparison (bleeding-edge + previous release)

### DIFF
--- a/packages/UsageAnalysis/CHANGELOG.md
+++ b/packages/UsageAnalysis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Usage Analysis changelog
 
+## 2.7.0 (2026-07-16)
+
+* Release: Tests slow-test alert now compares each test's latest duration against both the bleeding-edge recent average and the previous release (previous minor semver, found across instances) and shows both deltas; sub-second tests are ignored to cut noise; ReleaseTests returns a `prev_release_ms` baseline. (Stress keeps its bleeding-edge p95-vs-prior comparison — the previous release has no stress data to compare against.)
+
 ## 2.6.1 (2026-07-16)
 
 * Release: Tickets — match the "Main" label case-insensitively (was looking for "MAIN", so the MAIN panel was always empty)

--- a/packages/UsageAnalysis/package.json
+++ b/packages/UsageAnalysis/package.json
@@ -5,7 +5,7 @@
     "email": "oserhiienko@datagrok.ai"
   },
   "friendlyName": "Usage Analysis",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Platform usage analysis system",
   "repository": {
     "type": "git",

--- a/packages/UsageAnalysis/queries/release_tests.sql
+++ b/packages/UsageAnalysis/queries/release_tests.sql
@@ -44,6 +44,33 @@ active_tests AS (
     AND r.instance LIKE 'https://' || @instanceFilter || '.datagrok.ai'
     AND r.date_time >= now() - interval '14 days'
   GROUP BY r.test_name
+),
+prev_version AS (
+  -- Highest release minor strictly below the current window's version (e.g. 1.28 -> 1.27), found across
+  -- ALL instances: a previous release ran on its own instance at the time, not the current one.
+  SELECT v.minor FROM (
+    SELECT DISTINCT (regexp_match(b.name, '(\d+\.\d+)\.'))[1] AS minor
+    FROM builds b WHERE (regexp_match(b.name, '(\d+\.\d+)\.'))[1] IS NOT NULL
+  ) v
+  WHERE string_to_array(v.minor, '.')::int[] <
+        string_to_array((SELECT (regexp_match(build_name, '(\d+\.\d+)\.'))[1]
+                         FROM indexed_builds ORDER BY build_index DESC LIMIT 1), '.')::int[]
+  ORDER BY string_to_array(v.minor, '.')::int[] DESC
+  LIMIT 1
+),
+prev_builds AS (
+  SELECT b.name FROM builds b
+  WHERE (regexp_match(b.name, '(\d+\.\d+)\.'))[1] = (SELECT minor FROM prev_version)
+    AND EXISTS (SELECT 1 FROM test_runs r WHERE r.build_name = b.name
+                AND r.passed AND NOT r.stress_test AND NOT r.benchmark)
+  ORDER BY b.build_date DESC LIMIT 5
+),
+prev_avg AS (
+  -- Average passed-run duration per test across the previous release's last builds (the baseline).
+  SELECT r.test_name, CAST(AVG(r.duration) AS int) AS prev_ms
+  FROM test_runs r JOIN prev_builds pb ON pb.name = r.build_name
+  WHERE r.passed AND NOT r.stress_test AND NOT r.benchmark
+  GROUP BY r.test_name
 )
 SELECT
   COALESCE(p.name, t.package) AS package,
@@ -55,6 +82,7 @@ SELECT
   b.build_date,
   r.instance,
   act.last_run,
+  pa.prev_ms AS prev_release_ms,
   CASE WHEN r.passed IS NULL THEN 'did not run'
        WHEN r.skipped THEN 'skipped'
        WHEN r.passed THEN 'passed'
@@ -68,6 +96,7 @@ CROSS JOIN indexed_builds b
 LEFT JOIN latest_runs r
   ON r.test_name = t.name AND r.build_name = b.build_name AND r.rn = 1
 LEFT JOIN active_tests act ON act.test_name = t.name
+LEFT JOIN prev_avg pa ON pa.test_name = t.name
 LEFT JOIN published_packages p ON p.name = t.package AND p.is_current
 WHERE t.type <> 'manual'
   AND t.name IN (SELECT test_name FROM active_tests)

--- a/packages/UsageAnalysis/src/release/data.ts
+++ b/packages/UsageAnalysis/src/release/data.ts
@@ -9,6 +9,7 @@ export const DEV_HOST = 'dev.datagrok.ai';
 export const JIRA_BROWSE = 'https://reddata.atlassian.net/browse/';
 export const JENKINS_TEST_JOB = 'https://ops.datagrok.ai/job/test-build/';
 const SLOW_FACTOR = 1.25;
+const MIN_SLOW_MS = 1000; // ignore sub-second tests — a +% on a few-ms test is noise, not a regression
 
 /** Instances the dashboard can inspect; each maps to a `test_runs.instance` host (see release_tests.sql). */
 export const ENV_CHOICES = ['dev', 'release', 'public', 'release-ec2'];
@@ -243,6 +244,35 @@ export async function fetchReleaseTests(instanceFilter: string, lastBuildsNum: n
   const successCols = buildIndexes.map((bi) => `${bi} ok`);
   const resultCols = buildIndexes.map((bi) => `${bi} result`);
 
+  // Release version + per-test baselines (last-run date, previous-release avg duration), read from the raw
+  // result up front so the derived flags below (slower, stale) can use them.
+  const buildCol = raw.getCol('build');
+  let latestBuildName = '';
+  for (let i = 0; i < raw.rowCount; i++)
+    if (Number(biCol.get(i)) === latest) { latestBuildName = buildCol.get(i) ?? ''; break; }
+  const version = versionFromBuild(latestBuildName);
+  const nowMs = Date.now();
+  const rawTestCol = raw.getCol('test');
+  const lastRunByTest = new Map<string, number>();
+  const rawLastRun = raw.columns.byName('last_run');
+  if (rawLastRun) {
+    for (let i = 0; i < raw.rowCount; i++) {
+      const t = rawTestCol.get(i);
+      if (!lastRunByTest.has(t)) {
+        const v: any = rawLastRun.get(i);
+        lastRunByTest.set(t, v == null ? NaN : (v.valueOf ? Number(v.valueOf()) : Number(v)));
+      }
+    }
+  }
+  const prevReleaseByTest = new Map<string, number>();
+  const rawPrev = raw.columns.byName('prev_release_ms');
+  if (rawPrev) {
+    for (let i = 0; i < raw.rowCount; i++) {
+      const t = rawTestCol.get(i);
+      if (!prevReleaseByTest.has(t)) { const v: any = rawPrev.get(i); prevReleaseByTest.set(t, v == null ? NaN : Number(v)); }
+    }
+  }
+
   // Carry the last known result forward when the test didn't run in the latest build.
   const descBuilds = [...buildIndexes].reverse(); // latest → oldest
   pivot.columns.addNewString('effective_status').init((i) => {
@@ -265,43 +295,41 @@ export async function fetchReleaseTests(instanceFilter: string, lastBuildsNum: n
     const flakingFlag = buildIndexes.some((bi) => pivot.get(`${bi} flaking`, i) === true);
     return flakingFlag || (statuses.includes('passed') && statuses.includes('failed'));
   });
-  pivot.columns.addNewBool('slower').init((i) => {
-    // Only compare speed across passed runs — a failed/skipped run's duration isn't comparable.
-    if (pivot.get(`${latest}`, i) !== 'passed')
-      return false;
-    const latestMs = Number(pivot.get(`${latest} ms`, i));
-    if (!latestMs || isNaN(latestMs))
-      return false;
+  // Slow-test baselines: bleeding-edge recent average (prior window passed runs) and the previous-release
+  // average (from the query). A test is "slower" if the latest run exceeds SLOW_FACTOR x either baseline.
+  const baselineTestCol = pivot.getCol('test');
+  pivot.columns.addNewInt('prev_release_ms').init((i) => {
+    const v = prevReleaseByTest.get(baselineTestCol.get(i));
+    return (v == null || isNaN(v)) ? 0 : v;
+  });
+  pivot.columns.addNewInt('be_avg_ms').init((i) => {
     const prior = buildIndexes.slice(0, -1)
       .filter((bi) => pivot.get(`${bi}`, i) === 'passed')
       .map((bi) => Number(pivot.get(`${bi} ms`, i))).filter((v) => v && !isNaN(v));
-    if (prior.length < 2)
-      return false;
-    const med = median(prior);
-    return med > 0 && latestMs > med * SLOW_FACTOR;
+    return prior.length ? Math.round(prior.reduce((a, b) => a + b, 0) / prior.length) : 0;
   });
-
-  // Release version the latest build belongs to — mutes are bound to it.
-  const buildCol = raw.getCol('build');
-  let latestBuildName = '';
-  for (let i = 0; i < raw.rowCount; i++)
-    if (Number(biCol.get(i)) === latest) { latestBuildName = buildCol.get(i) ?? ''; break; }
-  const version = versionFromBuild(latestBuildName);
-
-  // Most recent run date per test (ms) → staleness. last_run is constant per test in the raw result.
-  const nowMs = Date.now();
-  const lastRunByTest = new Map<string, number>();
-  const rawTestCol = raw.getCol('test');
-  const rawLastRun = raw.columns.byName('last_run');
-  if (rawLastRun) {
-    for (let i = 0; i < raw.rowCount; i++) {
-      const t = rawTestCol.get(i);
-      if (!lastRunByTest.has(t)) {
-        const v: any = rawLastRun.get(i);
-        lastRunByTest.set(t, v == null ? NaN : (v.valueOf ? Number(v.valueOf()) : Number(v)));
-      }
-    }
-  }
+  pivot.columns.addNewBool('slower').init((i) => {
+    if (pivot.get(`${latest}`, i) !== 'passed')
+      return false;
+    const latestMs = Number(pivot.get(`${latest} ms`, i));
+    if (!latestMs || isNaN(latestMs) || latestMs < MIN_SLOW_MS)
+      return false;
+    const be = pivot.get('be_avg_ms', i);
+    const prev = pivot.get('prev_release_ms', i);
+    return (be > 0 && latestMs > be * SLOW_FACTOR) || (prev > 0 && latestMs > prev * SLOW_FACTOR);
+  });
+  pivot.columns.addNewString('slow_detail').init((i) => {
+    if (pivot.get('slower', i) !== true)
+      return '';
+    const latestMs = Number(pivot.get(`${latest} ms`, i));
+    const be = pivot.get('be_avg_ms', i);
+    const prev = pivot.get('prev_release_ms', i);
+    const pct = (base: number) => { const p = Math.round((latestMs / base - 1) * 100); return `${p >= 0 ? '+' : ''}${p}%`; };
+    const parts: string[] = [];
+    if (be > 0) parts.push(`${pct(be)} vs recent avg ${be}ms`);
+    if (prev > 0) parts.push(`${pct(prev)} vs prev release ${prev}ms`);
+    return `${latestMs}ms — ${parts.join(', ')}`;
+  });
 
   const schemas = await grok.dapi.stickyMeta.getSchemas();
   const schema = schemas.find((s) => s.name === 'Autotests');
@@ -381,7 +409,7 @@ export function computeTestAlerts(p: ReleasePivot): TestAlerts {
     if (df.get('flaky', i) === true && !muted)
       pushByPkg(a.flakyByPkg, pkg, test);
     if (df.get('slower', i) === true && !muted)
-      pushByPkg(a.slowerByPkg, pkg, test);
+      pushByPkg(a.slowerByPkg, pkg, `${test}: ${df.get('slow_detail', i) ?? ''}`);
     if (df.get('stale_alert', i) === true)
       pushByPkg(a.staleByPkg, pkg, test);
   }

--- a/packages/UsageAnalysis/src/release/overview.ts
+++ b/packages/UsageAnalysis/src/release/overview.ts
@@ -91,8 +91,8 @@ export class ReleaseOverviewView extends UaView {
       if (a.failed > 0)
         alerts.push({label: `${a.failed} failing tests`, band: 'red', tab: 'Tests', groups: a.failingByPkg});
       if (a.slower > 0)
-        alerts.push({label: `${a.slower} tests slower than recent median (passed runs)`, band: 'orange',
-          tab: 'Tests', groups: a.slowerByPkg});
+        alerts.push({label: `${a.slower} tests slower than baseline (recent avg or previous release)`,
+          band: 'orange', tab: 'Tests', groups: a.slowerByPkg});
       if (a.flaky > 0)
         alerts.push({label: `${a.flaky} unstable/flaky tests`, band: 'orange', tab: 'Tests', groups: a.flakyByPkg});
       if (a.stale > 0)

--- a/packages/UsageAnalysis/src/release/tests.ts
+++ b/packages/UsageAnalysis/src/release/tests.ts
@@ -215,7 +215,11 @@ export class TestsView extends UaView {
     resultBox.style.overflow = 'auto';
     return ui.divV([
       ui.h2(test),
-      ui.tableFromMap({Package: pkg, 'Latest status': status, Commit: commit || '—'}),
+      ui.tableFromMap({Package: pkg, 'Latest status': status,
+        'Latest ms': df.get(`${p.latest} ms`, i) ?? '—',
+        'Recent avg ms': df.get('be_avg_ms', i) || '—',
+        'Prev release ms': df.get('prev_release_ms', i) || '—',
+        Commit: commit || '—'}),
       ui.link('Open test-build in Jenkins', JENKINS_TEST_JOB),
       ui.divText('Latest build output', 'ua-metrics-panel-title'),
       resultBox,


### PR DESCRIPTION
Slow-test alert now compares latest duration vs BOTH the bleeding-edge recent average and the previous-release baseline (previous minor semver, found across instances), showing both deltas; sub-second tests ignored. Validated the query ad-hoc (54k rows, prev_release_ms present) and verified on dev (47 slow tests, down from 899 noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)