### PR TITLE
[ticket] GROK-17130: xamgle: filesSearch: enumerate System:DemoFiles and match file names client-side, case-insensitively

### DIFF
--- a/packages/PowerPack/CHANGELOG.md
+++ b/packages/PowerPack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v.next
 
-
+* GROK-17130: Search: Files search now includes System:DemoFiles and matches file names case-insensitively, so demo datasets like SPGI.csv are found in Search everywhere
 * Moved the PowerPack Playwright E2E suite into the package (playwright/); helpers from @datagrok-libraries/test/src/playwright
 * Workspace: Fixed the editor-header "Open" doing nothing for a pinned query/function or data connection — it now opens the entity's own view the way the Browse tree does (a query's run view, a connection's queries browser) via the handler's `renderPreview`, consistently for all entity types, instead of `Func.apply()` (which ran with empty inputs and added no view) or only setting the context object. Running the query and viewing its table result stays on Run / the bottom-preview "Open"
 * Search: Added Spaces, Plugins, Notebooks, and Models to the search provider

--- a/packages/PowerPack/src/search/entity-search.ts
+++ b/packages/PowerPack/src/search/entity-search.ts
@@ -248,5 +248,14 @@ export async function filesSearch(s: string): Promise<DG.FileInfo[]> {
   const appDataFiles = await grok.dapi.files.list('System:AppData/', true, s);
   allFiles.push(...appDataFiles);
 
+  // demo datasets live in a shared connection not covered above; match client-side because
+  // the server-side searchPattern filter is case-sensitive and would drop e.g. SPGI.csv for 'spgi'
+  try {
+    const demoFiles = await grok.dapi.files.list('System:DemoFiles/', true, null);
+    allFiles.push(...demoFiles.filter((f) => f.name.toLowerCase().includes(s)));
+  } catch (e) {
+    console.error('Error fetching demo files:', e);
+  }
+
   return allFiles;
 }


### PR DESCRIPTION
## GROK-17130: Browse 'Search everywhere' finds no results for SPGI and other demo datasets

**Symptom.** Typing `SPGI` (a real dataset at `System:DemoFiles/chem/SPGI.csv`) into Browse > Search everywhere returns no results, while `demog` works. Reported files genuinely exist (`grok.dapi.files.exists('System:DemoFiles/chem/SPGI.csv') === true`).

**Root cause.** PowerPack `filesSearch()` (`public/packages/PowerPack/src/search/entity-search.ts`, the `Files` provider registered in `package.ts`) only enumerates the user's home connection and `System:AppData/` — never `System:DemoFiles/`, where the demo datasets live. Compounding this, `filesSearch` lowercases the query and passes it as the server `searchPattern`, which the server matches **case-sensitively** (`datlas .../routers/connectors.dart:355`, `file.friendlyName.contains(ext)`). Verified live: `files.list('System:DemoFiles/', true, 'SPGI')` → 5 files, but `files.list(..., 'spgi')` → `[]`.

**Fix.** `filesSearch` now also enumerates `System:DemoFiles/` (recursively) with a `null` search pattern and filters the results client-side, case-insensitively (`f.name.toLowerCase().includes(query)`). This surfaces demo datasets and matches regardless of typed case, without depending on the case-sensitive server filter.

**Tested.** `npm run build` in `public/packages/PowerPack` exits 0. Confirmed against the live instance that `System:DemoFiles/` contains the SPGI files and that the client-side case-insensitive filter matches them for both `SPGI` and `spgi`.

Refs JIRA GROK-17130.