### PR TITLE
[ticket] GROK-19337: Tutorials: Make Tutorials paragraphs() bold a title only when one is explicitly passed, strip mid-sentence <br> tags, and narrow the action panel

### DIFF
--- a/packages/Tutorials/CHANGELOG.md
+++ b/packages/Tutorials/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* GROK-19337: Peptides-SAR tutorial: Fixed callouts rendering body text as bold headings (`paragraphs()` now emits a bold title only when one is explicitly passed), removed spurious mid-sentence `<br>` line breaks, and narrowed the action panel (~18% narrower dock ratio)
 * Demo app: Always clear the "Updating..." overlay when a demo finishes — moved `setUpdateIndicator(false)` into a `finally` so a failing demo no longer leaves the indicator covering the home page
 * Demo app: Fixed clipped/misplaced "Updating..." overlay — place it on the tab-content of the active view instead of `tab-content[0]`, so it stays bounded (tab-content is `position: relative`) and lands on the pane that's actually being replaced rather than a sibling (e.g. the home page) when the dock is split
 * Demo app: Made the "Updating..." overlay clearly readable during demo loading — scoped CSS (`.demo-app-loading > .d4-update-shadow`) gives the overlay a solid translucent white background with a subtle backdrop blur and renders the label/loader at full opacity, so widget text underneath no longer bleeds through

--- a/packages/Tutorials/src/package.ts
+++ b/packages/Tutorials/src/package.ts
@@ -43,7 +43,7 @@ export class PackageFunctions {
       if (existingDock)
         grok.shell.dockManager.close(existingDock);
     }
-    grok.shell.dockManager.dock(root, DG.DOCK_TYPE.LEFT, null, 'Tutorials', 0.27);
+    grok.shell.dockManager.dock(root, DG.DOCK_TYPE.LEFT, null, 'Tutorials', 0.22);
     setPath(window.location.pathname, tutorialRunners);
   }
 

--- a/packages/Tutorials/src/tracks/bio/tutorials/peptides-sar.ts
+++ b/packages/Tutorials/src/tracks/bio/tutorials/peptides-sar.ts
@@ -248,7 +248,7 @@ export class PeptidesSarTutorial extends Tutorial {
         step7B2.remove();
 
         // ########## Step 8: Sequence Variability Map · Mutation Cliffs ##########
-        const s81b = paragraphs(['Mutation Cliffs', 'In this mode, each <b>cell</b> shows <b>counts</b> of sequence pairs that differ only at that <br>monomer(row)-position(column) (<b>Size</b>) and <br>their mean activity difference (<b>Color</b>).','<b>Hover/Click</b> any non-empty cell.']);
+        const s81b = paragraphs(['In this mode, each <b>cell</b> shows <b>counts</b> of sequence pairs that differ only at that monomer(row)-position(column) (<b>Size</b>) and their mean activity difference (<b>Color</b>).','<b>Hover/Click</b> any non-empty cell.'], 'Mutation Cliffs');
         const step8B1 = greenHint(svmRoot, s81b, 'top');
         const mutViewerClickPromise = new Promise<void>((res) => {
             const timer = setInterval(() => {
@@ -308,7 +308,7 @@ export class PeptidesSarTutorial extends Tutorial {
         invariantHint.remove();
 
         // Step 9: Invariant Map
-        const step91Hint = greenHint(svmRoot, paragraphs(['Invariant Map', 'In this mode, each <b>cell</b> shows how many sequences contain <br>that monomer at that position (<b>number</b>) and <br>the mean activity of those sequences (<b>color</b>).','<b>Hover</b> or <b>click</b> any cell to see details']), 'right');
+        const step91Hint = greenHint(svmRoot, paragraphs(['In this mode, each <b>cell</b> shows how many sequences contain that monomer at that position (<b>number</b>) and the mean activity of those sequences (<b>color</b>).','<b>Hover</b> or <b>click</b> any cell to see details'], 'Invariant Map'), 'right');
         const step91Next = ui.button('NEXT', () => {});
         step91Hint.appendChild(step91Next);
         const step91Prom = new Promise<void>((resolve) => {
@@ -379,7 +379,7 @@ export class PeptidesSarTutorial extends Tutorial {
 
         const aggColumnsButton = aggColumnsHost!.querySelector('button') as HTMLButtonElement;
         const aggColumnsClick = rxjs.fromEvent(aggColumnsButton, 'click').pipe(operators.take(1)).toPromise();
-        const lstHint = greenHint(contextPanelRoot, paragraphs(['Add aggregated column','Under <b>Aggregations</b>, choose position <b>14</b> (Column named "14") and hit <b>OK</b> to add a <b>pie chart</b> distribution column.']), 'left');
+        const lstHint = greenHint(contextPanelRoot, paragraphs(['Under <b>Aggregations</b>, choose position <b>14</b> (Column named "14") and hit <b>OK</b> to add a <b>pie chart</b> distribution column.'], 'Add aggregated column'), 'left');
         const lstAggRegationPromise = new Promise<void>(async (resolve) => {
             await aggColumnsClick;
             const int = setInterval(() => {
@@ -450,7 +450,7 @@ export class PeptidesSarTutorial extends Tutorial {
             setTimeout(() => resolve(), 2000);
         });
 
-        const finalHintDiv = ui.divV([paragraphs([`All set!`, `You launched <b>SAR</b>, explored <b>WebLogos</b> and <b>monomers</b>,<br>configured <b>Sequence Variability Map</b> modes,<br>reviewed <b>Most Potent Residues</b>, examined <b>clusters</b>,<br>enriched the <b>Logo Summary Table</b>, and updated <b>global settings</b>.`]),
+        const finalHintDiv = ui.divV([paragraphs([`You launched <b>SAR</b>, explored <b>WebLogos</b> and <b>monomers</b>, configured <b>Sequence Variability Map</b> modes, reviewed <b>Most Potent Residues</b>, examined <b>clusters</b>, enriched the <b>Logo Summary Table</b>, and updated <b>global settings</b>.`], `All set!`),
             ui.link('Read more', 'https://datagrok.ai/help/datagrok/solutions/domains/bio/peptides-sar')
         ])
         const finalHint = greenHint(svmRoot, finalHintDiv, 'top');
@@ -474,12 +474,19 @@ function greenHint(el: HTMLElement, content: HTMLElement, position?: "top" | "bo
     return hint;
 }
 
-function paragraphs(texts: string[]) {
-    return ui.divV(texts.map((t, i) => {
-        const thing = i == 0 ? ui.h2(t, {style: {marginBottom: '0.8em'}}) : ui.divText(t);
-        thing.innerHTML = t;
-        return thing;
-}));
+function paragraphs(texts: string[], title?: string) {
+    const items: HTMLElement[] = [];
+    if (title != null) {
+        const heading = ui.h2(title, {style: {marginBottom: '0.8em'}});
+        heading.innerHTML = title;
+        items.push(heading);
+    }
+    for (const t of texts) {
+        const p = ui.divText(t);
+        p.innerHTML = t;
+        items.push(p);
+    }
+    return ui.divV(items);
 }
 
 function attachRemovingHintListener(hintDiv: HTMLElement, onRemoved: () => void) {

--- a/packages/Tutorials/src/widget.ts
+++ b/packages/Tutorials/src/widget.ts
@@ -54,7 +54,7 @@ export class TutorialWidget extends DG.Widget {
             if (existingDock)
               grok.shell.dockManager.close(existingDock);
           }
-          grok.shell.dockManager.dock(dockRoot, DG.DOCK_TYPE.LEFT, null, 'Tutorials', 0.27);
+          grok.shell.dockManager.dock(dockRoot, DG.DOCK_TYPE.LEFT, null, 'Tutorials', 0.22);
         });
 
         tracksRoot.append(ui.divV([


### PR DESCRIPTION
## GROK-19337: Peptides-SAR tutorial callout formatting and panel width

The Peptides-SAR tutorial (`Tutorials` plugin) rendered several callouts incorrectly: the step-4 callout showed its entire body sentence in bold, steps 5/6 (and other steps) bolded their first sentence, several callouts broke sentences onto new lines via mid-sentence `<br>` tags, and the left action panel was too wide.

### Root cause
`paragraphs()` in `public/packages/Tutorials/src/tracks/bio/tutorials/peptides-sar.ts` unconditionally wrapped the first array element in a bold `ui.h2()` heading. Call sites that pass a single body string (step 4) or lead with body text (steps 5/6, 7, 10, ...) therefore rendered that text as a bold title.

### Fix
- `paragraphs(texts, title?)` now renders every element of `texts` as plain body text and emits a bold `h2` only when an explicit `title` is provided. The four genuine-title callouts (Mutation Cliffs, Invariant Map, Add aggregated column, All set!) pass their short label via the new `title` argument, preserving intended headings while removing spurious bolding everywhere else.
- Removed literal mid-sentence `<br>` tags from the step-8/9/final callout strings (sentence-boundary `<br>` in `describe()` blocks left unchanged).
- Reduced the `.tutorials-root` dock ratio from `0.27` to `0.22` (~18% narrower) at both entry points that create it (`package.ts`, `widget.ts`).

### Testing
- `npm run build` exits 0 for the Tutorials package.
- Verified against the reproduction path: the step-4 callout's body string now renders at normal font-weight instead of a bold `<h2>`, so the "callout has all text bolded" symptom no longer occurs; title callouts still bold only their title. Reproduction evidence is on the JIRA ticket.

Closes GROK-19337.