### PR TITLE
GROK-20443: NodejsApiDemo: sample package — nodejs script with js-api and package functions

### DIFF
--- a/js-api/datagrok.ts
+++ b/js-api/datagrok.ts
@@ -1,13 +1,30 @@
 import * as dayjs from "dayjs";
 import * as wu from "wu";
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { createWindowProxy, DGNotSupportedError } from './src/node/window-proxy';
+import { installDomStub } from './src/node/dom-stub';
+
+export { DGNotSupportedError };
 
 (globalThis as any).self = globalThis;
-(globalThis as any).window = {};
+// grok_* registrations from the dart2js bundle land on the Proxy target;
+// unregistered names degrade gracefully instead of `undefined is not a function`.
+(globalThis as any).window = createWindowProxy();
 
-(globalThis as any).fetchWithCallback = function(url:any, params:any, callback:any, errorCallback:any) {
+// Stub asset imports (.css etc.) for unbundled CommonJS consumption; the webpack
+// bundle null-loads them already, tsx/ESM consumers use their own loader hooks.
+try {
+    const Module = require('node:module');
+    for (const ext of ['.css', '.scss', '.svg', '.png', '.jpg', '.gif', '.woff', '.woff2', '.ttf', '.eot'])
+        Module._extensions[ext] ??= (m: any) => { m.exports = {}; };
+} catch (_) { /* ESM-only runtime — loader hooks handle assets there */ }
+
+(globalThis as any).fetchWithCallback = function(url: any, params: any, callback: any, errorCallback: any) {
     fetch(url, params)
-        .then(async(response: any) => {callback(await response.bytes(), response.status, response.statusText, response.headers);})
+        .then(async (response: any) => {
+            // Response.bytes() is unavailable before Node 22 (JKG runs Node 18)
+            callback(new Uint8Array(await response.arrayBuffer()), response.status, response.statusText, response.headers);
+        })
         .catch(err => errorCallback(err));
 };
 
@@ -70,33 +87,56 @@ export function getContext() {
     return store?.token ?? null;
 }
 
-export async function startDatagrok(options: {apiUrl: string, apiToken?: string | undefined}): Promise<any> {
+/** Initializes the Datagrok environment under Node.js.
+ *
+ *  - Regular mode fetches startup data (functions registry, data sources, script
+ *    handlers) for the token's user — full `grok.functions` support, single-user.
+ *  - `detached: true` skips startup data: functions resolve lazily over REST and
+ *    server scripts run remotely. Required in shared/multi-user processes
+ *    (JKG kernels, per-request server contexts) so no per-user state is cached.
+ *
+ *  Idempotent: a second call only re-binds `grok.dapi.token` / `grok.dapi.root`. */
+export async function startDatagrok(options: {apiUrl: string, apiToken?: string | undefined, detached?: boolean}): Promise<void> {
+    const g = globalThis as any;
+    if (g.grok && g.DG) {
+        g.grok.dapi.token = options.apiToken;
+        g.grok.dapi.root = options.apiUrl;
+        return;
+    }
     console.log('Initializing Datagrok environment');
     //@ts-ignore
     await import ('./src/datagrok/build/web/grok_shared.dart.js');
 
-    await new Promise(resolve => setTimeout(resolve, 100));
-    (globalThis as any).document = {createElement: () => {return {bind: {}}}};
+    // dart2js runs async main() in a microtask after the import; wait for the interop
+    // surface ('in' bypasses the Proxy get-fallback and answers truthfully)
+    for (let waited = 0; !('grok_Init' in g.window); waited += 10) {
+        if (waited > 10000)
+            throw new Error('Datagrok Dart runtime failed to initialize (grok_Init never registered)');
+        await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    installDomStub();
     let DG = await import('./node-api');
+    // ui builders work against the DOM stub (inert elements); Dart-backed widgets
+    // still throw DGNotSupportedError via the window Proxy
+    let ui = await import('./ui');
 
-    (globalThis as any).grok = DG.grok;
-    (globalThis as any).DG = DG;
+    g.grok = DG.grok;
+    g.DG = DG;
+    g.ui = ui;
     const api: any = (typeof window !== 'undefined' ? window : global.window) as any;
     api.dayjs = dayjs;
     api.wu = wu;
     api.grok = DG.grok;
     api.DG = DG;
-    (globalThis as any).wu = wu;
-    (globalThis as any).dayjs = dayjs;
+    g.wu = wu;
+    g.dayjs = dayjs;
 
 
     DG.grok.dapi.token = options.apiToken;
     DG.grok.dapi.root = options.apiUrl;
 
-    let status = await (globalThis as any).window.grok_Init();
-    if (status != 0) {
-        console.log('Init function returned non-zero code');
-        process.exit(status);
-    }
+    let status = await g.window.grok_Init(options.detached === true);
+    if (status != 0)
+        throw new Error(`Datagrok initialization failed (grok_Init returned ${status}, see log above)`);
     console.log('Datagrok environment is ready');
 }

--- a/js-api/src/node/dom-stub.ts
+++ b/js-api/src/node/dom-stub.ts
@@ -1,0 +1,252 @@
+/**
+ * Minimal inert DOM for Node.js — installed by `startDatagrok` when no real
+ * `document` exists. It is just enough for the pure-DOM parts of the js-api
+ * (`ui.div()`-style builders, cash-dom, widgets' element bookkeeping) to run
+ * without a browser: elements are plain containers, nothing ever renders.
+ * Dart-backed UI (dialogs, viewers, grid) still degrades via the window Proxy.
+ */
+
+class FakeClassList {
+  private _set = new Set<string>();
+  add(...names: string[]) { for (const n of names) if (n) this._set.add(n); }
+  remove(...names: string[]) { for (const n of names) this._set.delete(n); }
+  contains(name: string): boolean { return this._set.has(name); }
+  toggle(name: string, force?: boolean): boolean {
+    const on = force ?? !this._set.has(name);
+    on ? this._set.add(name) : this._set.delete(name);
+    return on;
+  }
+  get value(): string { return [...this._set].join(' '); }
+  set value(v: string) { this._set = new Set(v.split(/\s+/).filter((s) => s)); }
+  forEach(f: (name: string) => void) { this._set.forEach(f); }
+  get length(): number { return this._set.size; }
+  toString(): string { return this.value; }
+}
+
+class FakeNode {
+  childNodes: FakeNode[] = [];
+  parentNode: FakeNode | null = null;
+  parentElement: FakeNode | null = null;
+  nodeType = 1;
+  nodeName = '';
+  textContent: any = '';
+
+  appendChild<T extends FakeNode>(child: T): T {
+    child.remove();
+    this.childNodes.push(child);
+    child.parentNode = child.parentElement = this;
+    return child;
+  }
+  append(...children: any[]) { for (const c of children) this.appendChild(typeof c === 'object' && c !== null ? c : new FakeText(String(c))); }
+  prepend(...children: any[]) { for (const c of children.reverse()) this.insertBefore(typeof c === 'object' && c !== null ? c : new FakeText(String(c)), this.firstChild); }
+  insertBefore<T extends FakeNode>(child: T, ref: FakeNode | null): T {
+    child.remove();
+    const i = ref ? this.childNodes.indexOf(ref) : -1;
+    i >= 0 ? this.childNodes.splice(i, 0, child) : this.childNodes.push(child);
+    child.parentNode = child.parentElement = this;
+    return child;
+  }
+  removeChild<T extends FakeNode>(child: T): T {
+    const i = this.childNodes.indexOf(child);
+    if (i >= 0) this.childNodes.splice(i, 1);
+    child.parentNode = child.parentElement = null;
+    return child;
+  }
+  replaceChild(newChild: FakeNode, oldChild: FakeNode): FakeNode {
+    this.insertBefore(newChild, oldChild);
+    return this.removeChild(oldChild);
+  }
+  remove() { this.parentNode?.removeChild(this); }
+  cloneNode(_deep?: boolean): FakeNode { return new (this.constructor as any)(); }
+  contains(other: FakeNode | null): boolean {
+    for (let n = other; n != null; n = n.parentNode)
+      if (n === this) return true;
+    return false;
+  }
+  get firstChild(): FakeNode | null { return this.childNodes[0] ?? null; }
+  get lastChild(): FakeNode | null { return this.childNodes[this.childNodes.length - 1] ?? null; }
+  get nextSibling(): FakeNode | null {
+    const sib = this.parentNode?.childNodes;
+    return sib ? sib[sib.indexOf(this) + 1] ?? null : null;
+  }
+  get previousSibling(): FakeNode | null {
+    const sib = this.parentNode?.childNodes;
+    return sib ? sib[sib.indexOf(this) - 1] ?? null : null;
+  }
+  hasChildNodes(): boolean { return this.childNodes.length > 0; }
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent(): boolean { return true; }
+}
+
+class FakeText extends FakeNode {
+  nodeType = 3;
+  nodeName = '#text';
+  constructor(text: string = '') { super(); this.textContent = text; }
+  get data() { return this.textContent; }
+  set data(v: any) { this.textContent = v; }
+}
+
+class FakeDocumentFragment extends FakeNode {
+  nodeType = 11;
+  nodeName = '#document-fragment';
+}
+
+function makeStyle(): any {
+  const store: Record<string, string> = {};
+  return new Proxy(store, {
+    get(t, prop: string) {
+      if (prop === 'setProperty') return (k: string, v: string) => { t[k] = v; };
+      if (prop === 'getPropertyValue') return (k: string) => t[k] ?? '';
+      if (prop === 'removeProperty') return (k: string) => { const v = t[k]; delete t[k]; return v ?? ''; };
+      if (prop === 'cssText') return Object.entries(t).map(([k, v]) => `${k}: ${v}`).join('; ');
+      return t[prop] ?? '';
+    },
+    set(t, prop: string, value) { t[prop] = value; return true; },
+  });
+}
+
+class FakeElement extends FakeNode {
+  tagName: string;
+  namespaceURI: string | null = null;
+  id = '';
+  classList = new FakeClassList();
+  style = makeStyle();
+  dataset: Record<string, string> = {};
+  attributes: Record<string, string> = {};
+  innerHTML = '';
+  innerText: any = '';
+  value: any = '';
+  checked = false;
+  disabled = false;
+  tabIndex = -1;
+  scrollTop = 0;
+  scrollLeft = 0;
+  offsetWidth = 0;
+  offsetHeight = 0;
+  clientWidth = 0;
+  clientHeight = 0;
+  onclick: any = null;
+  ownerDocument: any;
+
+  constructor(tagName: string = 'div') {
+    super();
+    this.tagName = tagName.toUpperCase();
+    this.nodeName = this.tagName;
+  }
+  get className(): string { return this.classList.value; }
+  set className(v: string) { this.classList.value = v; }
+  get children(): FakeElement[] { return this.childNodes.filter((n) => n instanceof FakeElement) as FakeElement[]; }
+  get firstElementChild(): FakeElement | null { return this.children[0] ?? null; }
+  get lastElementChild(): FakeElement | null { return this.children[this.children.length - 1] ?? null; }
+  setAttribute(name: string, value: any) { this.attributes[name] = String(value); }
+  getAttribute(name: string): string | null { return this.attributes[name] ?? null; }
+  removeAttribute(name: string) { delete this.attributes[name]; }
+  hasAttribute(name: string): boolean { return name in this.attributes; }
+  querySelector(): any { return null; }
+  querySelectorAll(): any[] { return []; }
+  getElementsByClassName(): any[] { return []; }
+  getElementsByTagName(): any[] { return []; }
+  closest(): any { return null; }
+  matches(): boolean { return false; }
+  getBoundingClientRect() { return {x: 0, y: 0, left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0}; }
+  getContext(): any { return null; }  // canvas — nothing renders under Node
+  focus() {}
+  blur() {}
+  click() {}
+  scrollIntoView() {}
+  insertAdjacentElement(_where: string, el: any) { this.appendChild(el); return el; }
+  insertAdjacentHTML() {}
+  cloneNode(_deep?: boolean): FakeElement { return new FakeElement(this.tagName); }
+  toString(): string { return `[FakeElement ${this.tagName}]`; }
+}
+
+class FakeHTMLCollection extends Array {}
+
+class FakeEvent {
+  type: string;
+  target: any = null;
+  defaultPrevented = false;
+  constructor(type: string = '', _init?: any) { this.type = type; }
+  preventDefault() { this.defaultPrevented = true; }
+  stopPropagation() {}
+  stopImmediatePropagation() {}
+}
+
+class FakeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): any[] { return []; }
+}
+
+/** Installs `document` + DOM classes on globalThis when running outside a browser.
+ *  Call AFTER the dart2js bundle import: its environment detection must keep
+ *  seeing `typeof document === 'undefined'` (the proven non-browser path). */
+export function installDomStub(): void {
+  const g = globalThis as any;
+  if (typeof g.document !== 'undefined' && g.document?.createElement && !g.document.__dgStub)
+    return;   // real DOM present — never override
+
+  const document: any = {
+    __dgStub: true,
+    readyState: 'complete',
+    currentScript: null,
+    cookie: '',
+    createElement: (tag: string) => {
+      const el = new FakeElement(tag);
+      el.ownerDocument = document;
+      return el;
+    },
+    createElementNS: (ns: string, tag: string) => {
+      const el = new FakeElement(tag);
+      el.namespaceURI = ns;
+      el.ownerDocument = document;
+      return el;
+    },
+    createTextNode: (text: string) => new FakeText(text),
+    createDocumentFragment: () => new FakeDocumentFragment(),
+    createEvent: () => new FakeEvent(),
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    getElementById: () => null,
+    getElementsByClassName: () => [],
+    getElementsByTagName: () => [],
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+    hasFocus: () => false,
+    execCommand: () => false,
+  };
+  document.documentElement = document.createElement('html');
+  document.head = document.createElement('head');
+  document.body = document.createElement('body');
+  document.defaultView = g.window;
+
+  g.document = document;
+  g.Node = FakeNode;
+  g.Element = FakeElement;
+  g.HTMLElement = FakeElement;
+  g.HTMLCollection = FakeHTMLCollection;
+  g.Text = FakeText;
+  g.DocumentFragment = FakeDocumentFragment;
+  g.Event = FakeEvent;
+  g.CustomEvent = FakeEvent;
+  g.KeyboardEvent = FakeEvent;
+  g.MouseEvent = FakeEvent;
+  g.MutationObserver = FakeObserver;
+  g.ResizeObserver = FakeObserver;
+  g.IntersectionObserver = FakeObserver;
+  // canvas API classes: js-api extends their prototypes at import time
+  g.CanvasRenderingContext2D ??= class CanvasRenderingContext2D {};
+  g.CanvasGradient ??= class CanvasGradient {};
+  g.CanvasPattern ??= class CanvasPattern {};
+  g.Image ??= class Image extends FakeElement { constructor() { super('img'); } };
+  g.Path2D ??= class Path2D {};
+  for (const tag of ['Div', 'Span', 'Input', 'TextArea', 'Select', 'Button', 'Anchor', 'Image',
+    'Canvas', 'Table', 'TableRow', 'TableCell', 'Label', 'Paragraph', 'Heading', 'UList', 'LI', 'IFrame'])
+    g[`HTML${tag}Element`] ??= FakeElement;
+  g.requestAnimationFrame ??= (f: Function) => setTimeout(f, 0);
+  g.cancelAnimationFrame ??= (id: any) => clearTimeout(id);
+  g.getComputedStyle ??= () => makeStyle();
+}

--- a/js-api/src/node/window-proxy.ts
+++ b/js-api/src/node/window-proxy.ts
@@ -1,0 +1,67 @@
+/**
+ * Node.js `window` shim.
+ *
+ * The dart2js bundle (grok_shared.dart.js) registers its interop functions by
+ * setting `grok_*` properties on `globalThis.window` — those land on the Proxy
+ * target and win over the fallback. Reading a `grok_*` name the Dart runtime did
+ * NOT register returns a stub that either maps to a console no-op (curated list)
+ * or throws a descriptive {@link DGNotSupportedError} instead of the raw
+ * `api.grok_X is not a function` TypeError.
+ *
+ * The `has` trap is left untouched on purpose: `'grok_X' in window` (and Dart-side
+ * hasProperty checks) still answer truthfully whether a function is registered.
+ */
+
+export class DGNotSupportedError extends Error {
+  constructor(name: string) {
+    super(`${name} is not available under Node.js: it is implemented by the Datagrok browser client (UI/Dart). ` +
+      'Use the server-side equivalents (grok.dapi.*, grok.functions.*, DG.DataFrame) or run this code in the browser.');
+    this.name = 'DGNotSupportedError';
+  }
+}
+
+function balloon(msg: any, type?: string): void {
+  const log = type === 'error' ? console.error : type === 'warning' ? console.warn : console.log;
+  log(`[shell.${type ?? 'info'}] ${typeof msg === 'string' ? msg : msg?.textContent ?? JSON.stringify(msg)}`);
+}
+
+/** UI notifications that degrade to console output / no-ops instead of throwing. */
+const consoleStubs: Record<string, Function> = {
+  grok_Balloon: balloon,
+  grok_ShowHelp: () => {},
+  grok_Utils_LoadJsCss: () => Promise.resolve([]),
+};
+
+/** Names that js-api feature-detects with `api.grok_X == null` and has a fallback
+ * for — they must read as undefined when unregistered, not as a throwing stub. */
+const nullCheckedNames = new Set(['grok_View_Set_Name', 'grok_UI_Render']);
+
+export function createWindowProxy(): any {
+  const target: any = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+    navigator: {userAgent: `Node.js ${typeof process !== 'undefined' ? process.version : ''}`},
+    location: {href: '', origin: '', pathname: '', search: '', hash: ''},
+    /** Feature detection for API authors: true if the Dart runtime registered the function. */
+    isDartRegistered: (name: string) => name in target,
+  };
+  return new Proxy(target, {
+    get(t, prop, receiver) {
+      if (prop in t)
+        return Reflect.get(t, prop, receiver);
+      if (typeof prop === 'string' && prop.startsWith('grok_') && !nullCheckedNames.has(prop)) {
+        // grok_UI_* are element builders — per the hybrid degradation contract they
+        // return inert stub elements instead of throwing, so shared layout code runs
+        if (prop.startsWith('grok_UI_'))
+          return (...args: any[]) => {
+            const el: any = (globalThis as any).document?.createElement?.('div') ?? {};
+            if (typeof args[0] === 'string') el.textContent = args[0];
+            return el;
+          };
+        return consoleStubs[prop] ?? (() => { throw new DGNotSupportedError(prop as string); });
+      }
+      return undefined;
+    },
+  });
+}

--- a/packages/ApiTests/CHANGELOG.md
+++ b/packages/ApiTests/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.10.3 (WIP)
 
+* Node runner: Expanded coverage from `dapi/` to all UI-independent categories (dataframe, functions, bitset, valuematcher, property, stats, shell); added `--mode functional|stress` (stress keeps the old stressTest-only behavior); per-file load errors no longer abort the run
+
 * Security: rebuilt `apitests-docker-test1` on `python:3.12-alpine` (+ `apk upgrade`, refreshed pip/setuptools/wheel) to clear base-OS CVEs (expat/krb5/openssl/musl) and stale Python tooling.
 
 Add `Dapi: entities.save (polymorphic)` tests covering Project and DataConnection round-trip via `grok.dapi.entities.save`.

--- a/packages/ApiTests/NODE_RUNNER.md
+++ b/packages/ApiTests/NODE_RUNNER.md
@@ -37,10 +37,17 @@ npm run stress-node
 
 | Script | What it does | Server? |
 |--------|--------------|---------|
-| `start-node` | Run the dapi suite once | yes |
-| `stress-node` | Run the suite repeatedly at increasing concurrency (`--concurrencyRange=10-100 --step=5`) | yes |
+| `start-node` | Run all UI-independent suites once (`--mode functional`, the default) | yes |
+| `stress-node` | Run the stressTest-marked suite repeatedly at increasing concurrency (`--mode stress --concurrencyRange=10-100 --step=5`) | yes |
+
+The runner loads the UI-independent category folders (`nodeTestDirs` in
+`package-test-node.ts`): `dapi`, `dataframe`, `functions`, `bitset`, `valuematcher`,
+`property`, `stats`, `shell`. `grid/`, `widgets/`, `ai/`, `packages/`, `utils/` stay
+browser-only. A test file that fails to load is reported and skipped — it doesn't
+abort the run (but fails the exit code).
 
 CLI flags (see `parseArgs` in `package-test-node.ts`): `--apiUrl`, `--devKey` (required),
+`--mode functional|stress` (default `functional`; `stress` = only stressTest-marked tests),
 `-c/--categories`, `--concurrentRuns`, `--concurrencyRange "1-10"`, `--step`, `-l/--loop`.
 
 Results are written to `test-report.csv` (gitignored), **overwritten on every run**.
@@ -82,8 +89,11 @@ few adjustments let Node load the same sources unchanged:
   transitively load the entire browser suite (which would run import-time browser/Dart side
   effects such as `cache.ts`'s top-level `grok.functions.register`).
 
-## Known failures under Node
+## UI degradation under Node
 
-A handful of tests depend on Dart-client features the Node client doesn't expose (e.g.
-`grok.shell.user` → `grok_User`, `grok.dapi.groups.currentUserGroups`). These are reported as
-failures rather than hidden — they are genuine Node-client gaps, not runner problems.
+The former known failures (`grok.shell.user`, `grok.dapi.groups.currentUserGroups`) are fixed —
+the Node Dart bundle now registers `grok_User`, shell vars, custom events, and client build info.
+Remaining browser-only APIs degrade gracefully: notifications (`grok.shell.info/warning/error`)
+log to the console, DOM builders return inert elements, and Dart-backed UI (views, dialogs,
+viewers, grid) throws a descriptive `DGNotSupportedError`. Tests that need them carry
+`skipReason: 'NodeJS environment'`.

--- a/packages/ApiTests/node-test-loader/register.mjs
+++ b/packages/ApiTests/node-test-loader/register.mjs
@@ -24,3 +24,30 @@ const ASSET_EXTENSIONS = [
 const stub = (module) => { module.exports = {}; };
 for (const ext of ASSET_EXTENSIONS)
   Module._extensions[ext] = stub;
+
+// Single-instance js-api: `startDatagrok` (webpack CommonJS bundle) defines the runtime
+// classes and sets globalThis.DG/grok/ui. Without this, test files would load a second
+// tsc-compiled copy of the same classes via 'datagrok-api/dg' — structurally identical
+// but failing every `instanceof` against runtime-created objects. Alias the subpath
+// imports to the runtime globals instead (tests run after startDatagrok, so the lazy
+// property reads resolve).
+const RUNTIME_GLOBALS = {
+  'datagrok-api/dg': () => globalThis.DG,
+  'datagrok-api/grok': () => globalThis.grok,
+  'datagrok-api/ui': () => globalThis.ui,
+};
+const origResolve = Module._resolveFilename;
+Module._resolveFilename = function(request, ...args) {
+  if (request in RUNTIME_GLOBALS) return `\0dg-runtime:${request}`;
+  return origResolve.call(this, request, ...args);
+};
+const origLoad = Module._load;
+Module._load = function(request, ...args) {
+  if (request in RUNTIME_GLOBALS) {
+    const value = RUNTIME_GLOBALS[request]();
+    if (value === undefined)
+      throw new Error(`${request} requested before startDatagrok() initialized the runtime`);
+    return value;
+  }
+  return origLoad.call(this, request, ...args);
+};

--- a/packages/ApiTests/package.json
+++ b/packages/ApiTests/package.json
@@ -67,7 +67,7 @@
     "debug-js-api-tests-localhost": "grok publish localhost",
     "release-js-api-tests-localhost": "npm run build-js-api-tests && grok publish localhost --release",
     "start-node": "node --import tsx --import ./node-test-loader/register.mjs src/package-test-node.ts --apiUrl=http://localhost:8888/api --devKey=admin",
-    "stress-node": "node --import tsx --import ./node-test-loader/register.mjs src/package-test-node.ts --apiUrl=http://localhost:8888/api --devKey=admin --concurrencyRange=10-100 --step=5"
+    "stress-node": "node --import tsx --import ./node-test-loader/register.mjs src/package-test-node.ts --apiUrl=http://localhost:8888/api --devKey=admin --mode=stress --concurrencyRange=10-100 --step=5"
   },
   "canEdit": [
     "Administrators"

--- a/packages/ApiTests/src/dapi/packages.ts
+++ b/packages/ApiTests/src/dapi/packages.ts
@@ -22,7 +22,7 @@ category('Dapi: packages', () => {
   test('webRoot content', async () => {
     const apiTestsPackage = await grok.dapi.packages.find(_package.id);
     expect(apiTestsPackage.webRoot + '/', _package.webRoot);
-  });
+  }, {skipReason: typeof process !== 'undefined' ? 'under Node the test package is a dapi entity (no client webRoot)' : undefined});
 
   test('readCsv error', async () => {
     await expectExceptionAsync(() => _package.files.readCsv('datasets/noFile.csv').then());

--- a/packages/ApiTests/src/dataframe/calculated-columns.ts
+++ b/packages/ApiTests/src/dataframe/calculated-columns.ts
@@ -34,7 +34,7 @@ category('DataFrame: Calculated columns', () => {
     } finally {
       df.columns.remove('new');
     }
-  });
+  }, {skipReason: typeof process !== 'undefined' ? 'client package functions are not loaded in NodeJS' : undefined});
 
   test('Create a calculated column with async formula', async () => {
     try {
@@ -44,7 +44,7 @@ category('DataFrame: Calculated columns', () => {
     } finally {
       df.columns.remove('new');
     }
-  });
+  }, {skipReason: typeof process !== 'undefined' ? 'client package functions are not loaded in NodeJS' : undefined});
 
   test('Add new column dialog', () => new Promise(async (resolve, reject) => {
     if ((await grok.dapi.packages.filter('PowerPack').list({pageSize: 5})).length > 0)

--- a/packages/ApiTests/src/dataframe/dataframe.ts
+++ b/packages/ApiTests/src/dataframe/dataframe.ts
@@ -156,7 +156,7 @@ category('DataFrame: Methods', () => {
     expect(t2.columns.byName('x').getNumber(0) === 9);
     expect(t2.columns.byName('z').getNumber(1) === 7);
     expect(t2.columns.byName('y').getNumber(2) === 6);
-  });
+  }, {skipReason: typeof process !== 'undefined' ? 'NodeJS environment' : undefined});
 
   test('toJson | fromJson', async () => {
     const t = createDf();

--- a/packages/ApiTests/src/functions/functions.ts
+++ b/packages/ApiTests/src/functions/functions.ts
@@ -8,6 +8,8 @@ import {category, test, expect, expectExceptionAsync} from '@datagrok-libraries/
 import * as grok from 'datagrok-api/grok';
 import * as DG from 'datagrok-api/dg';
 
+const nodeSkip = typeof process !== 'undefined' ? 'grok.functions.register is browser-only' : undefined;
+
 category('Functions: Multiple outputs', () => {
   test('sync: register and call', async () => {
     const f = grok.functions.register({
@@ -18,7 +20,7 @@ category('Functions: Multiple outputs', () => {
     await call.call();
     expect(call.outputs.get('sum'), 7, 'sum');
     expect(call.outputs.get('product'), 12, 'product');
-  });
+  }, {skipReason: nodeSkip});
 
   test('async: register and call', async () => {
     const f = grok.functions.register({
@@ -30,7 +32,7 @@ category('Functions: Multiple outputs', () => {
     await call.call();
     expect(call.outputs.get('greeting'), 'hello world', 'greeting');
     expect(call.outputs.get('length'), 5, 'length');
-  });
+  }, {skipReason: nodeSkip});
 
   test('output params metadata', async () => {
     const f = grok.functions.register({
@@ -40,7 +42,7 @@ category('Functions: Multiple outputs', () => {
     expect(f.outputs.length, 2, 'output count');
     expect(f.outputs[0].name, 'x', 'first output name');
     expect(f.outputs[1].name, 'y', 'second output name');
-  });
+  }, {skipReason: nodeSkip});
 
   test('with semantic type', async () => {
     const f = grok.functions.register({
@@ -51,7 +53,7 @@ category('Functions: Multiple outputs', () => {
     await call.call();
     expect(call.outputs.get('mol'), 'c1ccccc1', 'mol');
     expect(call.outputs.get('score'), 0.95, 'score');
-  });
+  }, {skipReason: nodeSkip});
 });
 
 category('Functions: General', () => {
@@ -59,13 +61,13 @@ category('Functions: General', () => {
     const dfList: DG.DataFrame[] = await grok.functions
       .eval('OpenServerFile("System:AppData/ApiTests/datasets/demog.csv")');
     expect(dfList[0].columns instanceof DG.ColumnList, true);
-  }, {stressTest: true});
+  }, {stressTest: true, skipReason: typeof process !== 'undefined' ? 'OpenServerFile is a client command' : undefined});
 
   test('call', async () => {
     const dfList: DG.DataFrame[] = await grok.functions
       .call('OpenServerFile', {'fullPath': 'System:AppData/ApiTests/datasets/demog.csv'});
     expect(dfList[0].columns instanceof DG.ColumnList, true);
-  }, {stressTest: true});
+  }, {stressTest: true, skipReason: typeof process !== 'undefined' ? 'OpenServerFile is a client command' : undefined});
 
   test('def param', async () => {
     await grok.functions.call('AddNewColumn', {table: grok.data.demo.demog(), expression: 'test', name: 'test'});
@@ -113,5 +115,5 @@ category('Functions: General', () => {
     expect(views.length, 1, 'one view');
     expect(views[0] instanceof DG.TableView, true, 'view is TableView');
     expect((views[0] as DG.TableView).dataFrame.columns.length, 2, 'dataframe columns');
-  });
+  }, {skipReason: nodeSkip});
 });

--- a/packages/ApiTests/src/package-test-node.ts
+++ b/packages/ApiTests/src/package-test-node.ts
@@ -14,12 +14,26 @@ import { setTestPackage } from './test-package';
 declare let grok: typeof _grok, DG: typeof _DG;
 export let _package: _DG.Package;
 
+// Entries are basenames or dir-qualified paths (e.g. 'shell/events.ts')
 const testsExclude = [
     'sticky_meta.ts',
     'benchmarks.ts',
     'functions-annotations.ts',
-    'vector-functions-and-scripts.ts'
+    'vector-functions-and-scripts.ts',
+    'cache.ts',          // client function-result cache: IndexedDB + grok.functions.register (browser-only)
+    'shell/events.ts',   // shell workspace events (table/view add) — browser-only
+    'shell/settings.ts', // client shell settings object — browser-only
+    'shell/ml.ts',       // registers client JS funcs at import (grok.functions.register)
+    'dataframe/add-new-column.ts', // dialog-driven (PowerPack addNewColumnDialog)
 ];
+
+// UI-independent test folders that run under Node; grid/, widgets/, ai/, packages/
+// and utils/ stay browser-only (Dart client / DOM dependencies).
+const nodeTestDirs = ['dapi', 'dataframe', 'functions', 'bitset', 'valuematcher', 'property', 'stats', 'shell'];
+
+// 'functional': run every loaded test (UI-dependent ones self-skip via skipReason);
+// 'stress': only stressTest-marked tests — the concurrency-sweep baseline.
+let mode: 'functional' | 'stress' = 'functional';
 
 async function main(): Promise<void> {
     const { apiUrl, devKey, concurrentRuns, categories, loop, concurrencyRange } = parseArgs();
@@ -68,6 +82,10 @@ async function main(): Promise<void> {
 
     await saveResults(results);
     console.log('Finished running tests');
+    if (loadFailures.length > 0) {
+        console.error(`\n❌ ${loadFailures.length} test file(s) failed to load: ${loadFailures.join(', ')}`);
+        process.exit(1);
+    }
     process.exit(0);
 }
 
@@ -117,6 +135,12 @@ function parseArgs() {
             default: false,
             describe: 'If true, continuously repeat tasks with the specified number of concurrent runs',
         })
+        .option('mode', {
+            type: 'string',
+            choices: ['functional', 'stress'] as const,
+            default: 'functional',
+            describe: 'functional: run all loaded tests once; stress: only stressTest-marked tests (concurrency baseline)',
+        })
         .option('step', {
             type: 'number',
             describe: 'Step to use for concurrencyRange'
@@ -137,6 +161,7 @@ function parseArgs() {
         .help()
         .parseSync();
 
+    mode = argv.mode as typeof mode;
     const res: any = {
         apiUrl: argv.apiUrl,
         devKey: argv.devKey,
@@ -172,17 +197,28 @@ async function getToken(url: string, key: string) {
         throw new Error('Unable to login to server. Check your dev key.');
 }
 
+const loadFailures: string[] = [];
+
 async function loadTestFiles(): Promise<void> {
-    const dapiDir = join(dirname(fileURLToPath(import.meta.url)), 'dapi');
-    const files = await readdir(dapiDir);
-    for (const file of files) {
-        const baseName = basename(file);
-        if (testsExclude.includes(baseName)) {
-            console.log(`Skipping tests in ${baseName} because test file marked as unsupported.`);
-            continue;
+    const srcDir = dirname(fileURLToPath(import.meta.url));
+    for (const dir of nodeTestDirs) {
+        const testDir = join(srcDir, dir);
+        const files = await readdir(testDir);
+        for (const file of files) {
+            const baseName = basename(file);
+            if (testsExclude.includes(baseName) || testsExclude.includes(`${dir}/${baseName}`)) {
+                console.log(`Skipping tests in ${dir}/${baseName} because test file marked as unsupported.`);
+                continue;
+            }
+            if (baseName.endsWith('.ts')) {
+                try {
+                    await import(pathToFileURL(join(testDir, file)).href);
+                } catch (e: any) {
+                    loadFailures.push(`${dir}/${baseName}`);
+                    console.error(`❌ Failed to load ${dir}/${baseName} (its tests will not run): ${e?.message ?? e}`);
+                }
+            }
         }
-        if (baseName.endsWith('.ts'))
-            await import(pathToFileURL(join(dapiDir, file)).href);
     }
 }
 
@@ -193,10 +229,13 @@ async function run(concurrentRun: number, categories: Set<string>, concurrency: 
     // The stress suite is the stressTest-marked tests. Filter the registry directly
     // (not all installed @datagrok-libraries/test versions honor the stressTest run
     // option), so only stress-marked tests run and the baseline can be 100%.
-    for (const key of Object.keys(tests)) {
-        const cat: any = (tests as any)[key];
-        if (cat?.tests)
-            cat.tests = cat.tests.filter((t: any) => t.options?.stressTest);
+    // Functional mode runs everything that was loaded.
+    if (mode === 'stress') {
+        for (const key of Object.keys(tests)) {
+            const cat: any = (tests as any)[key];
+            if (cat?.tests)
+                cat.tests = cat.tests.filter((t: any) => t.options?.stressTest);
+        }
     }
     // Wall-clock window for this task, so stress runs can be correlated with the
     // container CPU/memory time series (UTC, matching the docker_stats collector).
@@ -207,7 +246,7 @@ async function run(concurrentRun: number, categories: Set<string>, concurrency: 
                 category: key,
                 test: undefined,
                 testContext: undefined,
-                stressTest: true,
+                stressTest: mode === 'stress',
                 nodeOptions: {package: _package}
             })));
     if (data.length === 0)
@@ -257,7 +296,7 @@ async function saveResults(results: _DG.DataFrame[]): Promise<void> {
     const res: _DG.DataFrame = results[0];
     for (let i = 1; i < results.length; i++)
         res.append(results[i], true);
-    await res.columns.addNewCalculated('stress_test', 'true', DG.COLUMN_TYPE.BOOL, false, false);
+    await res.columns.addNewCalculated('stress_test', `${mode === 'stress'}`, DG.COLUMN_TYPE.BOOL, false, false);
     await res.columns.addNewCalculated('benchmark', 'false', DG.COLUMN_TYPE.BOOL, false, false);
     console.log('Writing results in test-report.csv.')
     writeFileSync('test-report.csv', res.toCsv(), 'utf-8')

--- a/packages/ApiTests/src/property/property.ts
+++ b/packages/ApiTests/src/property/property.ts
@@ -9,13 +9,13 @@ category('Property: General', () => {
     const dfList: DG.DataFrame[] = await grok.functions
       .eval('OpenServerFile("System:AppData/ApiTests/datasets/demog.csv")');
     expect(dfList[0].columns instanceof DG.ColumnList, true);
-  });
+  }, {skipReason: typeof process !== 'undefined' ? 'NodeJS environment' : undefined});
 
   test('call', async () => {
     const dfList: DG.DataFrame[] = await grok.functions
       .call('OpenServerFile', {'fullPath': 'System:AppData/ApiTests/datasets/demog.csv'});
     expect(dfList[0].columns instanceof DG.ColumnList, true);
-  });
+  }, {skipReason: typeof process !== 'undefined' ? 'NodeJS environment' : undefined});
 
   test('def param', async () => {
     await grok.functions.call('AddNewColumn', {table: grok.data.demo.demog(), expression: 'test', name: 'test'});
@@ -81,5 +81,5 @@ category('Property: Header parsing', () => {
   test('Complex caption', async () => {
     expect(func.inputs[11].friendlyName, 'MIC O2 P/V exponent');
     expect(ui.input.forProperty(func.inputs[11]).caption, 'MIC O2 P/V exponent');
-  });
+  }, {skipReason: typeof process !== 'undefined' ? 'NodeJS environment' : undefined});
 });

--- a/packages/ApiTests/src/shell/shell.ts
+++ b/packages/ApiTests/src/shell/shell.ts
@@ -5,6 +5,7 @@ import * as DG from 'datagrok-api/dg';
 import * as ui from 'datagrok-api/ui';
 
 category('Shell', () => {
+  const nodeSkip = typeof process !== 'undefined' ? 'NodeJS environment' : undefined;
   let demog: DG.DataFrame;
 
   before(async () => {
@@ -18,7 +19,7 @@ category('Shell', () => {
     expect(grok.shell.t, v.dataFrame);
     v.close();
     expect(grok.shell.v != v, true);
-  });
+  }, {skipReason: nodeSkip});
 
   test('addView', async () => {
     let view = DG.View.create();
@@ -28,7 +29,7 @@ category('Shell', () => {
     v.close();
     //@ts-ignore
     expect(grok.shell.v?.id != view.id, true);
-  });
+  }, {skipReason: nodeSkip});
 
   test('tables', async () => {
     grok.shell.closeAll();
@@ -38,20 +39,20 @@ category('Shell', () => {
     expectArray(grok.shell.tables.map(e => e.name), [t.name, t2.name, t3.name]);
     grok.shell.closeTable(t);
     expect(grok.shell.tables.length, 2)
-  });
+  }, {skipReason: nodeSkip});
 
   test('closeTable', async () => {
     grok.shell.closeAll();
     const t = grok.shell.addTableView(demog);
     grok.shell.closeTable(t.dataFrame);
     expect(grok.shell.tables.length, 0)
-  });
+  }, {skipReason: nodeSkip});
 
   test('tableByName', async () => {
     grok.shell.closeAll();
     const t = grok.shell.addTableView(demog);
     expect(grok.shell.tableByName(demog.name), t.dataFrame)
-  });
+  }, {skipReason: nodeSkip});
 
   test('dockManager', async () => {
     grok.shell.closeAll();
@@ -61,7 +62,7 @@ category('Shell', () => {
     expect(document.querySelector(".dockManagerTest"), v);
     grok.shell.dockManager.close(docked);
     expect(document.querySelector(".dockManagerTest"), null);
-  });
+  }, {skipReason: nodeSkip});
 
   test('closeAll', async () => {
     grok.shell.addTableView(demog);
@@ -70,14 +71,14 @@ category('Shell', () => {
     const views = Array.from(grok.shell.views);
     expect(views.length == 0 || views.every((v) => v.name === 'Datagrok' || v.name === 'Home' || v.name == 'Test Manager'), true);
     expect(document.querySelector(".dockManagerTest"), null);
-  });
+  }, {skipReason: nodeSkip});
 
   test('ViewBase rename after toDart-toJs conversion', async () => {
     const view = DG.toJs(DG.toDart(new DG.ViewBase())) as DG.ViewBase;
     const testName = 'TestViewName';
     view.name = testName;
     expect(view.name, testName);
-  });
+  }, {skipReason: typeof process !== 'undefined' ? 'NodeJS environment' : undefined});
 
   test('getSetVar', async () => {
     let x  = { test: 'test1' };
@@ -98,7 +99,7 @@ category('Shell', () => {
     expect(grok.shell.project.isDirty, true);
     grok.shell.clearDirtyFlag();
     expect(grok.shell.project.isDirty, false);
-  });
+  }, {skipReason: nodeSkip});
 
   test('sideBar', async () => {
     grok.shell.sidebar.addPane('testSideBarElement', ()=>ui.div());
@@ -107,5 +108,5 @@ category('Shell', () => {
     grok.shell.sidebar.clear();
     pane = document.querySelector('[name="testSideBarElement"]');
     expect(pane === null, true);
-  });
+  }, {skipReason: nodeSkip});
 }, { owner: 'aparamonov@datagrok.ai' });

--- a/packages/CVMTests/CHANGELOG.md
+++ b/packages/CVMTests/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v.next
 
+* Scripts: Migrated nodejs test scripts to the js-api (`grok`/`DG` globals); dataframe-js/axios are no longer injected into nodejs scripts (breaking — legacy scripts must `require()` them explicitly or move to `DG.DataFrame`)
+
 * Tests: fixed Docker tests — the container-name filter never matched. Platform registers package containers as `kebab(package.name)-<dockerfileFolder>` (`cvm-tests-cvmtests-docker-test1/2`); the test queried `cvmtests-Cvmtests-...`, so `before()` got `undefined` and all 5 Docker tests failed. Also added a clear not-found error instead of a cryptic undefined cascade.
 * Tests: fixed `Column list` script tests — JS `column_list` input is a name array (`string[]`), so use `cols[0]` not `cols.toList()[0]`; Grok script now `DeleteColumns(df, Named([cols.first]))` — a runtime list value isn't coerced to a column filter (only parse-time list literals are), so the prior `DeleteColumns(df, [cols.first])` threw `Class 'List' has no instance method 'makePredicate'`. Wrapping in `Named(...)` builds the predicate explicitly.
 * Security: rebuilt `cvmtests-docker-test1` (`python:3.12-alpine`) and `cvmtests-docker-test2` (`python:3.11-alpine`) on current bases (+ `apk upgrade`, refreshed pip/setuptools/wheel) to clear base-OS CVEs (expat/krb5/openssl/musl) and stale Python tooling.

--- a/packages/CVMTests/scripts/node/columns_list.js
+++ b/packages/CVMTests/scripts/node/columns_list.js
@@ -5,4 +5,4 @@
 //input: column_list cols
 //output: dataframe result
 
-result = df.select(...cols.slice(1));
+result = DG.DataFrame.fromColumns(cols.slice(1).map((name) => df.col(name)));

--- a/packages/CVMTests/scripts/node/file_test.js
+++ b/packages/CVMTests/scripts/node/file_test.js
@@ -8,5 +8,5 @@
 //condition: file.isFile && file.name.endsWith("csv")
 //output: int num_lines
 
-df = await DataFrame.fromCSV("file://" + path.resolve(file));
-num_lines = df.dim()[0];
+df = DG.DataFrame.fromCsv(await fs.readFile(file, 'utf-8'));
+num_lines = df.rowCount;

--- a/packages/CVMTests/scripts/nodejs-test.js
+++ b/packages/CVMTests/scripts/nodejs-test.js
@@ -25,7 +25,6 @@ rdt = new Date(dt);
 rdt.setDate(rdt.getDate() + 10);
 rm = m;
 rm['b'] = ri;
-col = df.clone().col('height');
-col.name = 'column';
+col = DG.Column.fromList(df.col('height').type, 'column', df.col('height').toList());
 df.columns.add(col);
 rdf = df;

--- a/packages/NodejsApiDemo/CHANGELOG.md
+++ b/packages/NodejsApiDemo/CHANGELOG.md
@@ -1,0 +1,6 @@
+# NodeJS API Demo changelog
+
+## v.next
+
+* GROK-20443: Initial version — nodejs script using the js-api (grok/DG) with a package
+  python function call and package file access, verified end-to-end on sandbox

--- a/packages/NodejsApiDemo/README.md
+++ b/packages/NodejsApiDemo/README.md
@@ -1,0 +1,45 @@
+# NodeJS API Demo
+
+A minimal package demonstrating the **js-api under Node.js** (GROK-20443): a `nodejs`
+script that uses `grok`/`DG` server-side and consumes **package functions** — no browser
+anywhere in the chain.
+
+## What it shows
+
+`scripts/node-demo.js` (`NodejsApiDemo:NodeDemo`, `#language: nodejs`) runs in the
+Jupyter Kernel Gateway's Node kernel and:
+
+1. bootstraps the js-api once per kernel (`startDatagrok({..., detached: true})`) with the
+   calling user's token re-bound per call;
+2. calls `grok.dapi.users.current()` — server API from inside the script;
+3. builds a `DG.DataFrame` and passes it to **this package's Python script**
+   (`NodejsApiDemo:PyMean`) via `grok.functions.call` — a cross-language package
+   function call with dataframe transfer;
+4. reads this package's AppData file (`files/hello.txt`) via `grok.dapi.files`.
+
+Expected outputs: `user` (caller's name), `cells = 4`, `mean = 2.5`,
+`fileText = "hello from package files"`.
+
+## Run
+
+```bash
+grok publish <host>       # from this folder
+```
+
+then call it from anywhere — for example from a standalone Node.js client:
+
+```js
+const {startDatagrok} = require('datagrok-api/datagrok');
+await startDatagrok({apiUrl, apiToken, detached: true});
+const r = await grok.functions.call('NodejsApiDemo:NodeDemo', {});
+// {user, cells, mean, fileText}
+```
+
+## Notes
+
+- The script `require`s `datagrok-api/datagrok` and falls back to `/tmp/datagrok-api` —
+  the fallback covers JKG images that don't ship `datagrok-api` globally yet
+  (the Dockerfile installs it behind the `DATAGROK_API_VERSION` build arg).
+- `detached: true` is required in shared kernels: it skips per-user startup data, so
+  nothing user-specific is cached across calls; functions resolve lazily over REST.
+- Verified end-to-end on sandbox 2026-07-20 (see GROK-20443).

--- a/packages/NodejsApiDemo/files/hello.txt
+++ b/packages/NodejsApiDemo/files/hello.txt
@@ -1,0 +1,1 @@
+hello from package files

--- a/packages/NodejsApiDemo/package.js
+++ b/packages/NodejsApiDemo/package.js
@@ -1,0 +1,5 @@
+//name: info
+//output: string result
+function info() {
+  return 'NodeJS API Demo package';
+}

--- a/packages/NodejsApiDemo/package.json
+++ b/packages/NodejsApiDemo/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@datagrok/nodejs-api-demo",
+  "friendlyName": "NodeJS API Demo",
+  "version": "0.0.1",
+  "description": "End-to-end demo: nodejs scripts using the js-api (grok/DG) and package functions",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/datagrok-ai/public.git",
+    "directory": "packages/NodejsApiDemo"
+  },
+  "dependencies": {},
+  "scripts": {
+    "build": "echo source-only package, no build step"
+  },
+  "canEdit": ["Administrators"],
+  "canView": ["All users"],
+  "category": "Development"
+}

--- a/packages/NodejsApiDemo/scripts/node-demo.js
+++ b/packages/NodejsApiDemo/scripts/node-demo.js
@@ -1,0 +1,24 @@
+//name: NodeDemo
+//description: nodejs script using the js-api (grok/DG) + a package python script + package files
+//language: nodejs
+//output: string user
+//output: int cells
+//output: double mean
+//output: string fileText
+
+// js-api bootstrap: resolves globally on images that ship datagrok-api;
+// falls back to the staged copy on this stand
+let dgapi;
+try { dgapi = require('datagrok-api/datagrok'); }
+catch (_) { dgapi = require('/tmp/datagrok-api/datagrok.js'); }
+if (!globalThis.__dgReady)
+  globalThis.__dgReady = dgapi.startDatagrok({apiUrl: @DATAGROK_API_URL, apiToken: @USER_API_KEY, detached: true});
+await globalThis.__dgReady;
+grok.dapi.token = @USER_API_KEY;
+grok.dapi.root = @DATAGROK_API_URL;
+
+user = (await grok.dapi.users.current()).friendlyName;
+const t = DG.DataFrame.fromCsv('x\n1\n2\n3\n4');
+cells = t.rowCount * t.columns.length;
+mean = await grok.functions.call('NodejsApiDemo:PyMean', {df: t});
+fileText = (await grok.dapi.files.readAsText('System:AppData/NodejsApiDemo/hello.txt')).trim();

--- a/packages/NodejsApiDemo/scripts/py-mean.py
+++ b/packages/NodejsApiDemo/scripts/py-mean.py
@@ -1,0 +1,5 @@
+#name: PyMean
+#language: python
+#input: dataframe df
+#output: double mean_out
+mean_out = float(df['x'].mean())

--- a/packages/Samples/CHANGELOG.md
+++ b/packages/Samples/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v.next
 
+* Scripts: Migrated nodejs sample scripts to the js-api (`grok`/`DG` globals) following the nodejs script runtime change
+
 * Docker: Raised conda env to Python 3.10 and added security floors (setuptools/wheel/urllib3/pyarrow/jaraco.context/brotli), plus removed stale ensurepip/pkgs-cache copies (VEX)
 * Docker: Cleared reported CVEs — added `apt upgrade` for base-image OS packages and upgraded pip/setuptools/wheel in the conda env
 * GROK-14287: Dashboards: Fixed errors when opening the "Chemical Space Using tSNE" project

--- a/tools/script-template/node.js
+++ b/tools/script-template/node.js
@@ -4,4 +4,4 @@
 //sample: cars.csv
 //input: dataframe table [Data table]
 //output: int count [Number of cells in table]
-const count = table.dim()[0] * table.dim()[1];
+const count = table.rowCount * table.columns.length;


### PR DESCRIPTION
## Summary

Stacked on #3925. Adds **NodejsApiDemo** — a minimal sample package proving the Node.js js-api runtime end-to-end, exactly as verified on sandbox:

- `scripts/node-demo.js` (`#language: nodejs`): bootstraps `grok`/`DG` in the JKG kernel (`startDatagrok` detached, per-call token rebind), calls `grok.dapi.users.current()`, builds a `DG.DataFrame` and passes it to **this package's Python script** via `grok.functions.call` (cross-language package function call with dataframe transfer), and reads the package's AppData file via `grok.dapi.files`.
- `scripts/py-mean.py`: the Python helper the nodejs script calls.
- `files/hello.txt`: package file read at runtime.

Verified on sandbox (branch build + staged datagrok-api in the JKG pod):

```json
{"user":"Admin","cells":4,"mean":2.5,"fileText":"hello from package files"}
```

Source-only package (no webpack); the `require('datagrok-api/datagrok')` fallback to `/tmp/datagrok-api` covers JKG images that don't ship datagrok-api globally yet.

## Merge order

After #3925 (base branch). The companion reddata PR adds the packages-under-Node design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)