### PR TITLE
CVMTests: fix Grok Column list script — wrap list in Named()

### DIFF
--- a/packages/CVMTests/CHANGELOG.md
+++ b/packages/CVMTests/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v.next
 
 * Tests: fixed Docker tests — the container-name filter never matched. Platform registers package containers as `kebab(package.name)-<dockerfileFolder>` (`cvm-tests-cvmtests-docker-test1/2`); the test queried `cvmtests-Cvmtests-...`, so `before()` got `undefined` and all 5 Docker tests failed. Also added a clear not-found error instead of a cryptic undefined cascade.
-* Tests: fixed `Column list` script tests — JS `column_list` input is a name array (`string[]`), so use `cols[0]` not `cols.toList()[0]`; Grok script used an undefined `columns` var and numeric indexing (Grok lists expose `first`/`last`/`length`, not `[i]`), now `cols.first`.
+* Tests: fixed `Column list` script tests — JS `column_list` input is a name array (`string[]`), so use `cols[0]` not `cols.toList()[0]`; Grok script now `DeleteColumns(df, Named([cols.first]))` — a runtime list value isn't coerced to a column filter (only parse-time list literals are), so the prior `DeleteColumns(df, [cols.first])` threw `Class 'List' has no instance method 'makePredicate'`. Wrapping in `Named(...)` builds the predicate explicitly.
 * Security: rebuilt `cvmtests-docker-test1` (`python:3.12-alpine`) and `cvmtests-docker-test2` (`python:3.11-alpine`) on current bases (+ `apk upgrade`, refreshed pip/setuptools/wheel) to clear base-OS CVEs (expat/krb5/openssl/musl) and stale Python tooling.
 * Docker: cvmtests-docker-test2 — raised Quart (>=0.20) and Werkzeug (>=3.1.6) floors to clear their CVEs (VEX)
 * Added datagrok-celery-task integration tests via the python/ celery worker

--- a/packages/CVMTests/scripts/grok/column_list.grok
+++ b/packages/CVMTests/scripts/grok/column_list.grok
@@ -5,5 +5,5 @@
 #input: column_list cols
 #output: dataframe result
 
-DeleteColumns(df, [cols.first])
+DeleteColumns(df, Named([cols.first]))
 result = df


### PR DESCRIPTION
## What

Fixes the failing **CVM Tests → Scripts: Grok scripts → Column list** test.

`scripts/grok/column_list.grok` called `DeleteColumns(df, [cols.first])`. `DeleteColumns`'s second parameter is a column-filter predicate (`ColFilterCall`). The parser only coerces a **parse-time** list literal (e.g. `DeleteColumns("cars", ["make","model"])`) into a `Named(...)` predicate — a **runtime** list value like `[cols.first]` reaches `deleteColumnsImpl` as a raw `List` and throws:

```
NoSuchMethodError: Class 'List' has no instance method 'makePredicate'
```

Wrapping the list in `Named([cols.first])` builds the `NamedColumnPredicate` explicitly, deleting the first column as intended (matching the Python/R/NodeJS/JS/Octave versions).

## Verification

- Reproduced the throw and confirmed the fix locally against the real Dart evaluation path (`Script.fromCode` → `GrokScriptHandler.run` → `Func.runScript` → `DeleteColumns`), result `(date, name)`.
- Ran the actual test on **dev**: `Scripts: Grok scripts / Column list` — **1 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)