### PR TITLE
[ticket] GROK-20424: Tutorials: Watch the always-present Add-New-Column dialog root instead of the not-yet-rendered .cm-line in the Calculated Columns expression step

### DIFF
--- a/packages/Tutorials/CHANGELOG.md
+++ b/packages/Tutorials/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Tutorials: Updated the Diff Studio tutorial with respect to the main app modifications
 * GROK-20145: Demo | Form viewer: Error on URL direct opening
 * GROK-20408: Tutorials: Fixed `waitForElementClick` dropping the first 500ms of clicks, hanging forever on a not-yet-rendered element, and leaking listeners with no cancellation — replaced by `elementClick` (immediate listener, polling getter with timeout, Observable so `firstEvent` cancels on close)
+* GROK-20424: Tutorials: Fixed the Calculated Columns tutorial hanging on the "Enter the expression" step — the MutationObserver watched `.cm-line`, which is null before CodeMirror renders, throwing `observe: parameter 1 is not of type 'Node'`; now watches the always-present dialog root subtree
 
 ## 1.11.2 (2026-04-10)
 

--- a/packages/Tutorials/src/tracks/transform/tutorials/calculated-columns.ts
+++ b/packages/Tutorials/src/tracks/transform/tutorials/calculated-columns.ts
@@ -48,16 +48,17 @@ export class CalculatedColumnsTutorial extends Tutorial {
     await this.dlgInputAction(addNCDlg, `Enter the expression "${simpleFormula}"`, '', simpleFormula, '', false, 2);
 
     await this.action(`Enter the expression "${simpleFormula}"`, new Observable((subscriber: any) => {
-      const observer = new MutationObserver((mutationsList, observer) => {
-        mutationsList.forEach((m) => {
-          //@ts-ignore
-          if (m.target.innerText === simpleFormula) {
-            subscriber.next(true);
-            observer.disconnect();
-          }
-        });
+      const formulaEntered = () => Array.from(addNCDlg!.root.querySelectorAll('.cm-line'))
+        .map((line) => line.textContent).join('\n') === simpleFormula;
+      if (formulaEntered()) return void subscriber.next(true);
+      // .cm-line may not be rendered yet when this step starts, so watch the dialog root instead
+      const observer = new MutationObserver(() => {
+        if (formulaEntered()) {
+          subscriber.next(true);
+          observer.disconnect();
+        }
       });
-      observer.observe(addNCDlg!.root.querySelector('.cm-line')!, {childList: true, attributes: true});
+      observer.observe(addNCDlg!.root, {childList: true, subtree: true, characterData: true});
     }));
 
     await this.action('Click "OK"', this.t!.onColumnsAdded.pipe(filter((data) =>


### PR DESCRIPTION
The Calculated Columns tutorial hung on the 'Enter the expression' step because its MutationObserver called observe() on `addNCDlg.root.querySelector('.cm-line')`, which is null before CodeMirror 6 renders its first line — throwing "parameter 1 is not of type 'Node'" and leaving the step with no completion condition (the tutorial's Observable subscriber runs synchronously the moment the previous step finishes, which can beat CodeMirror's async render). The fix observes the always-present dialog root subtree and checks the .cm-line text on each mutation, so observe() never receives null and the step still advances when the formula is typed. Tested by rebuilding the Tutorials package (npm run build exits 0, webpack compiled successfully); the change is confined to the one tutorial file, not the shared Tutorial framework.

---
**Diff:** +11/-9 · 2 files · full analysis: [GROK-20424](https://reddata.atlassian.net/browse/GROK-20424)


[GROK-20424]: https://reddata.atlassian.net/browse/GROK-20424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ