### PR TITLE
GROK-20452: Celery Node worker: meta.queue JS server functions

### DIFF
--- a/datagrok-celery-worker/.gitignore
+++ b/datagrok-celery-worker/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.tgz
+*.log

--- a/datagrok-celery-worker/README.md
+++ b/datagrok-celery-worker/README.md
@@ -1,0 +1,101 @@
+# datagrok-celery-worker
+
+A generic Node.js, Celery-compatible worker that executes a published Datagrok package's
+JS functions. It is the JS mirror of the python library
+[`datagrok-celery-task`](../datagrok-celery-task): the Datagrok server (datlas) queues a
+`DockerFunc` call into a RabbitMQ task queue, the worker picks it up, streams dataframe /
+blob parameters over [grok_pipe](../../grok_pipe), runs the function from the package's
+published webpack bundle (loaded via the `datagrok-api` Node runtime), and publishes the
+result back.
+
+## How it works
+
+1. **Task pickup** — consumes the queue named by `TASK_QUEUE_NAME` (the worker owns the
+   `assertQueue {durable: true}` declaration; datlas publishes into it passively). The
+   message body is `{"args": [funcCallJson], "kwargs": {}}` (celery protocol-2 array
+   bodies are accepted too). The message is acked immediately and an `accepted` message
+   is published to the `calls_fanout` exchange — datlas requires it within its
+   task-pickup timeout (60 s by default).
+2. **Package loading** — on the first task the worker calls
+   `startDatagrok({apiUrl, apiToken, detached: true})` and `loadPackage(name)` from
+   `datagrok-api/datagrok`, then resolves the function implementation directly from the
+   bundle's module exports (never through `grok.functions.call`, which would recurse to
+   the server entity).
+3. **Param streaming** — when the call has dataframe/blob/file params, the worker joins
+   the grok_pipe room `ws://$DATAGROK_PIPE_HOST:$DATAGROK_PIPE_PORT/<callId>` (headers
+   `x-member-name: celery-$DATAGROK_CELERY_NAME`, `authorization: $DATAGROK_PIPE_KEY`).
+   Inputs: send `PARAM <name>`, receive `SENDING DATAFRAME <size> <tagsJson>` + binary
+   chunks (each acked with `PART OK`), terminated by `PARAM_SENT <name>`. Outputs: the
+   same `SENDING`/chunks/`PART OK` exchange in the other direction. Dataframes travel as
+   UTF-8 CSV (`DG.DataFrame.fromCsv` / `df.toCsv()`).
+4. **Result** — a `CALL <funcCallJson>` text frame over the pipe when one is open,
+   otherwise a `call` message on `calls_fanout`. Progress reports go out as
+   `PROGRESS {json}` frames / `progress` fanout messages; package code can call
+   `globalThis.DG_TASK_PROGRESS(percent, description)`.
+5. **Cancellation** — datlas publishes `{method: 'revoke', arguments: {task_id}}` to the
+   `celery.pidbox` exchange; the worker keeps a per-hostname pidbox queue
+   (`celery@$CELERY_HOSTNAME.celery.pidbox`). A revoke immediately publishes a
+   `Canceled` result and sets a cooperative cancel flag — a running function is not
+   killed, but its next progress call throws.
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TASK_QUEUE_NAME` | yes | | RabbitMQ task queue to consume (the DockerFunc's `task_queue`) |
+| `CELERY_HOSTNAME` | yes | | Worker hostname; forms the pidbox queue name `celery@<hostname>.celery.pidbox` |
+| `DATAGROK_PACKAGE_NAME` | yes | | Published Datagrok package whose JS functions this worker executes |
+| `DATAGROK_PACKAGE_VERSION` | no | | Logged only; the worker always loads the server's current published version |
+| `DATAGROK_CELERY_NAME` | no | `datagrok-celery` | grok_pipe member name suffix (`celery-<name>`) |
+| `DATAGROK_AMPQ_HOST` | no | `localhost` | RabbitMQ host (note the existing 'AMPQ' spelling, kept from the python lib) |
+| `DATAGROK_AMPQ_PORT` | no | `5672` | RabbitMQ port |
+| `DATAGROK_AMPQ_USER` | no | `guest` | RabbitMQ user |
+| `DATAGROK_AMPQ_PASSWORD` | no | `guest` | RabbitMQ password |
+| `DATAGROK_AMPQ_TLS` | no | `false` | `true` → `amqps://` |
+| `DATAGROK_PIPE_HOST` | no | `localhost` | grok_pipe host |
+| `DATAGROK_PIPE_PORT` | no | `3000` | grok_pipe port |
+| `DATAGROK_PIPE_KEY` | no | empty | grok_pipe `authorization` header value |
+| `DATAGROK_API_URL` | no | | Fallback Datagrok API url; normally each call carries `aux.DATAGROK_API_URL` |
+| `DATAGROK_PARAM_TIMEOUT` | no | `5` | Total budget for receiving one param, minutes |
+| `DATAGROK_WS_MESSAGE_TIMEOUT` | no | `30` | Per-message pipe wait timeout, seconds |
+| `HEALTH_PORT` | no | `8000` | Port of the `{"status":"ok"}` health endpoint |
+
+## Local run
+
+Start RabbitMQ and grok_pipe from the datlas compose stack:
+
+```bash
+cd core/server/datlas/resources/compose
+docker compose -f deps.docker-compose.yaml -p datagrok-dev --profile scripting up -d rabbitmq grok_pipe
+```
+
+Then build and run the worker against them (with datlas running on 8082):
+
+```bash
+npm install && npm run build
+TASK_QUEUE_NAME=my_pkg_queue \
+CELERY_HOSTNAME=local-worker \
+DATAGROK_PACKAGE_NAME=MyPackage \
+DATAGROK_API_URL=http://localhost:8082/api \
+npm start
+```
+
+`datagrok-api` is a peer dependency — install a version that exposes the
+`datagrok-api/datagrok` Node entrypoint (>= 1.27) next to this package.
+
+## Limitations
+
+- **CSV-only dataframe transfer** — no parquet; the server sends CSV for js-lang funcs
+  (a call with `options.isParquet = true` fails fast).
+- **Single in-flight task** — tasks are acked immediately and drained from an in-memory
+  FIFO one at a time.
+- **Cooperative cancellation** — a revoke publishes the `Canceled` result right away,
+  but the running JS function is only interrupted at its next
+  `DG_TASK_PROGRESS` call.
+- **One return parameter max** (same rule as the python lib).
+
+## Security
+
+Never log `aux` or `USER_API_KEY` — the call's `aux` carries the user's session token.
+The worker only echoes `aux` back inside the result message (as the protocol requires)
+and never prints it.

--- a/datagrok-celery-worker/jest.config.js
+++ b/datagrok-celery-worker/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+};

--- a/datagrok-celery-worker/package-lock.json
+++ b/datagrok-celery-worker/package-lock.json
@@ -1,0 +1,4049 @@
+{
+  "name": "datagrok-celery-worker",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "datagrok-celery-worker",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "amqplib": "^0.10.5",
+        "ws": "^8.21.0"
+      },
+      "bin": {
+        "datagrok-celery-worker": "dist/worker.js"
+      },
+      "devDependencies": {
+        "@types/amqplib": "^0.10.6",
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.10.0",
+        "@types/ws": "^8.5.13",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.5",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "datagrok-api": ">=1.27.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@datagrok-libraries/chem-meta": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@datagrok-libraries/chem-meta/-/chem-meta-1.2.12.tgz",
+      "integrity": "sha512-inHt2TbTATxB+udEx73+VTpfmvKH/8VuvZPzNncYgHKSC95SWZIiExKenbRuwm+/oxmqNYuCI4G5bqXGW2VNig==",
+      "dependencies": {
+        "wu": "^2.1.0"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@types/amqplib": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.8.tgz",
+      "integrity": "sha512-vtDp8Pk1wsE/AuQ8/Rgtm6KUZYqcnTgNvEHwzCkX8rL7AGsC6zqAfKAAJhUZXFhM/Pp++tbnUHiam/8vVpPztA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/wu": {
+      "version": "2.1.44",
+      "resolved": "https://registry.npmjs.org/@types/wu/-/wu-2.1.44.tgz",
+      "integrity": "sha512-veqvAklPyeT4DJFD66iBwzUKW5zicMDwaDShIvJmDkteQhwhXBKvgydA+yrNN8FnxWUFCI5y9+a2DI5sSwMUlQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/amqplib": {
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.9.tgz",
+      "integrity": "sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
+      "integrity": "sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/cash-dom": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/cash-dom/-/cash-dom-8.1.5.tgz",
+      "integrity": "sha512-/BS05CfzyHR5xT2ksKj1sDLPaOv5rSmIwoGxNgdKwUtnIuiJ5neMxVEmZxvfyJiSjGbOMD0Lwe+9v+fszDqHew==",
+      "license": "MIT"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/datagrok-api": {
+      "version": "1.27.7",
+      "resolved": "https://registry.npmjs.org/datagrok-api/-/datagrok-api-1.27.7.tgz",
+      "integrity": "sha512-sVi+oMdVjRa2A6C+E3hEF9DRbUSn68dWabUNAiGOOVhLHo0IXaaDUwv2YgBPfmcfueWaAILFQBYuQYTHvJrl3A==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.27.1",
+        "@datagrok-libraries/chem-meta": "^1.0.12",
+        "@types/react": "^18.3.11",
+        "@types/wu": "^2.1.44",
+        "cash-dom": "^8.1.5",
+        "dayjs": "^1.11.10",
+        "openchemlib": "^7.2.3",
+        "react": "^18.3.1",
+        "rxjs": "^6.5.5",
+        "typeahead-standalone": "4.14.1",
+        "ws": "^8.18.2",
+        "wu": "^2.1.0"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.394",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.394.tgz",
+      "integrity": "sha512-Wmt2Gm0o8JWBuGgmc4XZ0u9s1RaCRqhxP47phplmfg04+qypTUurpeJGP45A7Fhv7jdrrVH44PLlR9qXo37cVQ==",
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openchemlib": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/openchemlib/-/openchemlib-7.5.0.tgz",
+      "integrity": "sha512-cxEmgL1Szuw5zPDX29PyuAIkokSKPkzEIc/61oPA84GqvGyjMMRrGaF4tbFCDOT4c7ULZ/qmIWk9/ERj3wOg1w==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.0",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typeahead-standalone": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/typeahead-standalone/-/typeahead-standalone-4.14.1.tgz",
+      "integrity": "sha512-K+mqXmHferhxlyFD5blmOV9UIlazUxumyLWxO5QXnD1cjL6uQ6JGuqvjk0rHt4uz5cD2POAFxnyfkyZUD1ce7A==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wu": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wu/-/wu-2.1.0.tgz",
+      "integrity": "sha512-j+Gdt5IUK4eoLO6mrN/ZurInHacaxr/EPCvQHf1ARq6ROdKRN/aFtc0PGdH9lnRPMg6vhJOOqIYdNhMN6uWtUg=="
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/datagrok-celery-worker/package.json
+++ b/datagrok-celery-worker/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "datagrok-celery-worker",
+  "version": "0.0.1",
+  "description": "Generic Node.js Celery-compatible worker that executes a published Datagrok package's JS functions",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "datagrok-celery-worker": "dist/worker.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "jest",
+    "start": "node dist/worker.js"
+  },
+  "keywords": [
+    "datagrok",
+    "celery",
+    "worker",
+    "amqp"
+  ],
+  "dependencies": {
+    "amqplib": "^0.10.5",
+    "ws": "^8.21.0"
+  },
+  "peerDependencies": {
+    "datagrok-api": ">=1.27.0"
+  },
+  "devDependencies": {
+    "@types/amqplib": "^0.10.6",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.10.0",
+    "@types/ws": "^8.5.13",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
+    "typescript": "^5.7.2"
+  }
+}

--- a/datagrok-celery-worker/src/celery-consumer.ts
+++ b/datagrok-celery-worker/src/celery-consumer.ts
@@ -1,0 +1,187 @@
+/** Task queue consumer. The worker OWNS the task queue declaration ({durable: true});
+ *  datlas publishes into it with passive: true (call_queue_service.dart _putTask) and
+ *  expects an 'accepted' fanout reply within taskPickupTimeout (60s), so ACCEPTED is
+ *  published immediately on message receipt — datlas' own worker mode does the same
+ *  (ack + ACCEPTED before parsing, _handleTasksQueueMessage). */
+import * as amqplib from 'amqplib';
+
+import {FanoutPublisher} from './fanout-publisher';
+import {FuncCall, FuncCallStatus} from './func-call';
+import {RevokedSet} from './pidbox';
+import {Settings} from './settings';
+import {logError, logInfo, logWarn} from './logger';
+
+export class CeleryConsumer {
+  static MAX_RECONNECT_WAIT_MS = 30000;
+
+  private readonly settings: Settings;
+  private readonly publisher: FanoutPublisher;
+  private readonly revoked: RevokedSet;
+  private readonly runTask: (call: FuncCall) => Promise<void>;
+  private readonly connectFn: (url: string) => Promise<any>;
+  private conn: any = null;
+  private channel: any = null;
+  private consumerTag: string | null = null;
+  private readonly fifo: FuncCall[] = [];
+  private draining = false;
+  private stopped = false;
+  private reconnectWaitMs = 0;
+
+  constructor(settings: Settings, publisher: FanoutPublisher, revoked: RevokedSet,
+    runTask: (call: FuncCall) => Promise<void>, connectFn?: (url: string) => Promise<any>) {
+    this.settings = settings;
+    this.publisher = publisher;
+    this.revoked = revoked;
+    this.runTask = runTask;
+    this.connectFn = connectFn ?? ((url: string) => amqplib.connect(url));
+  }
+
+  get isBusy(): boolean {
+    return this.draining;
+  }
+
+  async start(): Promise<void> {
+    try {
+      await this.connect();
+      this.reconnectWaitMs = 0;
+      logInfo(`Consuming task queue '${this.settings.taskQueueName}'`);
+    }
+    catch (e: any) {
+      logError(`Task queue connection failed: ${e?.message ?? e}`);
+      this.scheduleReconnect();
+    }
+  }
+
+  private async connect(): Promise<void> {
+    const conn = await this.connectFn(`${this.settings.brokerUrl}?heartbeat=30`);
+    this.conn = conn;
+    conn.on?.('error', (e: Error) => logError(`Task queue connection error: ${e.message}`));
+    conn.on?.('close', () => {
+      this.conn = null;
+      this.channel = null;
+      if (!this.stopped)
+        this.scheduleReconnect();
+    });
+    const channel = await conn.createChannel();
+    channel.on?.('error', (e: Error) => logWarn(`Task queue channel error: ${e.message}`));
+    await channel.assertQueue(this.settings.taskQueueName, {durable: true});
+    const consumed = await channel.consume(this.settings.taskQueueName,
+      (message: any) => this.onMessage(message), {noAck: false});
+    this.channel = channel;
+    this.consumerTag = consumed.consumerTag;
+  }
+
+  private scheduleReconnect(): void {
+    this.reconnectWaitMs = Math.min(this.reconnectWaitMs === 0 ? 1000 : this.reconnectWaitMs * 2,
+      CeleryConsumer.MAX_RECONNECT_WAIT_MS);
+    logInfo(`Task queue consumer reconnecting in ${this.reconnectWaitMs} ms`);
+    setTimeout(() => {
+      if (!this.stopped)
+        void this.start();
+    }, this.reconnectWaitMs);
+  }
+
+  /** Handles one task message; visible for tests (pass the channel-delivered message). */
+  onMessage(message: any): void {
+    if (message == null)
+      return; // consumer was cancelled by the broker
+    try {
+      this.channel?.ack(message);
+      const headers = message.properties?.headers ?? {};
+      if (headers['lang'] != null && headers['lang'] !== 'js')
+        logWarn(`Task '${headers['task']}' has lang='${headers['lang']}', expected 'js'`);
+      const call = FuncCall.fromCeleryBody(JSON.parse(message.content.toString('utf8')));
+      // ACCEPTED must reach datlas within taskPickupTimeout
+      void this.publisher.publish({}, call.id, 'accepted');
+      if (this.revoked.has(call.id)) {
+        this.publishCanceled(call);
+        return;
+      }
+      this.fifo.push(call);
+      void this.drain();
+    }
+    catch (e: any) {
+      logError(`Failed to handle a task message: ${e?.message ?? e}`);
+      // Poison message: fail fast with an Error CALL instead of letting datlas wait
+      // out the full taskPickupTimeout (60s) on a missing ACCEPTED
+      const correlationId = message.properties?.correlationId;
+      if (correlationId != null) {
+        void this.publisher.publish({}, correlationId, 'accepted');
+        void this.publisher.publish({
+          id: correlationId,
+          status: FuncCallStatus.ERROR,
+          errorMessage: `Worker failed to parse the task message: ${e?.message ?? e}`,
+        }, correlationId, 'call');
+      }
+    }
+  }
+
+  private publishCanceled(call: FuncCall): void {
+    logInfo('Task was revoked before pickup, publishing Canceled CALL', call.id);
+    call.status = FuncCallStatus.CANCELED;
+    void this.publisher.publish(call.toJson(), call.id, 'call');
+  }
+
+  /** Single-in-flight executor loop draining the in-memory FIFO. */
+  private async drain(): Promise<void> {
+    if (this.draining)
+      return;
+    this.draining = true;
+    try {
+      while (this.fifo.length > 0) {
+        const call = this.fifo.shift()!;
+        if (this.revoked.has(call.id)) {
+          this.publishCanceled(call);
+          continue;
+        }
+        try {
+          await this.runTask(call);
+        }
+        catch (e: any) {
+          logError(`Task runner threw: ${e?.message ?? e}`, call.id);
+        }
+      }
+    }
+    finally {
+      this.draining = false;
+    }
+  }
+
+  /** Stops receiving new tasks (queued messages stay in the broker for other workers). */
+  async stopConsuming(): Promise<void> {
+    this.stopped = true;
+    if (this.channel != null && this.consumerTag != null) {
+      try {
+        await this.channel.cancel(this.consumerTag);
+      }
+      catch (e: any) {
+        logWarn(`Consumer cancel failed: ${e?.message ?? e}`);
+      }
+      this.consumerTag = null;
+    }
+  }
+
+  /** Waits until the in-flight task (and the FIFO) is done, up to [timeoutMs]. */
+  async waitForIdle(timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (this.draining || this.fifo.length > 0) {
+      if (Date.now() >= deadline)
+        return false;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    return true;
+  }
+
+  async close(): Promise<void> {
+    this.stopped = true;
+    const conn = this.conn;
+    this.conn = null;
+    this.channel = null;
+    if (conn != null) {
+      try {
+        await conn.close();
+      }
+      catch (_) {}
+    }
+  }
+}

--- a/datagrok-celery-worker/src/fanout-publisher.ts
+++ b/datagrok-celery-worker/src/fanout-publisher.ts
@@ -1,0 +1,93 @@
+/** Publisher for the 'calls_fanout' exchange (mirrors amqp_publisher.py).
+ *  Datlas consumes this exchange in call_queue_service.dart and expects message
+ *  properties correlationId = call id and type in 'accepted'|'call'|'progress'|'log'. */
+import * as amqplib from 'amqplib';
+
+import {logError, logWarn} from './logger';
+
+export type FanoutType = 'call' | 'log' | 'accepted' | 'progress';
+
+export const CALLS_FANOUT = 'calls_fanout';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class FanoutPublisher {
+  static MAX_ATTEMPTS = 3;
+
+  private readonly brokerUrl: string;
+  private readonly connectFn: (url: string) => Promise<any>;
+  private conn: any = null;
+  private channel: any = null;
+
+  constructor(brokerUrl: string, connectFn?: (url: string) => Promise<any>) {
+    this.brokerUrl = brokerUrl;
+    this.connectFn = connectFn ?? ((url: string) => amqplib.connect(url));
+  }
+
+  private async ensureChannel(): Promise<any> {
+    if (this.channel != null)
+      return this.channel;
+    this.conn = await this.connectFn(this.brokerUrl);
+    this.conn.on?.('error', (e: Error) => {
+      logWarn(`Fanout publisher connection error: ${e.message}`);
+      this.reset();
+    });
+    this.conn.on?.('close', () => this.reset());
+    const channel = await this.conn.createChannel();
+    channel.on?.('error', (e: Error) => logWarn(`Fanout publisher channel error: ${e.message}`));
+    // datlas binds a private queue to this exchange with default (non-durable) settings
+    await channel.assertExchange(CALLS_FANOUT, 'fanout', {durable: false});
+    this.channel = channel;
+    return channel;
+  }
+
+  private reset(): void {
+    this.channel = null;
+    const conn = this.conn;
+    this.conn = null;
+    if (conn != null) {
+      try {
+        conn.close().catch(() => {});
+      }
+      catch (_) {}
+    }
+  }
+
+  /** Publishes a JSON payload; 3 attempts with 2^attempt seconds backoff, reconnecting
+   *  between attempts. Never throws — returns false when all attempts failed. */
+  async publish(payload: object, correlationId: string, type: FanoutType): Promise<boolean> {
+    for (let attempt = 0; attempt < FanoutPublisher.MAX_ATTEMPTS; attempt++) {
+      try {
+        const channel = await this.ensureChannel();
+        channel.publish(CALLS_FANOUT, '', Buffer.from(JSON.stringify(payload)), {
+          contentType: 'application/json',
+          correlationId: correlationId,
+          type: type,
+        });
+        return true;
+      }
+      catch (e: any) {
+        this.reset();
+        logWarn(`Fanout publish '${type}' failed (attempt ${attempt + 1}): ${e?.message ?? e}`, correlationId);
+        if (attempt < FanoutPublisher.MAX_ATTEMPTS - 1)
+          await sleep(Math.pow(2, attempt + 1) * 1000);
+      }
+    }
+    logError(`Fanout publish '${type}' failed after ${FanoutPublisher.MAX_ATTEMPTS} attempts`, correlationId);
+    return false;
+  }
+
+  async close(): Promise<void> {
+    const conn = this.conn;
+    this.channel = null;
+    this.conn = null;
+    if (conn != null) {
+      try {
+        await conn.close();
+      }
+      catch (_) {}
+    }
+  }
+}

--- a/datagrok-celery-worker/src/func-call.ts
+++ b/datagrok-celery-worker/src/func-call.ts
@@ -1,0 +1,143 @@
+/** FuncCall model, mirroring datagrok-celery-task/func_call.py.
+ *  The serialized shape is produced by the Dart FuncCall.toJson() (ddt) and consumed
+ *  back by datlas' `new FuncCall.fromJson(...)` (call_queue_service.dart), so toJson()
+ *  must echo `func`, `options` and `aux` untouched. */
+
+export const Type = {
+  INT: 'int',
+  STRING: 'string',
+  BOOL: 'bool',
+  FLOAT: 'double',
+  BIG_INT: 'bigint',
+  DATA_FRAME: 'dataframe',
+  DATE_TIME: 'datetime',
+  FILE: 'file',
+  BLOB: 'blob',
+  GRAPHICS: 'graphics',
+} as const;
+
+export const FuncCallStatus = {
+  RUNNING: 'Running',
+  QUEUED: 'Queued',
+  COMPLETED: 'Completed',
+  ERROR: 'Error',
+  CANCELED: 'Canceled',
+  CANCELING: 'Canceling',
+} as const;
+
+export function isCompletedStatus(status: string): boolean {
+  return status === FuncCallStatus.COMPLETED || status === FuncCallStatus.ERROR ||
+    status === FuncCallStatus.CANCELED;
+}
+
+export class FuncCallParam {
+  name: string;
+  propertyType: string;
+  isInput: boolean;
+  value: any;
+  originalValue: any;
+
+  constructor(name: string, propertyType: string, isInput: boolean, value: any) {
+    this.name = name;
+    this.propertyType = propertyType;
+    this.isInput = isInput;
+    this.value = value;
+    this.originalValue = value;
+  }
+
+  /** The python lib (func_call.py) treats dataframe/blob/file as streamable; the Dart
+   *  server (ddt func_param.dart `isStreamable`) additionally includes graphics.
+   *  We match the server so `requiresPipe` agrees with datlas' decision to open a pipe. */
+  get isStreamable(): boolean {
+    return this.propertyType === Type.DATA_FRAME || this.propertyType === Type.BLOB ||
+      this.propertyType === Type.FILE || this.propertyType === Type.GRAPHICS;
+  }
+}
+
+export class FuncCall {
+  static DEFAULT_BINARY_BATCH_SIZE = 2048000;
+
+  id: string;
+  func: {[key: string]: any};
+  options: {[key: string]: any};
+  aux: {[key: string]: any};
+  params: FuncCallParam[];
+  status: string;
+  errorMessage: string | null = null;
+  errorStackTrace: string | null = null;
+
+  constructor(callJson: {[key: string]: any}) {
+    this.id = callJson['id'];
+    this.func = callJson['func'] ?? {};
+    this.options = callJson['options'] ?? {};
+    this.aux = callJson['aux'] ?? {};
+    this.status = FuncCallStatus.RUNNING;
+    const parameterValues: {[key: string]: any} = callJson['parameterValues'] ?? {};
+    const funcParams: any[] = this.func['params'] ?? [];
+    this.params = funcParams.map((p) => new FuncCallParam(
+      p['name'], p['propertyType'], p['isInput'] ?? true, parameterValues[p['name']] ?? null));
+  }
+
+  /** Parses a celery task message body. Accepts BOTH shapes:
+   *  - the Dart hybrid `{"args": [callJson], "kwargs": {}}` produced by
+   *    DockerFunc.getQueueMessageBody (docker_func.dart);
+   *  - celery protocol 2 `[[callJson], {}, {...embed}]` (what a real celery
+   *    client would send). */
+  static fromCeleryBody(body: any): FuncCall {
+    const callJson = Array.isArray(body) ? body[0]?.[0] : body?.['args']?.[0];
+    if (callJson == null || typeof callJson !== 'object')
+      throw new Error('Unrecognized celery task body: expected {"args": [call]} or [[call], {}, {}]');
+    return new FuncCall(callJson);
+  }
+
+  get funcName(): string {
+    return this.func['name'] ?? '';
+  }
+
+  get useParquetTransfer(): boolean {
+    return this.options['isParquet'] === true;
+  }
+
+  get userApiKey(): string | null {
+    return this.aux['USER_API_KEY'] ?? null;
+  }
+
+  get apiUrl(): string | null {
+    return this.aux['DATAGROK_API_URL'] ?? null;
+  }
+
+  get binaryBatchSize(): number {
+    return this.aux['batchSize'] ?? FuncCall.DEFAULT_BINARY_BATCH_SIZE;
+  }
+
+  get inputParams(): FuncCallParam[] {
+    return this.params.filter((p) => p.isInput);
+  }
+
+  /** Declared outputs. */
+  get outputParams(): FuncCallParam[] {
+    return this.params.filter((p) => !p.isInput);
+  }
+
+  get requiresPipe(): boolean {
+    return this.params.some((p) => p.isStreamable);
+  }
+
+  /** Mirrors func_call.py to_json(): inputs echo the original raw values, outputs carry
+   *  the serialized value (dataframe -> {id: uuid}, blob -> param name, scalars as-is). */
+  toJson(): {[key: string]: any} {
+    const parameterValues: {[key: string]: any} = {};
+    for (const p of this.params)
+      parameterValues[p.name] = p.isInput ? p.originalValue : p.value;
+    return {
+      'id': this.id,
+      'parameterValues': parameterValues,
+      'func': this.func,
+      'options': this.options,
+      'aux': this.aux,
+      'status': this.status,
+      'errorMessage': this.errorMessage,
+      'errorStackTrace': this.errorStackTrace,
+    };
+  }
+}

--- a/datagrok-celery-worker/src/health.ts
+++ b/datagrok-celery-worker/src/health.ts
@@ -1,0 +1,13 @@
+/** Tiny health endpoint (the worker container EXPOSEs 8000). */
+import * as http from 'node:http';
+
+import {logInfo} from './logger';
+
+export function startHealthServer(port: number): http.Server {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.end(JSON.stringify({'status': 'ok'}));
+  });
+  server.listen(port, () => logInfo(`Health endpoint listening on port ${port}`));
+  return server;
+}

--- a/datagrok-celery-worker/src/index.ts
+++ b/datagrok-celery-worker/src/index.ts
@@ -1,0 +1,15 @@
+export {Settings} from './settings';
+export {FuncCall, FuncCallParam, FuncCallStatus, Type, isCompletedStatus} from './func-call';
+export {FanoutPublisher, CALLS_FANOUT} from './fanout-publisher';
+export type {FanoutType} from './fanout-publisher';
+export {CeleryConsumer} from './celery-consumer';
+export {PipeClient, Const} from './pipe-client';
+export type {PipeClientOptions} from './pipe-client';
+export {marshalInput, marshalOutput, validateCall} from './marshal';
+export type {MarshaledOutput} from './marshal';
+export {PackageHost} from './package-host';
+export {PidboxConsumer, RevokedSet, PIDBOX_EXCHANGE} from './pidbox';
+export type {RunningTask} from './pidbox';
+export {TaskContext, CancelledError} from './progress';
+export {TaskRunner} from './task-runner';
+export {startHealthServer} from './health';

--- a/datagrok-celery-worker/src/logger.ts
+++ b/datagrok-celery-worker/src/logger.ts
@@ -1,0 +1,17 @@
+/** Minimal timestamped stdout logger (mirrors datagrok-celery-task's logger.py role). */
+
+function line(level: string, message: string, taskId?: string): string {
+  return `${new Date().toISOString()} [${level}]${taskId ? ` [task ${taskId}]` : ''} ${message}`;
+}
+
+export function logInfo(message: string, taskId?: string): void {
+  console.log(line('INFO', message, taskId));
+}
+
+export function logWarn(message: string, taskId?: string): void {
+  console.log(line('WARN', message, taskId));
+}
+
+export function logError(message: string, taskId?: string): void {
+  console.error(line('ERROR', message, taskId));
+}

--- a/datagrok-celery-worker/src/marshal.ts
+++ b/datagrok-celery-worker/src/marshal.ts
@@ -1,0 +1,168 @@
+/** Input/output value marshaling, mirroring datagrok-celery-task/utils.py
+ *  (InputValueProcessor/ReturnValueProcessor) with DG.DataFrame instead of pandas. */
+import {randomUUID} from 'node:crypto';
+
+import {FuncCall, FuncCallParam, Type} from './func-call';
+
+/** Fail fast on unsupported call shapes (python DatagrokTask.__call__ parity). */
+export function validateCall(call: FuncCall): void {
+  // The server sets options.isParquet = false for js-lang funcs (docker_func.dart
+  // executeCall); a parquet payload means a misconfigured deployment.
+  if (call.useParquetTransfer)
+    throw new Error('Parquet transfer is not supported by the JS worker: the server must send dataframes as CSV (call.options.isParquet must be false)');
+  if (call.outputParams.length > 1)
+    throw new Error('Only one return parameter is allowed, but more are present in the Datagrok function declaration.');
+}
+
+function inputError(param: FuncCallParam, expected: string): Error {
+  return new Error(`Incorrect input type for ${param.name}. Expected ${expected}, got ${typeof param.value}`);
+}
+
+/** Coerces param.value (raw JSON value, or Uint8Array for streamed params) into the
+ *  runtime value passed to the package function. [dg] is the datagrok-api DG namespace
+ *  (required for dataframe params only, so scalar marshaling is testable standalone). */
+export function marshalInput(param: FuncCallParam, dg?: any): any {
+  const value = param.value;
+  if (value == null)
+    return null;
+  switch (param.propertyType) {
+    case Type.INT: {
+      const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+      if (!Number.isInteger(n))
+        throw inputError(param, 'int');
+      param.value = n;
+      break;
+    }
+    case Type.FLOAT: {
+      const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+      if (Number.isNaN(n))
+        throw inputError(param, 'double');
+      param.value = n;
+      break;
+    }
+    case Type.BOOL: {
+      if (typeof value === 'boolean')
+        break;
+      if (value === 'true' || value === 'false')
+        param.value = value === 'true';
+      else
+        throw inputError(param, 'bool');
+      break;
+    }
+    case Type.STRING:
+      param.value = String(value);
+      break;
+    case Type.BIG_INT: {
+      try {
+        param.value = BigInt(typeof value === 'string' ? value : String(value));
+      }
+      catch (_) {
+        throw new Error(`Incorrect input type for ${param.name}. Expected a string-representable bigint.`);
+      }
+      break;
+    }
+    case Type.DATE_TIME: {
+      // ISO string passthrough (the server serializes datetimes as ISO-8601)
+      if (value instanceof Date)
+        break;
+      if (typeof value !== 'string')
+        throw inputError(param, 'ISO datetime string');
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime()))
+        throw new Error(`Incorrect input value for ${param.name}: not a valid ISO datetime: ${value}`);
+      param.value = date;
+      break;
+    }
+    case Type.DATA_FRAME: {
+      if (!(value instanceof Uint8Array))
+        throw inputError(param, 'bytes (streamed CSV)');
+      if (dg?.DataFrame?.fromCsv == null)
+        throw new Error('DG runtime is not initialized: cannot parse a dataframe input');
+      param.value = dg.DataFrame.fromCsv(Buffer.from(value.buffer, value.byteOffset, value.byteLength).toString('utf8'));
+      break;
+    }
+    case Type.FILE:
+    case Type.BLOB: {
+      if (!(value instanceof Uint8Array))
+        throw inputError(param, 'bytes');
+      break;
+    }
+    default:
+      break; // unknown types pass through as-is (python parity: no processor registered)
+  }
+  return param.value;
+}
+
+export interface MarshaledOutput {
+  /** Bytes to stream over the pipe for dataframe/blob outputs, null otherwise. */
+  bytes: Uint8Array | null;
+  /** grok_pipe SENDING tags ('.id'/'.type') for streamable outputs, null otherwise. */
+  tags: {[key: string]: string} | null;
+}
+
+function returnError(param: FuncCallParam, expected: string, value: any): Error {
+  return new Error(`Incorrect return type for ${param.name}. Expected ${expected}, got ${typeof value}`);
+}
+
+/** Sets param.value to the serialized value that goes into the result CALL json
+ *  (mirrors ReturnValueProcessor + _send_param_grok_pipe: dataframe -> {id: uuid} with
+ *  tags {'.id': id, '.type': 'csv'}, blob -> param name with {'.id': name, '.type': 'blob'})
+ *  and returns the bytes to stream for streamable outputs. */
+export function marshalOutput(param: FuncCallParam, value: any, dg?: any): MarshaledOutput {
+  if (value == null) {
+    param.value = null;
+    return {bytes: null, tags: null};
+  }
+  switch (param.propertyType) {
+    case Type.DATA_FRAME: {
+      if (typeof value?.toCsv !== 'function')
+        throw returnError(param, 'DG.DataFrame', value);
+      const bytes = new Uint8Array(Buffer.from(value.toCsv(), 'utf8'));
+      const id = randomUUID();
+      param.value = {'id': id};
+      return {bytes: bytes, tags: {'.id': id, '.type': 'csv'}};
+    }
+    // python's ReturnValueProcessor supports blob only; the Dart server handles FILE
+    // identically to BLOB (server_action.dart getParamsFromRemoteCall), so file outputs
+    // are accepted here as a superset.
+    case Type.FILE:
+    case Type.BLOB: {
+      if (!(value instanceof Uint8Array))
+        throw returnError(param, 'Uint8Array', value);
+      param.value = param.name;
+      return {bytes: value instanceof Buffer ? new Uint8Array(value) : value, tags: {'.id': param.name, '.type': 'blob'}};
+    }
+    case Type.INT: {
+      const n = Number(value);
+      if (Number.isNaN(n))
+        throw returnError(param, 'int', value);
+      param.value = Math.trunc(n);
+      break;
+    }
+    case Type.FLOAT: {
+      const n = Number(value);
+      if (Number.isNaN(n))
+        throw returnError(param, 'double', value);
+      param.value = n;
+      break;
+    }
+    case Type.BOOL:
+      param.value = Boolean(value);
+      break;
+    case Type.STRING:
+      param.value = String(value);
+      break;
+    case Type.BIG_INT:
+      param.value = String(value); // python set_bigint: str(val)
+      break;
+    case Type.DATE_TIME: {
+      if (typeof value?.toISOString !== 'function') // Date or dayjs
+        throw returnError(param, 'Date/dayjs', value);
+      param.value = value.toISOString();
+      break;
+    }
+    default:
+      throw new Error(`Unsupported return type: ${param.propertyType}`);
+  }
+  return {bytes: null, tags: null};
+}

--- a/datagrok-celery-worker/src/package-host.ts
+++ b/datagrok-celery-worker/src/package-host.ts
@@ -1,0 +1,68 @@
+/** Lazy singleton host for the Datagrok Node runtime + the published package bundle.
+ *
+ *  'datagrok-api' is a peer dependency loaded at runtime via require() — no static
+ *  imports, so this library compiles and unit-tests without it installed. */
+import {FuncCall} from './func-call';
+import {Settings} from './settings';
+import {logInfo} from './logger';
+
+export class PackageHost {
+  private readonly settings: Settings;
+  private loadPromise: Promise<any> | null = null;
+
+  constructor(settings: Settings) {
+    this.settings = settings;
+  }
+
+  /** The DG namespace, available after the first successful init. */
+  get dg(): any {
+    return (globalThis as any).DG;
+  }
+
+  private ensureLoaded(call: FuncCall): Promise<any> {
+    if (this.loadPromise == null) {
+      const promise = (async () => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const runtime = require('datagrok-api/datagrok');
+        const apiUrl = call.apiUrl ?? this.settings.apiUrl;
+        if (apiUrl == null)
+          throw new Error('Datagrok API url is not available: neither call.aux.DATAGROK_API_URL nor the DATAGROK_API_URL environment variable is set');
+        // detached: no per-user startup data is cached — required because the worker
+        // serves calls from many users (see js-api/datagrok.ts startDatagrok docs)
+        await runtime.startDatagrok({apiUrl: apiUrl, apiToken: call.userApiKey ?? undefined, detached: true});
+        logInfo(`Loading package ${this.settings.packageName}${this.settings.packageVersion ? ` (expected version ${this.settings.packageVersion})` : ''}...`);
+        const pkg = await runtime.loadPackage(this.settings.packageName);
+        logInfo(`Loaded package ${pkg.name} v${pkg.version}, ${pkg.functions.length} functions registered`);
+        return pkg;
+      })();
+      // clear the cached promise on failure so the next call retries the init
+      promise.catch(() => {
+        if (this.loadPromise === promise)
+          this.loadPromise = null;
+      });
+      this.loadPromise = promise;
+    }
+    return this.loadPromise;
+  }
+
+  /** Resolves the raw JS implementation of call.func.name from the loaded package
+   *  module (loadPackage returns {name, version, webRoot, module, functions} — see
+   *  js-api/src/node/package-loader.ts). NEVER routed through grok.functions.call:
+   *  that would resolve the server-side DockerFunc entity and recurse into this queue. */
+  async resolve(call: FuncCall): Promise<(...args: any[]) => any> {
+    const pkg = await this.ensureLoaded(call);
+    // re-bind the session token per call (node_script_handler.dart parity:
+    // `grok.dapi.token = USER_API_KEY`)
+    const grok = (globalThis as any).grok;
+    if (grok?.dapi != null && call.userApiKey != null)
+      grok.dapi.token = call.userApiKey;
+    const name = call.funcName;
+    const module = pkg.module ?? {};
+    let impl = module[name];
+    if (typeof impl !== 'function' && name.length > 0)
+      impl = module[name.charAt(0).toLowerCase() + name.slice(1)];
+    if (typeof impl !== 'function')
+      throw new Error(`Function "${name}" was not found in the module exports of package "${pkg.name}"`);
+    return impl;
+  }
+}

--- a/datagrok-celery-worker/src/pidbox.ts
+++ b/datagrok-celery-worker/src/pidbox.ts
@@ -1,0 +1,170 @@
+/** Celery pidbox (control) consumer for cancellation.
+ *
+ *  Datlas publishes {method: 'revoke', arguments: {task_id, terminate, signal}} to the
+ *  'celery.pidbox' exchange with routing key '<control_queue>' and contentType
+ *  application/json (server_docker_func.dart cancelImpl; the exchange is declared
+ *  passive there, so the WORKER owns the declaration). kombu's pidbox convention is a
+ *  fanout, non-durable exchange with a per-worker auto-delete queue named
+ *  'celery@<hostname>.celery.pidbox'. Note: server_docker_func.dart passes
+ *  ExchangeType.DIRECT, but with passive: true the broker ignores the type — the
+ *  worker-asserted fanout wins and the routing key becomes irrelevant. */
+import * as amqplib from 'amqplib';
+
+import {FanoutPublisher} from './fanout-publisher';
+import {FuncCall, FuncCallStatus, isCompletedStatus} from './func-call';
+import {Settings} from './settings';
+import {TaskContext} from './progress';
+import {logError, logInfo, logWarn} from './logger';
+
+export const PIDBOX_EXCHANGE = 'celery.pidbox';
+
+/** Recently revoked task ids with a TTL, so a revoke that arrives before the task is
+ *  picked up from the queue still cancels it. */
+export class RevokedSet {
+  static DEFAULT_TTL_MS = 600000;
+
+  private readonly ttlMs: number;
+  private readonly entries: Map<string, number> = new Map();
+
+  constructor(ttlMs: number = RevokedSet.DEFAULT_TTL_MS) {
+    this.ttlMs = ttlMs;
+  }
+
+  add(taskId: string): void {
+    this.prune();
+    this.entries.set(taskId, Date.now() + this.ttlMs);
+  }
+
+  has(taskId: string): boolean {
+    this.prune();
+    return this.entries.has(taskId);
+  }
+
+  private prune(): void {
+    const now = Date.now();
+    for (const [id, expires] of this.entries)
+      if (expires <= now)
+        this.entries.delete(id);
+  }
+}
+
+export interface RunningTask {
+  call: FuncCall;
+  context: TaskContext;
+}
+
+export class PidboxConsumer {
+  static MAX_RECONNECT_WAIT_MS = 30000;
+
+  private readonly settings: Settings;
+  private readonly publisher: FanoutPublisher;
+  private readonly revoked: RevokedSet;
+  private readonly getCurrent: () => RunningTask | null;
+  private readonly connectFn: (url: string) => Promise<any>;
+  private conn: any = null;
+  private stopped = false;
+  private reconnectWaitMs = 0;
+
+  constructor(settings: Settings, publisher: FanoutPublisher, revoked: RevokedSet,
+    getCurrent: () => RunningTask | null, connectFn?: (url: string) => Promise<any>) {
+    this.settings = settings;
+    this.publisher = publisher;
+    this.revoked = revoked;
+    this.getCurrent = getCurrent;
+    this.connectFn = connectFn ?? ((url: string) => amqplib.connect(url));
+  }
+
+  async start(): Promise<void> {
+    try {
+      await this.connect();
+      this.reconnectWaitMs = 0;
+      logInfo('Pidbox consumer connected');
+    }
+    catch (e: any) {
+      logError(`Pidbox consumer connection failed: ${e?.message ?? e}`);
+      this.scheduleReconnect();
+    }
+  }
+
+  private async connect(): Promise<void> {
+    const conn = await this.connectFn(`${this.settings.brokerUrl}?heartbeat=30`);
+    this.conn = conn;
+    conn.on?.('error', (e: Error) => logError(`Pidbox connection error: ${e.message}`));
+    conn.on?.('close', () => {
+      this.conn = null;
+      if (!this.stopped)
+        this.scheduleReconnect();
+    });
+    const channel = await conn.createChannel();
+    channel.on?.('error', (e: Error) => logWarn(`Pidbox channel error: ${e.message}`));
+    await channel.assertExchange(PIDBOX_EXCHANGE, 'fanout', {durable: false});
+    const queueName = `celery@${this.settings.celeryHostname}.celery.pidbox`;
+    await channel.assertQueue(queueName, {durable: false, autoDelete: true, arguments: {'x-expires': 10000}});
+    await channel.bindQueue(queueName, PIDBOX_EXCHANGE, '');
+    await channel.consume(queueName, (message: any) => this.onMessage(message), {noAck: true});
+  }
+
+  private scheduleReconnect(): void {
+    this.reconnectWaitMs = Math.min(this.reconnectWaitMs === 0 ? 1000 : this.reconnectWaitMs * 2,
+      PidboxConsumer.MAX_RECONNECT_WAIT_MS);
+    logInfo(`Pidbox consumer reconnecting in ${this.reconnectWaitMs} ms`);
+    setTimeout(() => {
+      if (!this.stopped)
+        void this.start();
+    }, this.reconnectWaitMs);
+  }
+
+  private onMessage(message: any): void {
+    if (message == null)
+      return;
+    try {
+      // both datlas (contentType application/json) and kombu (json serializer)
+      // put a JSON document in the message body
+      this.handleControl(JSON.parse(message.content.toString('utf8')));
+    }
+    catch (e: any) {
+      logWarn(`Ignoring malformed pidbox message: ${e?.message ?? e}`);
+    }
+  }
+
+  /** Parses a control message body; visible for tests. */
+  handleControl(body: any): void {
+    if (body?.['method'] !== 'revoke')
+      return;
+    const args = body['arguments'] ?? {};
+    // datlas sends a single arguments.task_id; celery broadcast revokes may carry a list
+    // (task_id or task_ids)
+    const ids: string[] = ([] as any[]).concat(args['task_id'] ?? args['task_ids'] ?? [])
+      .filter((x) => typeof x === 'string');
+    for (const id of ids)
+      this.revoke(id);
+  }
+
+  private revoke(taskId: string): void {
+    logInfo('Revoke received', taskId);
+    this.revoked.add(taskId);
+    const current = this.getCurrent();
+    if (current == null || current.call.id !== taskId)
+      return;
+    current.context.cancelled = true;
+    // python send_canceled_call parity: publish the Canceled CALL immediately and
+    // ALWAYS via AMQP, even for pipe calls; the runner then suppresses the duplicate
+    if (!current.context.cancelPublished && !isCompletedStatus(current.call.status)) {
+      current.call.status = FuncCallStatus.CANCELED;
+      current.context.cancelPublished = true;
+      void this.publisher.publish(current.call.toJson(), current.call.id, 'call');
+    }
+  }
+
+  async close(): Promise<void> {
+    this.stopped = true;
+    const conn = this.conn;
+    this.conn = null;
+    if (conn != null) {
+      try {
+        await conn.close();
+      }
+      catch (_) {}
+    }
+  }
+}

--- a/datagrok-celery-worker/src/pipe-client.ts
+++ b/datagrok-celery-worker/src/pipe-client.ts
@@ -1,0 +1,260 @@
+/** WebSocket client for grok_pipe implementing the param streaming protocol.
+ *  Ground truth for the framing:
+ *  - core/shared/grok_shared/lib/src/http_client/sockets.dart (Const, SocketSender,
+ *    SocketReceiver): 'SENDING DATAFRAME <size> <tagsJson>' + binary chunks, each
+ *    acknowledged with 'PART OK'; abort constant Const.ERROR = 'PART ERROR'.
+ *  - datagrok-celery-task/datagrok_task.py (_get_param_grok_pipe/_send_param_grok_pipe):
+ *    the python lib compares the bare string 'ERROR' instead — we accept BOTH as abort.
+ *  - grok_pipe/src/server.ts: rooms are joined at ws://host:port/<callId> with headers
+ *    'x-member-name' and 'authorization'; all frames are relayed to the other members. */
+import WebSocket from 'ws';
+
+import {logInfo, logWarn} from './logger';
+
+export const Const = {
+  PART_OK: 'PART OK',
+  /** Dart abort constant (sockets.dart Const.ERROR). */
+  PART_ERROR: 'PART ERROR',
+  /** The python lib's abort comparison value (datagrok_task.py) — tolerated too. */
+  ERROR: 'ERROR',
+  CANCEL_PARAM: 'CANCEL PARAM',
+  SENDING: 'SENDING DATAFRAME',
+  PARAM: 'PARAM',
+  PARAM_SENT: 'PARAM_SENT',
+  CALL: 'CALL',
+  PROGRESS: 'PROGRESS',
+} as const;
+
+type PipeMessage = string | Uint8Array;
+
+interface Waiter {
+  resolve: (message: PipeMessage) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export interface PipeClientOptions {
+  /** Per-message wait timeout, ms (DATAGROK_WS_MESSAGE_TIMEOUT). */
+  messageTimeoutMs: number;
+  /** Total budget for receiving one param, ms (DATAGROK_PARAM_TIMEOUT). */
+  paramTimeoutMs: number;
+  /** Outbound chunk size (call.aux.batchSize, default 2048000). */
+  batchSize: number;
+  connectAttempts?: number;
+  connectRetryMs?: number;
+}
+
+export class PipeClient {
+  private readonly url: string;
+  private readonly headers: {[key: string]: string};
+  private readonly options: PipeClientOptions;
+  private ws: WebSocket | null = null;
+  private inbound: PipeMessage[] = [];
+  private waiter: Waiter | null = null;
+  private closed = false;
+
+  constructor(url: string, headers: {[key: string]: string}, options: PipeClientOptions) {
+    this.url = url;
+    this.headers = headers;
+    this.options = options;
+  }
+
+  get isConnected(): boolean {
+    return this.ws != null && this.ws.readyState === WebSocket.OPEN;
+  }
+
+  async connect(): Promise<void> {
+    const attempts = this.options.connectAttempts ?? 5;
+    const retryMs = this.options.connectRetryMs ?? 3000;
+    let lastError: any = null;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      try {
+        await this.connectOnce();
+        return;
+      }
+      catch (e: any) {
+        lastError = e;
+        logWarn(`grok_pipe connection failed (attempt ${attempt + 1}/${attempts}): ${e?.message ?? e}`);
+        if (attempt < attempts - 1)
+          await new Promise((resolve) => setTimeout(resolve, retryMs));
+      }
+    }
+    throw new Error(`Failed to connect to grok_pipe at ${this.url} after ${attempts} retries: ${lastError?.message ?? lastError}`);
+  }
+
+  private connectOnce(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.url, {headers: this.headers});
+      let settled = false;
+      ws.on('open', () => {
+        settled = true;
+        this.ws = ws;
+        this.attach(ws);
+        resolve();
+      });
+      ws.on('error', (e: Error) => {
+        if (!settled) {
+          settled = true;
+          reject(e);
+        }
+      });
+    });
+  }
+
+  private attach(ws: WebSocket): void {
+    ws.on('message', (data: WebSocket.RawData, isBinary: boolean) => {
+      const buffer = Array.isArray(data) ? Buffer.concat(data) :
+        data instanceof ArrayBuffer ? Buffer.from(data) : data;
+      this.push(isBinary ? new Uint8Array(buffer) : buffer.toString('utf8'));
+    });
+    ws.on('error', (e: Error) => logWarn(`grok_pipe socket error: ${e.message}`));
+    ws.on('close', () => {
+      if (this.ws === ws)
+        this.ws = null;
+      const waiter = this.waiter;
+      if (waiter != null) {
+        this.waiter = null;
+        clearTimeout(waiter.timer);
+        waiter.reject(new Error('grok_pipe connection was closed'));
+      }
+    });
+  }
+
+  private push(message: PipeMessage): void {
+    const waiter = this.waiter;
+    if (waiter != null) {
+      this.waiter = null;
+      clearTimeout(waiter.timer);
+      waiter.resolve(message);
+    }
+    else
+      this.inbound.push(message);
+  }
+
+  /** Next inbound message from the serialized queue, bounded by [timeoutMs]. */
+  private nextMessage(timeoutMs: number): Promise<PipeMessage> {
+    if (this.inbound.length > 0)
+      return Promise.resolve(this.inbound.shift()!);
+    if (!this.isConnected)
+      return Promise.reject(new Error('grok_pipe connection is closed'));
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.waiter = null;
+        reject(new Error(`Timeout (${timeoutMs} ms) waiting for a message from grok_pipe`));
+      }, timeoutMs);
+      this.waiter = {resolve: resolve, reject: reject, timer: timer};
+    });
+  }
+
+  sendText(message: string): void {
+    if (!this.isConnected)
+      throw new Error('grok_pipe connection is closed');
+    this.ws!.send(message);
+  }
+
+  private sendBinary(data: Uint8Array): void {
+    if (!this.isConnected)
+      throw new Error('grok_pipe connection is closed');
+    this.ws!.send(data, {binary: true});
+  }
+
+  /** Requests an input param ('PARAM <name>') and collects the peer's
+   *  'SENDING DATAFRAME <size> <tags>' + binary chunks (each acked with 'PART OK'),
+   *  terminated by 'PARAM_SENT <name>'. Returns null when no data was sent. */
+  async receiveParam(name: string): Promise<Uint8Array | null> {
+    logInfo(`Receiving param ${name}`);
+    const start = Date.now();
+    this.sendText(`${Const.PARAM} ${name}`);
+    const chunks: Uint8Array[] = [];
+    let expectedSize: number | null = null;
+    let received = 0;
+    for (;;) {
+      if (Date.now() - start > this.options.paramTimeoutMs)
+        throw new Error(`Timeout receiving param ${name}`);
+      const message = await this.nextMessage(this.options.messageTimeoutMs);
+      if (typeof message === 'string') {
+        if (message.startsWith(`${Const.PARAM_SENT} ${name}`))
+          break;
+        else if (message.startsWith('SENDING'))
+          expectedSize = PipeClient.parseExpectedSize(message);
+        else if (message === Const.PART_ERROR || message === Const.ERROR)
+          throw new Error(`Peer reported an error while sending param ${name}`);
+        // unrelated frames (LOG/PROGRESS/relay echoes) are tolerated and skipped
+      }
+      else {
+        if (expectedSize == null)
+          throw new Error('Protocol error: binary data received before the SENDING header');
+        chunks.push(message);
+        received += message.length;
+        this.sendText(Const.PART_OK);
+        if (received > expectedSize)
+          throw new Error(`Received more binary data than expected for param ${name}`);
+      }
+    }
+    if (chunks.length === 0)
+      return null;
+    logInfo(`Received param ${name} (${received} bytes in ${chunks.length} chunks)`);
+    return chunks.length === 1 ? chunks[0] : PipeClient.concat(chunks, received);
+  }
+
+  /** Sends an output param: 'SENDING DATAFRAME <size> <tagsJson>' followed by binary
+   *  chunks, waiting for 'PART OK' after each one (Dart SocketSender._send parity;
+   *  'CANCEL PARAM' stops sending, 'PART ERROR'/'ERROR' aborts). */
+  async sendParam(data: Uint8Array, tags: {[key: string]: string}): Promise<void> {
+    this.sendText(`${Const.SENDING} ${data.length} ${JSON.stringify(tags)}`);
+    const batchSize = this.options.batchSize;
+    for (let offset = 0; offset < data.length; offset += batchSize) {
+      this.sendBinary(data.subarray(offset, Math.min(offset + batchSize, data.length)));
+      for (;;) {
+        const response = await this.nextMessage(this.options.messageTimeoutMs);
+        if (typeof response !== 'string')
+          continue;
+        if (response === Const.PART_OK)
+          break;
+        if (response === Const.CANCEL_PARAM)
+          return;
+        if (response === Const.PART_ERROR || response === Const.ERROR)
+          throw new Error('Peer reported an error while receiving the parameter');
+        // skip unrelated text frames, keep waiting for the ack
+      }
+    }
+  }
+
+  /** Safe to call twice. */
+  close(): void {
+    if (this.closed)
+      return;
+    this.closed = true;
+    const ws = this.ws;
+    this.ws = null;
+    if (ws != null) {
+      try {
+        ws.close();
+      }
+      catch (_) {}
+    }
+    const waiter = this.waiter;
+    if (waiter != null) {
+      this.waiter = null;
+      clearTimeout(waiter.timer);
+      waiter.reject(new Error('grok_pipe client was closed'));
+    }
+  }
+
+  private static parseExpectedSize(message: string): number {
+    const size = parseInt(message.split(' ')[2], 10);
+    if (!Number.isFinite(size))
+      throw new Error(`Could not parse size from SENDING message: ${message.substring(0, 50)}`);
+    return size;
+  }
+
+  private static concat(chunks: Uint8Array[], totalLength: number): Uint8Array {
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      result.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return result;
+  }
+}

--- a/datagrok-celery-worker/src/progress.ts
+++ b/datagrok-celery-worker/src/progress.ts
@@ -1,0 +1,56 @@
+/** Per-call task context: cooperative cancellation flag + progress reporting
+ *  (mirrors DatagrokTask.update_state in datagrok_task.py). */
+import {FanoutPublisher} from './fanout-publisher';
+import {Const, PipeClient} from './pipe-client';
+import {logWarn} from './logger';
+
+export class CancelledError extends Error {
+  constructor(callId: string) {
+    super(`Call ${callId} was cancelled`);
+    this.name = 'CancelledError';
+  }
+}
+
+export class TaskContext {
+  readonly callId: string;
+  cancelled = false;
+  /** Set when the Canceled CALL was already published (by pidbox) so the runner
+   *  suppresses the duplicate result. */
+  cancelPublished = false;
+  pipe: PipeClient | null = null;
+
+  private readonly publisher: FanoutPublisher;
+
+  constructor(callId: string, publisher: FanoutPublisher) {
+    this.callId = callId;
+    this.publisher = publisher;
+  }
+
+  /** Reports progress: 'PROGRESS {json}' over the pipe when one is open, otherwise a
+   *  fanout 'progress' message (datlas parses {percent, description} either way).
+   *  Throws CancelledError when the call was revoked; other errors are swallowed. */
+  progress(percent: number | null, description: string): void {
+    if (this.cancelled)
+      throw new CancelledError(this.callId);
+    try {
+      const message = {'percent': percent, 'description': description};
+      if (this.pipe != null && this.pipe.isConnected)
+        this.pipe.sendText(`${Const.PROGRESS} ${JSON.stringify(message)}`);
+      else
+        this.publisher.publish(message, this.callId, 'progress').catch(() => {});
+    }
+    catch (e: any) {
+      logWarn(`Progress update failed: ${e?.message ?? e}`, this.callId);
+    }
+  }
+
+  /** Exposes progress to package code as globalThis.DG_TASK_PROGRESS. */
+  install(): void {
+    (globalThis as any).DG_TASK_PROGRESS =
+      (percent: number | null, description: string) => this.progress(percent, description);
+  }
+
+  uninstall(): void {
+    delete (globalThis as any).DG_TASK_PROGRESS;
+  }
+}

--- a/datagrok-celery-worker/src/settings.ts
+++ b/datagrok-celery-worker/src/settings.ts
@@ -1,0 +1,108 @@
+/** Worker settings, read from environment variables.
+ *  Mirrors datagrok-celery-task/settings.py (including the existing 'AMPQ' spelling
+ *  of the AMQP variables — kept for parity with the python lib and deploy tooling). */
+export class Settings {
+  taskQueueName: string;
+  celeryHostname: string;
+  celeryName: string;
+  packageName: string;
+  packageVersion?: string;
+  amqpHost: string;
+  amqpPort: number;
+  amqpUser: string;
+  amqpPassword: string;
+  amqpTls: boolean;
+  pipeHost: string;
+  pipePort: number;
+  pipeKey: string;
+  apiUrl?: string;
+  paramTimeoutMinutes: number;
+  wsMessageTimeoutSeconds: number;
+  healthPort: number;
+
+  constructor(values: {
+    taskQueueName: string,
+    celeryHostname: string,
+    celeryName: string,
+    packageName: string,
+    packageVersion?: string,
+    amqpHost: string,
+    amqpPort: number,
+    amqpUser: string,
+    amqpPassword: string,
+    amqpTls: boolean,
+    pipeHost: string,
+    pipePort: number,
+    pipeKey: string,
+    apiUrl?: string,
+    paramTimeoutMinutes: number,
+    wsMessageTimeoutSeconds: number,
+    healthPort: number,
+  }) {
+    this.taskQueueName = values.taskQueueName;
+    this.celeryHostname = values.celeryHostname;
+    this.celeryName = values.celeryName;
+    this.packageName = values.packageName;
+    this.packageVersion = values.packageVersion;
+    this.amqpHost = values.amqpHost;
+    this.amqpPort = values.amqpPort;
+    this.amqpUser = values.amqpUser;
+    this.amqpPassword = values.amqpPassword;
+    this.amqpTls = values.amqpTls;
+    this.pipeHost = values.pipeHost;
+    this.pipePort = values.pipePort;
+    this.pipeKey = values.pipeKey;
+    this.apiUrl = values.apiUrl;
+    this.paramTimeoutMinutes = values.paramTimeoutMinutes;
+    this.wsMessageTimeoutSeconds = values.wsMessageTimeoutSeconds;
+    this.healthPort = values.healthPort;
+  }
+
+  static fromEnv(env: NodeJS.ProcessEnv = process.env): Settings {
+    const missing: string[] = [];
+    const required = (name: string): string => {
+      const value = env[name];
+      if (value == null || value === '')
+        missing.push(name);
+      return value ?? '';
+    };
+    const intEnv = (name: string, defaultValue: number): number => {
+      const parsed = parseInt(env[name] ?? '', 10);
+      return Number.isFinite(parsed) ? parsed : defaultValue;
+    };
+
+    const settings = new Settings({
+      taskQueueName: required('TASK_QUEUE_NAME'),
+      celeryHostname: required('CELERY_HOSTNAME'),
+      celeryName: env['DATAGROK_CELERY_NAME'] || 'datagrok-celery',
+      packageName: required('DATAGROK_PACKAGE_NAME'),
+      packageVersion: env['DATAGROK_PACKAGE_VERSION'] || undefined,
+      amqpHost: env['DATAGROK_AMPQ_HOST'] || 'localhost',
+      amqpPort: intEnv('DATAGROK_AMPQ_PORT', 5672),
+      amqpUser: env['DATAGROK_AMPQ_USER'] || 'guest',
+      amqpPassword: env['DATAGROK_AMPQ_PASSWORD'] || 'guest',
+      amqpTls: (env['DATAGROK_AMPQ_TLS'] ?? 'false').toLowerCase() === 'true',
+      pipeHost: env['DATAGROK_PIPE_HOST'] || 'localhost',
+      pipePort: intEnv('DATAGROK_PIPE_PORT', 3000),
+      pipeKey: env['DATAGROK_PIPE_KEY'] ?? '',
+      apiUrl: env['DATAGROK_API_URL'] || undefined,
+      paramTimeoutMinutes: intEnv('DATAGROK_PARAM_TIMEOUT', 5),
+      wsMessageTimeoutSeconds: intEnv('DATAGROK_WS_MESSAGE_TIMEOUT', 30),
+      healthPort: intEnv('HEALTH_PORT', 8000),
+    });
+    if (missing.length > 0)
+      throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+    return settings;
+  }
+
+  /** amqp(s)://user:password@host:port (settings.py builds the same URL; credentials
+   *  are URL-encoded here because amqplib parses the string as a URL). */
+  get brokerUrl(): string {
+    const protocol = this.amqpTls ? 'amqps' : 'amqp';
+    return `${protocol}://${encodeURIComponent(this.amqpUser)}:${encodeURIComponent(this.amqpPassword)}@${this.amqpHost}:${this.amqpPort}`;
+  }
+
+  get pipeUrl(): string {
+    return `ws://${this.pipeHost}:${this.pipePort}`;
+  }
+}

--- a/datagrok-celery-worker/src/task-runner.ts
+++ b/datagrok-celery-worker/src/task-runner.ts
@@ -1,0 +1,115 @@
+/** Executes one FuncCall end to end (mirrors DatagrokTask's task lifecycle in
+ *  datagrok_task.py: input streaming -> run -> output streaming -> result CALL). */
+import {FanoutPublisher} from './fanout-publisher';
+import {FuncCall, FuncCallStatus} from './func-call';
+import {PackageHost} from './package-host';
+import {Const, PipeClient} from './pipe-client';
+import {CancelledError, TaskContext} from './progress';
+import {RunningTask} from './pidbox';
+import {Settings} from './settings';
+import {marshalInput, marshalOutput, validateCall} from './marshal';
+import {logError, logInfo, logWarn} from './logger';
+
+export class TaskRunner {
+  private readonly settings: Settings;
+  private readonly publisher: FanoutPublisher;
+  private readonly host: PackageHost;
+  private _current: RunningTask | null = null;
+
+  constructor(settings: Settings, publisher: FanoutPublisher, host: PackageHost) {
+    this.settings = settings;
+    this.publisher = publisher;
+    this.host = host;
+  }
+
+  get current(): RunningTask | null {
+    return this._current;
+  }
+
+  async run(call: FuncCall): Promise<void> {
+    logInfo(`Running ${call.funcName}`, call.id);
+    const context = new TaskContext(call.id, this.publisher);
+    this._current = {call: call, context: context};
+    let pipe: PipeClient | null = null;
+    call.status = FuncCallStatus.RUNNING;
+    try {
+      validateCall(call);
+      const impl = await this.host.resolve(call);
+      if (call.requiresPipe) {
+        pipe = new PipeClient(`${this.settings.pipeUrl}/${call.id}`, {
+          'x-member-name': `celery-${this.settings.celeryName}`,
+          'authorization': this.settings.pipeKey,
+        }, {
+          messageTimeoutMs: this.settings.wsMessageTimeoutSeconds * 1000,
+          paramTimeoutMs: this.settings.paramTimeoutMinutes * 60000,
+          batchSize: call.binaryBatchSize,
+        });
+        await pipe.connect();
+        context.pipe = pipe;
+      }
+      for (const param of call.inputParams)
+        if (param.isStreamable)
+          param.value = await pipe!.receiveParam(param.name);
+      const dg = this.host.dg;
+      for (const param of call.inputParams)
+        marshalInput(param, dg);
+      const args = call.inputParams.map((p) => p.value);
+      context.install();
+      let value: any;
+      try {
+        value = await impl(...args);
+      }
+      finally {
+        context.uninstall();
+      }
+      if (context.cancelled)
+        throw new CancelledError(call.id);
+      const output = call.outputParams[0];
+      if (output != null) {
+        if (value == null)
+          logWarn('Task returned null', call.id);
+        const marshaled = marshalOutput(output, value, dg);
+        if (output.isStreamable && marshaled.bytes != null)
+          await pipe!.sendParam(marshaled.bytes, marshaled.tags!);
+      }
+      call.status = FuncCallStatus.COMPLETED;
+      logInfo(`Completed ${call.funcName}`, call.id);
+    }
+    catch (e: any) {
+      if (e instanceof CancelledError || context.cancelled) {
+        call.status = FuncCallStatus.CANCELED;
+        logInfo(`Canceled ${call.funcName}`, call.id);
+      }
+      else {
+        call.status = FuncCallStatus.ERROR;
+        call.errorMessage = e?.message ?? String(e);
+        call.errorStackTrace = typeof e?.stack === 'string' ? e.stack : String(e);
+        logError(`Task failed: ${call.errorMessage}`, call.id);
+      }
+    }
+    finally {
+      await this.publishResult(call, context, pipe);
+      pipe?.close();
+      this._current = null;
+    }
+  }
+
+  /** Sends the result: 'CALL <json>' over the pipe for streamable calls, otherwise a
+   *  fanout 'call' message. Datlas accepts BOTH channels for any call
+   *  (call_queue_service.dart completes serverCalls from either), so a broken pipe
+   *  falls back to AMQP instead of retrying the pipe like the python lib does. */
+  private async publishResult(call: FuncCall, context: TaskContext, pipe: PipeClient | null): Promise<void> {
+    if (context.cancelPublished)
+      return; // pidbox already published the Canceled CALL
+    try {
+      if (pipe != null && pipe.isConnected) {
+        pipe.sendText(`${Const.CALL} ${JSON.stringify(call.toJson())}`);
+        return;
+      }
+    }
+    catch (e: any) {
+      logWarn(`CALL send over the pipe failed, falling back to AMQP: ${e?.message ?? e}`, call.id);
+    }
+    await this.publisher.publish(call.toJson(), call.id, 'call');
+  }
+}

--- a/datagrok-celery-worker/src/tests/fanout-publisher.test.ts
+++ b/datagrok-celery-worker/src/tests/fanout-publisher.test.ts
@@ -1,0 +1,66 @@
+import {CALLS_FANOUT, FanoutPublisher} from '../fanout-publisher';
+
+function mockConnection(publishFn: jest.Mock): any {
+  return {
+    on: jest.fn(),
+    close: jest.fn().mockResolvedValue(undefined),
+    createChannel: jest.fn().mockResolvedValue({
+      on: jest.fn(),
+      assertExchange: jest.fn().mockResolvedValue(undefined),
+      publish: publishFn,
+    }),
+  };
+}
+
+describe('FanoutPublisher', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  test('retries with 2^attempt backoff and succeeds on the third attempt', async () => {
+    const publishFn = jest.fn().mockReturnValue(true);
+    const connectFn = jest.fn()
+      .mockRejectedValueOnce(new Error('conn refused 1'))
+      .mockRejectedValueOnce(new Error('conn refused 2'))
+      .mockResolvedValue(mockConnection(publishFn));
+    const publisher = new FanoutPublisher('amqp://guest:guest@localhost:5672', connectFn);
+
+    const resultPromise = publisher.publish({'percent': 50, 'description': 'half'}, 'call-1', 'progress');
+    // attempt 1 fails -> 2s backoff, attempt 2 fails -> 4s backoff, attempt 3 succeeds
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(connectFn).toHaveBeenCalledTimes(2);
+    await jest.advanceTimersByTimeAsync(4000);
+    const result = await resultPromise;
+
+    expect(result).toBe(true);
+    expect(connectFn).toHaveBeenCalledTimes(3);
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    const [exchange, routingKey, content, options] = publishFn.mock.calls[0];
+    expect(exchange).toBe(CALLS_FANOUT);
+    expect(routingKey).toBe('');
+    expect(JSON.parse(content.toString('utf8'))).toEqual({'percent': 50, 'description': 'half'});
+    expect(options).toEqual({contentType: 'application/json', correlationId: 'call-1', type: 'progress'});
+  });
+
+  test('returns false (never throws) after all attempts fail', async () => {
+    const connectFn = jest.fn().mockRejectedValue(new Error('down'));
+    const publisher = new FanoutPublisher('amqp://guest:guest@localhost:5672', connectFn);
+    const resultPromise = publisher.publish({}, 'call-2', 'accepted');
+    await jest.advanceTimersByTimeAsync(2000);
+    await jest.advanceTimersByTimeAsync(4000);
+    await expect(resultPromise).resolves.toBe(false);
+    expect(connectFn).toHaveBeenCalledTimes(3);
+  });
+
+  test('reuses the channel across publishes and asserts the exchange non-durable', async () => {
+    const publishFn = jest.fn().mockReturnValue(true);
+    const conn = mockConnection(publishFn);
+    const connectFn = jest.fn().mockResolvedValue(conn);
+    const publisher = new FanoutPublisher('amqp://guest:guest@localhost:5672', connectFn);
+    await publisher.publish({}, 'c1', 'accepted');
+    await publisher.publish({}, 'c1', 'call');
+    expect(connectFn).toHaveBeenCalledTimes(1);
+    const channel = await conn.createChannel.mock.results[0].value;
+    expect(channel.assertExchange).toHaveBeenCalledWith(CALLS_FANOUT, 'fanout', {durable: false});
+    expect(publishFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/datagrok-celery-worker/src/tests/func-call.test.ts
+++ b/datagrok-celery-worker/src/tests/func-call.test.ts
@@ -1,0 +1,86 @@
+import {FuncCall, FuncCallStatus} from '../func-call';
+
+function sampleCallJson(): any {
+  return {
+    'id': 'call-1',
+    'func': {
+      'name': 'myFunc',
+      'params': [
+        {'name': 'x', 'propertyType': 'int', 'isInput': true},
+        {'name': 'df', 'propertyType': 'dataframe', 'isInput': true},
+        {'name': 'result', 'propertyType': 'dataframe', 'isInput': false},
+      ],
+    },
+    'parameterValues': {'x': 42},
+    'options': {'isParquet': false},
+    'aux': {'USER_API_KEY': 'secret', 'DATAGROK_API_URL': 'http://localhost:8082/api', 'batchSize': 1000},
+  };
+}
+
+describe('FuncCall', () => {
+  test('parses the Dart hybrid body {"args":[call],"kwargs":{}}', () => {
+    const call = FuncCall.fromCeleryBody({'args': [sampleCallJson()], 'kwargs': {}});
+    expect(call.id).toBe('call-1');
+    expect(call.funcName).toBe('myFunc');
+    expect(call.params.length).toBe(3);
+    expect(call.params[0].value).toBe(42);
+    expect(call.status).toBe(FuncCallStatus.RUNNING);
+  });
+
+  test('parses the celery proto2 array body [[call],{},{}]', () => {
+    const call = FuncCall.fromCeleryBody([[sampleCallJson()], {}, {}]);
+    expect(call.id).toBe('call-1');
+    expect(call.inputParams.map((p) => p.name)).toEqual(['x', 'df']);
+    expect(call.outputParams.map((p) => p.name)).toEqual(['result']);
+  });
+
+  test('throws on an unrecognized body', () => {
+    expect(() => FuncCall.fromCeleryBody({'kwargs': {}})).toThrow(/Unrecognized celery task body/);
+    expect(() => FuncCall.fromCeleryBody(null)).toThrow(/Unrecognized celery task body/);
+  });
+
+  test('streamable detection: dataframe/blob/file/graphics stream, scalars do not', () => {
+    const call = new FuncCall({
+      'id': 'c',
+      'func': {'name': 'f', 'params': [
+        {'name': 'a', 'propertyType': 'int', 'isInput': true},
+        {'name': 'b', 'propertyType': 'blob', 'isInput': true},
+        {'name': 'c', 'propertyType': 'file', 'isInput': true},
+        {'name': 'g', 'propertyType': 'graphics', 'isInput': false},
+      ]},
+    });
+    expect(call.params.map((p) => p.isStreamable)).toEqual([false, true, true, true]);
+    expect(call.requiresPipe).toBe(true);
+    const scalarCall = new FuncCall({'id': 'c2', 'func': {'name': 'f', 'params': [
+      {'name': 'a', 'propertyType': 'string', 'isInput': true}]}});
+    expect(scalarCall.requiresPipe).toBe(false);
+  });
+
+  test('aux getters', () => {
+    const call = new FuncCall(sampleCallJson());
+    expect(call.userApiKey).toBe('secret');
+    expect(call.apiUrl).toBe('http://localhost:8082/api');
+    expect(call.binaryBatchSize).toBe(1000);
+    expect(new FuncCall({'id': 'x'}).binaryBatchSize).toBe(FuncCall.DEFAULT_BINARY_BATCH_SIZE);
+  });
+
+  test('toJson round-trip: aux/func/options echoed, inputs keep original values, df output replaced by {id}', () => {
+    const source = sampleCallJson();
+    const call = new FuncCall(source);
+    call.params[1].value = new Uint8Array([1, 2, 3]); // streamed + marshaled input
+    call.params[2].value = {'id': 'some-uuid'};       // marshaled df output
+    call.status = FuncCallStatus.COMPLETED;
+    const json = call.toJson();
+    expect(json['id']).toBe('call-1');
+    expect(json['func']).toEqual(source['func']);
+    expect(json['options']).toEqual(source['options']);
+    expect(json['aux']).toEqual(source['aux']);
+    expect(json['status']).toBe('Completed');
+    expect(json['errorMessage']).toBeNull();
+    expect(json['errorStackTrace']).toBeNull();
+    // inputs echo the ORIGINAL raw values, not the marshaled ones
+    expect(json['parameterValues']['x']).toBe(42);
+    expect(json['parameterValues']['df']).toBeNull();
+    expect(json['parameterValues']['result']).toEqual({'id': 'some-uuid'});
+  });
+});

--- a/datagrok-celery-worker/src/tests/marshal.test.ts
+++ b/datagrok-celery-worker/src/tests/marshal.test.ts
@@ -1,0 +1,143 @@
+import {FuncCall, FuncCallParam, Type} from '../func-call';
+import {marshalInput, marshalOutput, validateCall} from '../marshal';
+
+function param(propertyType: string, value: any, isInput: boolean = true): FuncCallParam {
+  return new FuncCallParam('p', propertyType, isInput, value);
+}
+
+describe('validateCall', () => {
+  test('fails fast on isParquet', () => {
+    const call = new FuncCall({'id': 'c', 'func': {'params': []}, 'options': {'isParquet': true}});
+    expect(() => validateCall(call)).toThrow(/Parquet transfer is not supported/);
+  });
+
+  test('rejects multiple outputs (python parity message)', () => {
+    const call = new FuncCall({'id': 'c', 'func': {'params': [
+      {'name': 'a', 'propertyType': 'int', 'isInput': false},
+      {'name': 'b', 'propertyType': 'int', 'isInput': false}]}});
+    expect(() => validateCall(call)).toThrow(/Only one return parameter is allowed/);
+  });
+
+  test('accepts a single output without parquet', () => {
+    const call = new FuncCall({'id': 'c', 'func': {'params': [
+      {'name': 'a', 'propertyType': 'int', 'isInput': false}]}, 'options': {}});
+    expect(() => validateCall(call)).not.toThrow();
+  });
+});
+
+describe('marshalInput', () => {
+  test('int: number and numeric string', () => {
+    expect(marshalInput(param(Type.INT, 7))).toBe(7);
+    expect(marshalInput(param(Type.INT, '7'))).toBe(7);
+    expect(() => marshalInput(param(Type.INT, 'abc'))).toThrow(/Incorrect input type/);
+    expect(() => marshalInput(param(Type.INT, 1.5))).toThrow(/Incorrect input type/);
+  });
+
+  test('double', () => {
+    expect(marshalInput(param(Type.FLOAT, 1.5))).toBe(1.5);
+    expect(marshalInput(param(Type.FLOAT, '1.5'))).toBe(1.5);
+    expect(() => marshalInput(param(Type.FLOAT, 'abc'))).toThrow(/Incorrect input type/);
+  });
+
+  test('bool', () => {
+    expect(marshalInput(param(Type.BOOL, true))).toBe(true);
+    expect(marshalInput(param(Type.BOOL, 'false'))).toBe(false);
+    expect(() => marshalInput(param(Type.BOOL, 'yes'))).toThrow(/Incorrect input type/);
+  });
+
+  test('string', () => {
+    expect(marshalInput(param(Type.STRING, 'hi'))).toBe('hi');
+    expect(marshalInput(param(Type.STRING, 5))).toBe('5');
+  });
+
+  test('bigint via BigInt(string)', () => {
+    expect(marshalInput(param(Type.BIG_INT, '9007199254740993'))).toBe(BigInt('9007199254740993'));
+    expect(() => marshalInput(param(Type.BIG_INT, 'nope'))).toThrow(/bigint/);
+  });
+
+  test('datetime from ISO string', () => {
+    const value = marshalInput(param(Type.DATE_TIME, '2026-01-02T03:04:05.000Z'));
+    expect(value).toBeInstanceOf(Date);
+    expect((value as Date).toISOString()).toBe('2026-01-02T03:04:05.000Z');
+    expect(() => marshalInput(param(Type.DATE_TIME, 'not-a-date'))).toThrow(/ISO datetime/);
+  });
+
+  test('dataframe: UTF-8 CSV bytes through DG.DataFrame.fromCsv', () => {
+    const fromCsv = jest.fn().mockReturnValue({'fake': 'df'});
+    const dg = {DataFrame: {fromCsv: fromCsv}};
+    const p = param(Type.DATA_FRAME, new Uint8Array(Buffer.from('a,b\n1,2\n', 'utf8')));
+    expect(marshalInput(p, dg)).toEqual({'fake': 'df'});
+    expect(fromCsv).toHaveBeenCalledWith('a,b\n1,2\n');
+    expect(() => marshalInput(param(Type.DATA_FRAME, 'not-bytes'), dg)).toThrow(/Incorrect input type/);
+  });
+
+  test('blob passes bytes through', () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    expect(marshalInput(param(Type.BLOB, bytes))).toBe(bytes);
+    expect(() => marshalInput(param(Type.BLOB, 'no'))).toThrow(/Incorrect input type/);
+  });
+
+  test('null stays null', () => {
+    expect(marshalInput(param(Type.INT, null))).toBeNull();
+  });
+});
+
+describe('marshalOutput', () => {
+  test('dataframe: csv bytes + value {id} + tags', () => {
+    const p = param(Type.DATA_FRAME, null, false);
+    const df = {toCsv: () => 'a,b\n1,2\n'};
+    const out = marshalOutput(p, df);
+    expect(Buffer.from(out.bytes!).toString('utf8')).toBe('a,b\n1,2\n');
+    expect(p.value).toEqual({'id': out.tags!['.id']});
+    expect(out.tags!['.type']).toBe('csv');
+    expect(() => marshalOutput(param(Type.DATA_FRAME, null, false), 'not-a-df')).toThrow(/Incorrect return type/);
+  });
+
+  test('blob: bytes + value = param name + tags', () => {
+    const p = param(Type.BLOB, null, false);
+    const out = marshalOutput(p, new Uint8Array([9, 8]));
+    expect(Array.from(out.bytes!)).toEqual([9, 8]);
+    expect(p.value).toBe('p');
+    expect(out.tags).toEqual({'.id': 'p', '.type': 'blob'});
+    expect(() => marshalOutput(param(Type.BLOB, null, false), 'str')).toThrow(/Incorrect return type/);
+  });
+
+  test('scalars coerced, NaN throws', () => {
+    const intParam = param(Type.INT, null, false);
+    marshalOutput(intParam, 3.7);
+    expect(intParam.value).toBe(3); // python int() truncation parity
+    expect(() => marshalOutput(param(Type.INT, null, false), 'abc')).toThrow(/Incorrect return type/);
+    const floatParam = param(Type.FLOAT, null, false);
+    marshalOutput(floatParam, '2.5');
+    expect(floatParam.value).toBe(2.5);
+    expect(() => marshalOutput(param(Type.FLOAT, null, false), 'abc')).toThrow(/Incorrect return type/);
+    const boolParam = param(Type.BOOL, null, false);
+    marshalOutput(boolParam, 1);
+    expect(boolParam.value).toBe(true);
+    const strParam = param(Type.STRING, null, false);
+    marshalOutput(strParam, 42);
+    expect(strParam.value).toBe('42');
+    const bigParam = param(Type.BIG_INT, null, false);
+    marshalOutput(bigParam, BigInt('9007199254740993'));
+    expect(bigParam.value).toBe('9007199254740993');
+  });
+
+  test('datetime output requires Date/dayjs', () => {
+    const p = param(Type.DATE_TIME, null, false);
+    marshalOutput(p, new Date('2026-01-02T03:04:05.000Z'));
+    expect(p.value).toBe('2026-01-02T03:04:05.000Z');
+    expect(() => marshalOutput(param(Type.DATE_TIME, null, false), '2026-01-02')).toThrow(/Incorrect return type/);
+  });
+
+  test('null return keeps value null, no streaming', () => {
+    const p = param(Type.DATA_FRAME, null, false);
+    const out = marshalOutput(p, null);
+    expect(p.value).toBeNull();
+    expect(out.bytes).toBeNull();
+    expect(out.tags).toBeNull();
+  });
+
+  test('unsupported return type throws', () => {
+    expect(() => marshalOutput(param(Type.GRAPHICS, null, false), 'svg')).toThrow(/Unsupported return type/);
+  });
+});

--- a/datagrok-celery-worker/src/tests/pidbox.test.ts
+++ b/datagrok-celery-worker/src/tests/pidbox.test.ts
@@ -1,0 +1,131 @@
+import {CeleryConsumer} from '../celery-consumer';
+import {FuncCall, FuncCallStatus} from '../func-call';
+import {PidboxConsumer, RevokedSet, RunningTask} from '../pidbox';
+import {Settings} from '../settings';
+import {TaskContext} from '../progress';
+
+function testSettings(): Settings {
+  return new Settings({
+    taskQueueName: 'test_queue',
+    celeryHostname: 'test-host',
+    celeryName: 'datagrok-celery',
+    packageName: 'TestPkg',
+    amqpHost: 'localhost', amqpPort: 5672, amqpUser: 'guest', amqpPassword: 'guest', amqpTls: false,
+    pipeHost: 'localhost', pipePort: 3000, pipeKey: '',
+    paramTimeoutMinutes: 5, wsMessageTimeoutSeconds: 30, healthPort: 8000,
+  });
+}
+
+function mockPublisher(): any {
+  return {publish: jest.fn().mockResolvedValue(true)};
+}
+
+function callJson(id: string): any {
+  return {'id': id, 'func': {'name': 'f', 'params': []}, 'aux': {}};
+}
+
+describe('RevokedSet', () => {
+  test('entries expire after the TTL', () => {
+    jest.useFakeTimers();
+    try {
+      const revoked = new RevokedSet(1000);
+      revoked.add('t1');
+      expect(revoked.has('t1')).toBe(true);
+      jest.advanceTimersByTime(1001);
+      expect(revoked.has('t1')).toBe(false);
+    }
+    finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('PidboxConsumer', () => {
+  test('parses the datlas revoke payload and adds to the revoked set', () => {
+    const revoked = new RevokedSet();
+    const pidbox = new PidboxConsumer(testSettings(), mockPublisher(), revoked, () => null);
+    // exact shape from server_docker_func.dart cancelImpl
+    pidbox.handleControl({'method': 'revoke', 'arguments': {'task_id': 'task-9', 'terminate': true, 'signal': 'SIGTERM'}});
+    expect(revoked.has('task-9')).toBe(true);
+  });
+
+  test('accepts kombu-style task_ids lists and ignores other methods', () => {
+    const revoked = new RevokedSet();
+    const pidbox = new PidboxConsumer(testSettings(), mockPublisher(), revoked, () => null);
+    pidbox.handleControl({'method': 'revoke', 'arguments': {'task_ids': ['a', 'b']}});
+    expect(revoked.has('a')).toBe(true);
+    expect(revoked.has('b')).toBe(true);
+    pidbox.handleControl({'method': 'ping', 'arguments': {}});
+    pidbox.handleControl(null);
+    expect(revoked.has('undefined')).toBe(false);
+  });
+
+  test('revoking the running call sets its cancel flag and publishes the Canceled CALL once', () => {
+    const publisher = mockPublisher();
+    const call = new FuncCall(callJson('running-1'));
+    const context = new TaskContext(call.id, publisher);
+    const current: RunningTask = {call: call, context: context};
+    const pidbox = new PidboxConsumer(testSettings(), publisher, new RevokedSet(), () => current);
+
+    pidbox.handleControl({'method': 'revoke', 'arguments': {'task_id': 'running-1'}});
+    expect(context.cancelled).toBe(true);
+    expect(context.cancelPublished).toBe(true);
+    expect(call.status).toBe(FuncCallStatus.CANCELED);
+    expect(publisher.publish).toHaveBeenCalledTimes(1);
+    const [payload, correlationId, type] = publisher.publish.mock.calls[0];
+    expect(payload['status']).toBe('Canceled');
+    expect(correlationId).toBe('running-1');
+    expect(type).toBe('call');
+
+    // a duplicate revoke does not publish again
+    pidbox.handleControl({'method': 'revoke', 'arguments': {'task_id': 'running-1'}});
+    expect(publisher.publish).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('CeleryConsumer cancel-before-pickup', () => {
+  test('a task revoked before pickup gets a Canceled CALL instead of running', async () => {
+    const publisher = mockPublisher();
+    const revoked = new RevokedSet();
+    revoked.add('task-1');
+    const runTask = jest.fn().mockResolvedValue(undefined);
+    const consumer = new CeleryConsumer(testSettings(), publisher, revoked, runTask);
+
+    consumer.onMessage({
+      content: Buffer.from(JSON.stringify({'args': [callJson('task-1')], 'kwargs': {}}), 'utf8'),
+      properties: {headers: {'lang': 'js', 'task': 'f', 'id': 'task-1'}},
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(runTask).not.toHaveBeenCalled();
+    // ACCEPTED first, then the Canceled CALL
+    expect(publisher.publish).toHaveBeenCalledTimes(2);
+    expect(publisher.publish.mock.calls[0]).toEqual([{}, 'task-1', 'accepted']);
+    const [payload, correlationId, type] = publisher.publish.mock.calls[1];
+    expect(payload['status']).toBe('Canceled');
+    expect(correlationId).toBe('task-1');
+    expect(type).toBe('call');
+  });
+
+  test('a normal task is accepted and executed single-in-flight in FIFO order', async () => {
+    const publisher = mockPublisher();
+    const order: string[] = [];
+    const runTask = jest.fn().mockImplementation(async (call: FuncCall) => {
+      order.push(`start-${call.id}`);
+      await new Promise((resolve) => setImmediate(resolve));
+      order.push(`end-${call.id}`);
+    });
+    const consumer = new CeleryConsumer(testSettings(), publisher, new RevokedSet(), runTask);
+    const messageFor = (id: string): any => ({
+      content: Buffer.from(JSON.stringify({'args': [callJson(id)], 'kwargs': {}}), 'utf8'),
+      properties: {headers: {}},
+    });
+    consumer.onMessage(messageFor('t1'));
+    consumer.onMessage(messageFor('t2'));
+    await consumer.waitForIdle(1000);
+
+    expect(publisher.publish).toHaveBeenCalledWith({}, 't1', 'accepted');
+    expect(publisher.publish).toHaveBeenCalledWith({}, 't2', 'accepted');
+    expect(order).toEqual(['start-t1', 'end-t1', 'start-t2', 'end-t2']);
+  });
+});

--- a/datagrok-celery-worker/src/tests/pipe-client.test.ts
+++ b/datagrok-celery-worker/src/tests/pipe-client.test.ts
@@ -1,0 +1,171 @@
+import {AddressInfo} from 'node:net';
+import {WebSocketServer, WebSocket} from 'ws';
+
+import {Const, PipeClient} from '../pipe-client';
+
+interface PeerFrame {
+  data: string | Uint8Array;
+  isBinary: boolean;
+}
+
+/** Scripted grok_pipe stand-in: records inbound frames and lets tests await them. */
+class ScriptedPeer {
+  wss!: WebSocketServer;
+  socket: WebSocket | null = null;
+  headers: any = null;
+  frames: PeerFrame[] = [];
+  private waiters: ((frame: PeerFrame) => void)[] = [];
+  private processed = 0;
+
+  static async start(): Promise<ScriptedPeer> {
+    const peer = new ScriptedPeer();
+    peer.wss = new WebSocketServer({port: 0});
+    await new Promise<void>((resolve) => peer.wss.on('listening', () => resolve()));
+    peer.wss.on('connection', (ws, req) => {
+      peer.socket = ws;
+      peer.headers = req.headers;
+      ws.on('message', (data: any, isBinary: boolean) => {
+        const frame: PeerFrame = {
+          data: isBinary ? new Uint8Array(data as Buffer) : (data as Buffer).toString('utf8'),
+          isBinary: isBinary,
+        };
+        peer.frames.push(frame);
+        const waiter = peer.waiters.shift();
+        if (waiter != null)
+          waiter(frame);
+      });
+    });
+    return peer;
+  }
+
+  get port(): number {
+    return (this.wss.address() as AddressInfo).port;
+  }
+
+  nextFrame(): Promise<PeerFrame> {
+    if (this.frames.length > this.processed)
+      return Promise.resolve(this.frames[this.processed++]);
+    return new Promise((resolve) => this.waiters.push((frame) => {
+      this.processed++;
+      resolve(frame);
+    }));
+  }
+
+  send(message: string | Uint8Array): void {
+    this.socket!.send(message, {binary: typeof message !== 'string'});
+  }
+
+  async stop(): Promise<void> {
+    for (const ws of this.wss.clients)
+      ws.terminate();
+    await new Promise<void>((resolve) => this.wss.close(() => resolve()));
+  }
+}
+
+function makeClient(peer: ScriptedPeer, batchSize: number = 4): PipeClient {
+  return new PipeClient(`ws://127.0.0.1:${peer.port}/call-1`, {
+    'x-member-name': 'celery-datagrok-celery',
+    'authorization': 'test-key',
+  }, {messageTimeoutMs: 2000, paramTimeoutMs: 10000, batchSize: batchSize, connectAttempts: 1});
+}
+
+describe('PipeClient', () => {
+  let peer: ScriptedPeer;
+  let client: PipeClient;
+
+  beforeEach(async () => {
+    peer = await ScriptedPeer.start();
+    client = makeClient(peer);
+    await client.connect();
+  });
+
+  afterEach(async () => {
+    client.close();
+    client.close(); // safe to call twice
+    await peer.stop();
+  });
+
+  test('sends the room-join headers', () => {
+    expect(peer.headers['x-member-name']).toBe('celery-datagrok-celery');
+    expect(peer.headers['authorization']).toBe('test-key');
+  });
+
+  test('receiveParam: PARAM -> SENDING/chunks/PARAM_SENT with PART OK cadence, unrelated frames skipped', async () => {
+    const chunk1 = new Uint8Array([1, 2, 3]);
+    const chunk2 = new Uint8Array([4, 5]);
+    const resultPromise = client.receiveParam('df');
+
+    expect((await peer.nextFrame()).data).toBe('PARAM df');
+    peer.send('LOG {"message":"unrelated"}'); // must be tolerated and skipped
+    peer.send(`${Const.SENDING} 5 {".id":"x",".type":"csv"}`);
+    peer.send(chunk1);
+    expect((await peer.nextFrame()).data).toBe(Const.PART_OK);
+    peer.send(chunk2);
+    expect((await peer.nextFrame()).data).toBe(Const.PART_OK);
+    peer.send('PARAM_SENT df');
+
+    const result = await resultPromise;
+    expect(Array.from(result!)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test('receiveParam returns null when the peer sends no data', async () => {
+    const resultPromise = client.receiveParam('df');
+    expect((await peer.nextFrame()).data).toBe('PARAM df');
+    peer.send('PARAM_SENT df');
+    await expect(resultPromise).resolves.toBeNull();
+  });
+
+  test('receiveParam aborts on the Dart PART ERROR constant', async () => {
+    const resultPromise = client.receiveParam('df');
+    await peer.nextFrame();
+    peer.send(Const.PART_ERROR);
+    await expect(resultPromise).rejects.toThrow(/error while sending param df/);
+  });
+
+  test('receiveParam aborts on the bare python ERROR constant', async () => {
+    const resultPromise = client.receiveParam('df');
+    await peer.nextFrame();
+    peer.send(Const.ERROR);
+    await expect(resultPromise).rejects.toThrow(/error while sending param df/);
+  });
+
+  test('sendParam: chunks by batchSize and waits for PART OK after each chunk', async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]); // batchSize 4 -> 4+4+2
+    const sendPromise = client.sendParam(data, {'.id': 'out', '.type': 'csv'});
+
+    const header = await peer.nextFrame();
+    expect(header.data).toBe(`${Const.SENDING} 10 {".id":"out",".type":"csv"}`);
+
+    const received: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const frame = await peer.nextFrame();
+      expect(frame.isBinary).toBe(true);
+      received.push(...(frame.data as Uint8Array));
+      if (i === 0)
+        peer.send('PING REPLY'); // unrelated frame while waiting for the ack — skipped
+      peer.send(Const.PART_OK);
+    }
+    await sendPromise;
+    expect(received).toEqual(Array.from(data));
+    expect(peer.frames.filter((f) => f.isBinary).map((f) => (f.data as Uint8Array).length)).toEqual([4, 4, 2]);
+  });
+
+  test('sendParam aborts on PART ERROR and on bare ERROR', async () => {
+    const sendPromise = client.sendParam(new Uint8Array([1, 2, 3]), {'.id': 'out', '.type': 'blob'});
+    await peer.nextFrame(); // SENDING header
+    await peer.nextFrame(); // binary chunk
+    peer.send(Const.PART_ERROR);
+    await expect(sendPromise).rejects.toThrow(/error while receiving/);
+
+    const sendPromise2 = client.sendParam(new Uint8Array([1]), {'.id': 'out', '.type': 'blob'});
+    await peer.nextFrame();
+    await peer.nextFrame();
+    peer.send(Const.ERROR);
+    await expect(sendPromise2).rejects.toThrow(/error while receiving/);
+  });
+
+  test('sendText is used for CALL/PROGRESS frames', async () => {
+    client.sendText('CALL {"id":"call-1","status":"Completed"}');
+    expect((await peer.nextFrame()).data).toBe('CALL {"id":"call-1","status":"Completed"}');
+  });
+});

--- a/datagrok-celery-worker/src/worker.ts
+++ b/datagrok-celery-worker/src/worker.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/** Entrypoint: wires settings, health endpoint, pidbox + task queue consumers, and
+ *  graceful shutdown. */
+import {CeleryConsumer} from './celery-consumer';
+import {FanoutPublisher} from './fanout-publisher';
+import {PackageHost} from './package-host';
+import {PidboxConsumer, RevokedSet} from './pidbox';
+import {Settings} from './settings';
+import {TaskRunner} from './task-runner';
+import {startHealthServer} from './health';
+import {logError, logInfo} from './logger';
+
+const SHUTDOWN_WAIT_MS = 30000;
+
+async function main(): Promise<void> {
+  let settings: Settings;
+  try {
+    settings = Settings.fromEnv();
+  }
+  catch (e: any) {
+    console.error(`datagrok-celery-worker: ${e?.message ?? e}`);
+    process.exit(1);
+    return;
+  }
+
+  logInfo(`Starting datagrok-celery-worker for package '${settings.packageName}'` +
+    `${settings.packageVersion ? ` v${settings.packageVersion}` : ''}` +
+    `, queue '${settings.taskQueueName}', hostname '${settings.celeryHostname}'`);
+
+  const health = startHealthServer(settings.healthPort);
+  const publisher = new FanoutPublisher(settings.brokerUrl);
+  const revoked = new RevokedSet();
+  const host = new PackageHost(settings);
+  const runner = new TaskRunner(settings, publisher, host);
+  const pidbox = new PidboxConsumer(settings, publisher, revoked, () => runner.current);
+  const consumer = new CeleryConsumer(settings, publisher, revoked, (call) => runner.run(call));
+
+  await pidbox.start();
+  await consumer.start();
+
+  let shuttingDown = false;
+  const shutdown = async (signal: string): Promise<void> => {
+    if (shuttingDown)
+      return;
+    shuttingDown = true;
+    logInfo(`Received ${signal}, shutting down...`);
+    try {
+      await consumer.stopConsuming();
+      if (!await consumer.waitForIdle(SHUTDOWN_WAIT_MS))
+        logError(`In-flight task did not finish within ${SHUTDOWN_WAIT_MS} ms, exiting anyway`);
+      await consumer.close();
+      await pidbox.close();
+      await publisher.close();
+      health.close();
+    }
+    catch (e: any) {
+      logError(`Shutdown error: ${e?.message ?? e}`);
+    }
+    process.exit(0);
+  };
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+}
+
+main().catch((e) => {
+  logError(`Fatal: ${e?.message ?? e}`);
+  process.exit(1);
+});

--- a/datagrok-celery-worker/tsconfig.json
+++ b/datagrok-celery-worker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/tests"]
+}

--- a/help/develop/how-to/packages/js-server-functions.md
+++ b/help/develop/how-to/packages/js-server-functions.md
@@ -1,0 +1,91 @@
+---
+title: "JS server functions (meta.queue)"
+description: Run package JS/TS functions server-side as Celery tasks in Docker-based Node workers managed automatically by Datagrok.
+keywords:
+  - Celery task
+  - meta.queue
+  - Node worker
+  - server function
+  - RabbitMQ worker
+  - docker container
+---
+
+## Overview
+
+A function declared in your package's `src/package.ts` normally runs in the browser. Annotate it with
+`meta.queue` and it becomes a **server function**: on publish, Datagrok registers it as a Docker
+function, spins up a Docker-based Node worker container, and routes every call through the platform's
+task queue (RabbitMQ + Celery protocol) — exactly like [Python Docker functions](python-functions.md),
+but for JavaScript/TypeScript.
+
+The worker loads your published package bundle via the js-api Node runtime, so the function body runs
+with the familiar `grok` / `DG` APIs available (server-side, no UI).
+
+## Declaring a function
+
+Comment annotation:
+
+```typescript
+//name: heavyCompute
+//meta.queue: true
+//input: dataframe df
+//output: dataframe result
+export function heavyCompute(df: DG.DataFrame): DG.DataFrame {
+  // runs inside the Node worker container, not the browser
+  return df;
+}
+```
+
+Or with a decorator:
+
+```typescript
+@grok.decorators.func({meta: {queue: true}})
+```
+
+Calling it is unchanged:
+
+```typescript
+const result = await grok.functions.call('MyPackage:heavyCompute', {df});
+```
+
+## Container options
+
+* `//meta.queue: true` — the platform auto-creates a worker container from the stock
+  `datagrok/celery_node_worker` image. Optionally add `queue/container.json` in the package root to
+  configure resources: `{"cpu": 1, "memory": 1024, "gpu": 0, "on_demand": true, "shutdown_timeout": 60}`.
+  The `queue/` folder is reserved for this purpose.
+* `//meta.queue: <dirName>` — bind the function to your own container defined in
+  `dockerfiles/<dirName>/`. Base your Dockerfile on the worker image:
+
+  ```dockerfile
+  FROM datagrok/celery_node_worker:bleeding-edge
+  EXPOSE 8000
+  ```
+
+  A container cannot mix Python Celery tasks (`.py` files) and JS queue functions.
+
+## Inside the function
+
+* All package code and bundled npm dependencies are available (the worker loads the published webpack
+  bundle). `grok.dapi.*` calls run with the calling user's session token.
+* Report progress with the worker-provided global (a no-op in the browser):
+
+  ```typescript
+  (globalThis as any).DG_TASK_PROGRESS?.(50, 'half way');
+  ```
+
+  When the call was cancelled, this throws, letting long loops stop cooperatively.
+
+## Limitations
+
+* One output parameter per function (same as Python Celery tasks).
+* DataFrames are transferred as CSV (no Parquet yet).
+* Cancellation is cooperative: the call completes as `Canceled` immediately, but a running function
+  body only observes it at the next `DG_TASK_PROGRESS` call.
+* `meta.queue` is only recognized in `package.ts` (not detectors or test entrypoints).
+* Package `init` functions run once per worker process, with the first caller's token.
+
+See also:
+
+* [Creating Python Docker Apps](python-functions.md)
+* [Docker containers in packages](docker-containers.md)

--- a/js-api/src/api/ddt.api.g.ts
+++ b/js-api/src/api/ddt.api.g.ts
@@ -387,6 +387,10 @@ export class FuncOptions {
   /// Function that returns a Widget that gets added as a tab to the "Inspector" window
   static InspectorPanel = 'inspectorPanel';
 
+  /// Runs a package JS function as a celery task in a docker-based worker.
+  /// 'true' — an auto-created Node worker container; a name — the package's dockerfiles/[name] container.
+  static Queue = 'queue';
+
   /// Function that should be cached
   static Cache = 'cache';
 

--- a/js-api/src/decorators/functions.ts
+++ b/js-api/src/decorators/functions.ts
@@ -163,6 +163,9 @@ export namespace decorators {
     url?: string;
     propertyType?: string;
     semType?: string;
+    /** Runs the function server-side as a celery task in a docker-based Node worker.
+     * `true` — an auto-created worker container; a string — the package's `dockerfiles/<name>` container. */
+    queue?: boolean | string;
   }
 
   interface FunctionOptions {

--- a/packages/CVMTests/CHANGELOG.md
+++ b/packages/CVMTests/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v.next
 
+* Tests: Added `Celery: node worker` suite — JS queue functions (`meta.queue`) executed server-side in the celery Node worker: scalar/string/dataframe round-trips, error propagation, progress, cancellation, dapi token pass-through, and a custom `dockerfiles/node-worker` container
+
 * Tests: env scripts now declare `#meta.timeout: 600` (the 300s server exec default fired at ~318s under merged-stage load) and env-test client budgets sit above it at 660s — real hangs still surface, a busy stand doesn't flake
 * GROK-20445: Env tests: dropped the obsolete `numpy < 2` assertion (base env now resolves numpy-2-native pyarrow); made the two DG-idiom nodejs scripts (Column list, Lines count) runtime-agnostic until the Node js-api runtime lands on master
 * Scripts: Migrated nodejs test scripts to the js-api (`grok`/`DG` globals); dataframe-js/axios are no longer injected into nodejs scripts (breaking — legacy scripts must `require()` them explicitly or move to `DG.DataFrame`)

--- a/packages/CVMTests/dockerfiles/node-worker/Dockerfile
+++ b/packages/CVMTests/dockerfiles/node-worker/Dockerfile
@@ -1,0 +1,2 @@
+FROM datagrok/celery_node_worker:bleeding-edge
+EXPOSE 8000

--- a/packages/CVMTests/dockerfiles/node-worker/container.json
+++ b/packages/CVMTests/dockerfiles/node-worker/container.json
@@ -1,0 +1,1 @@
+{"cpu": 1, "memory": 1024, "on_demand": true}

--- a/packages/CVMTests/src/celery/node_celery_tests.ts
+++ b/packages/CVMTests/src/celery/node_celery_tests.ts
@@ -1,0 +1,71 @@
+import * as grok from 'datagrok-api/grok';
+import * as DG from 'datagrok-api/dg';
+
+import {category, test, expect, expectTable, expectExceptionAsync} from '@datagrok-libraries/test/src/test';
+
+import {randomString, escapingTestStrings} from '../utils/test-utils';
+
+category('Celery: node worker', () => {
+  test('Scalars round-trip', async () => {
+    const scalars: {[func: string]: any} = {jsCvmInt: 42, jsCvmDouble: 0.3, jsCvmBool: true, jsCvmString: 'Datagrok'};
+    for (const [func, value] of Object.entries(scalars))
+      expect(await grok.functions.call(`CVMTests:${func}`, {x: value}), value);
+    const big = '9007199254740993'; // 2^53 + 1 — survives only as a string
+    expect(String(await grok.functions.call('CVMTests:jsCvmBigInt', {x: big})), big);
+  }, {timeout: 120000 /* long timeout: first call starts the worker container */});
+
+  test('String escaping', async () => {
+    for (const s of escapingTestStrings)
+      expect(await grok.functions.call('CVMTests:jsCvmString', {x: s}), s);
+  }, {timeout: 90000});
+
+  test('Long string', async () => {
+    const long = randomString(500000, '0123456789abcdefghijklmnopqrstuvwxyz');
+    expect(await grok.functions.call('CVMTests:jsCvmString', {x: long}), long);
+  }, {timeout: 90000});
+
+  test('DataFrame round-trip', async () => {
+    const df = DG.DataFrame.fromColumns([
+      DG.Column.fromList(DG.COLUMN_TYPE.INT, 'i', [1, 2, 3]),
+      DG.Column.fromList(DG.COLUMN_TYPE.FLOAT, 'd', [1.5, 2.5, 3.5]),
+      DG.Column.fromList(DG.COLUMN_TYPE.STRING, 's', ['a', 'x,y', 'Ünï']),
+      DG.Column.fromList(DG.COLUMN_TYPE.BOOL, 'b', [true, false, true]),
+    ]);
+    expectTable(await grok.functions.call('CVMTests:jsCvmDataframe', {df}), df);
+  }, {timeout: 90000});
+
+  test('Empty dataframe', async () => {
+    const result: DG.DataFrame = await grok.functions.call('CVMTests:jsCvmEmptyDataframe', {});
+    expect(result.rowCount, 0);
+  }, {timeout: 90000});
+
+  test('Error propagation', async () => {
+    await expectExceptionAsync(
+      async () => {
+        await grok.functions.call('CVMTests:jsCvmError', {});
+      },
+      (e) => String(e).includes('planned jsCvmError failure'));
+  }, {timeout: 90000});
+
+  test('Progress call is a no-op-safe pass-through', async () => {
+    expect(await grok.functions.call('CVMTests:jsCvmProgress', {}), 'ok');
+  }, {timeout: 90000});
+
+  test('Dapi access with caller token', async () => {
+    const login: string = await grok.functions.call('CVMTests:jsCvmCurrentUser', {});
+    expect(login, (await grok.dapi.users.current()).login);
+  }, {timeout: 90000});
+
+  test('Cancellation', async () => {
+    const call = DG.Func.find({package: 'CVMTests', name: 'jsCvmCancel'})[0].prepare({seconds: 60});
+    const promise = call.call().catch(() => {});
+    await DG.delay(5000);
+    await call.cancel();
+    await promise;
+    expect(call.status, 'Canceled');
+  }, {timeout: 120000});
+
+  test('Custom container', async () => {
+    expect(await grok.functions.call('CVMTests:jsCvmCustomContainer', {}), 'custom');
+  }, {timeout: 240000 /* separate container cold start */});
+});

--- a/packages/CVMTests/src/package-api.ts
+++ b/packages/CVMTests/src/package-api.ts
@@ -512,6 +512,54 @@ export namespace funcs {
     return await grok.functions.call('CVMTests:GetColumn', { table, columnName });
   }
 
+  export async function jsCvmInt(x: number ): Promise<number> {
+    return await grok.functions.call('CVMTests:JsCvmInt', { x });
+  }
+
+  export async function jsCvmDouble(x: number ): Promise<number> {
+    return await grok.functions.call('CVMTests:JsCvmDouble', { x });
+  }
+
+  export async function jsCvmBool(x: boolean ): Promise<boolean> {
+    return await grok.functions.call('CVMTests:JsCvmBool', { x });
+  }
+
+  export async function jsCvmString(x: string ): Promise<string> {
+    return await grok.functions.call('CVMTests:JsCvmString', { x });
+  }
+
+  export async function jsCvmBigInt(x: bigint ): Promise<bigint> {
+    return await grok.functions.call('CVMTests:JsCvmBigInt', { x });
+  }
+
+  export async function jsCvmDataframe(df: DG.DataFrame ): Promise<DG.DataFrame> {
+    return await grok.functions.call('CVMTests:JsCvmDataframe', { df });
+  }
+
+  export async function jsCvmEmptyDataframe(): Promise<DG.DataFrame> {
+    return await grok.functions.call('CVMTests:JsCvmEmptyDataframe', {});
+  }
+
+  export async function jsCvmError(): Promise<string> {
+    return await grok.functions.call('CVMTests:JsCvmError', {});
+  }
+
+  export async function jsCvmCancel(seconds: number ): Promise<string> {
+    return await grok.functions.call('CVMTests:JsCvmCancel', { seconds });
+  }
+
+  export async function jsCvmProgress(): Promise<string> {
+    return await grok.functions.call('CVMTests:JsCvmProgress', {});
+  }
+
+  export async function jsCvmCurrentUser(): Promise<string> {
+    return await grok.functions.call('CVMTests:JsCvmCurrentUser', {});
+  }
+
+  export async function jsCvmCustomContainer(): Promise<string> {
+    return await grok.functions.call('CVMTests:JsCvmCustomContainer', {});
+  }
+
   export async function info(): Promise<void> {
     return await grok.functions.call('CVMTests:Info', {});
   }

--- a/packages/CVMTests/src/package-test.ts
+++ b/packages/CVMTests/src/package-test.ts
@@ -4,6 +4,7 @@ import * as DG from 'datagrok-api/dg';
 import './shell/ml';
 import './scripts/scripts_tests';
 import './celery/celery_tests';
+import './celery/node_celery_tests';
 import './docker/docker';
 import './files/files';
 // import './gui/dialogs'; To fix!

--- a/packages/CVMTests/src/package.ts
+++ b/packages/CVMTests/src/package.ts
@@ -20,3 +20,98 @@ export function getColumn(table: DG.DataFrame, columnName: string): DG.Column {
   const col = table.getCol(columnName);
   return col;
 }
+
+// ---- JS queue functions: run server-side in the celery Node worker (meta.queue) ----
+
+//name: jsCvmInt
+//meta.queue: true
+//input: int x
+//output: int result
+export function jsCvmInt(x: number): number {
+  return x;
+}
+
+//name: jsCvmDouble
+//meta.queue: true
+//input: double x
+//output: double result
+export function jsCvmDouble(x: number): number {
+  return x;
+}
+
+//name: jsCvmBool
+//meta.queue: true
+//input: bool x
+//output: bool result
+export function jsCvmBool(x: boolean): boolean {
+  return x;
+}
+
+//name: jsCvmString
+//meta.queue: true
+//input: string x
+//output: string result
+export function jsCvmString(x: string): string {
+  return x;
+}
+
+//name: jsCvmBigInt
+//meta.queue: true
+//input: bigint x
+//output: bigint result
+export function jsCvmBigInt(x: bigint): bigint {
+  return x;
+}
+
+//name: jsCvmDataframe
+//meta.queue: true
+//input: dataframe df
+//output: dataframe result
+export function jsCvmDataframe(df: DG.DataFrame): DG.DataFrame {
+  return df;
+}
+
+//name: jsCvmEmptyDataframe
+//meta.queue: true
+//output: dataframe result
+export function jsCvmEmptyDataframe(): DG.DataFrame {
+  return DG.DataFrame.fromColumns([DG.Column.fromList(DG.COLUMN_TYPE.FLOAT, 'col1', [])]);
+}
+
+//name: jsCvmError
+//meta.queue: true
+//output: string result
+export function jsCvmError(): string {
+  throw new Error('planned jsCvmError failure');
+}
+
+//name: jsCvmCancel
+//meta.queue: true
+//input: int seconds
+//output: string result
+export async function jsCvmCancel(seconds: number): Promise<string> {
+  await new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+  return 'done';
+}
+
+//name: jsCvmProgress
+//meta.queue: true
+//output: string result
+export function jsCvmProgress(): string {
+  (globalThis as any).DG_TASK_PROGRESS?.(50, 'half way');
+  return 'ok';
+}
+
+//name: jsCvmCurrentUser
+//meta.queue: true
+//output: string result
+export async function jsCvmCurrentUser(): Promise<string> {
+  return (await grok.dapi.users.current()).login;
+}
+
+//name: jsCvmCustomContainer
+//meta.queue: node-worker
+//output: string result
+export function jsCvmCustomContainer(): string {
+  return 'custom';
+}

--- a/packages/Notebooks/dockerfiles/jupyter-notebook/grok_helper/environments.py
+++ b/packages/Notebooks/dockerfiles/jupyter-notebook/grok_helper/environments.py
@@ -90,9 +90,10 @@ class Environments(object):
             if isinstance(dep, str) and dep.startswith('python='):
                 ver = dep.split('=')[1]
                 major_minor = '.'.join(ver.split('.')[:2])
-                tar_path = os.path.join(CONDA_HOME, 'envs', TEMPLATE_ENV_PREFIX + major_minor + '.tar')
-                if os.path.isfile(tar_path):
-                    return tar_path
+                for ext in ('.tar.zst', '.tar'):
+                    tar_path = os.path.join(CONDA_HOME, 'envs', TEMPLATE_ENV_PREFIX + major_minor + ext)
+                    if os.path.isfile(tar_path):
+                        return tar_path
         return None
 
     def _normalize_environment(self, environment, language):
@@ -169,10 +170,11 @@ class Environments(object):
             'else\n'
 
         if template_tar:
-            # Extract pre-built template tarball (sequential I/O, fast on overlay2).
+            # Extract pre-built template tarball (sequential I/O, fast on overlay2;
+            # tar auto-detects zstd compression on extract).
             # Then fix shebangs and symlinks that reference the template env path.
             # Use grep -rIl (-I skips binary files) to avoid corrupting ELF binaries.
-            template_env_dir = os.path.splitext(template_tar)[0]
+            template_env_dir = re.sub(r'\.tar(\.zst)?$', '', template_tar)
             script += \
                 'mkdir -p ' + env_path + '\n' + \
                 'tar xf ' + template_tar + ' -C ' + env_path + '\n' + \

--- a/tools/bin/commands/publish.ts
+++ b/tools/bin/commands/publish.ts
@@ -14,6 +14,7 @@ import {loadPackages} from '../utils/test-utils';
 import * as color from '../utils/color-utils';
 import {check} from './check';
 import {generateCeleryArtifacts} from '../utils/python-celery-gen';
+import {generateQueueArtifacts} from '../utils/queue-worker-gen';
 
 const {exec, execSync} = require('child_process');
 
@@ -577,6 +578,9 @@ export async function processPackage(debug: boolean, rebuild: boolean, host: str
 
   // Generate Celery Docker artifacts from python/ if present
   generateCeleryArtifacts(curDir);
+
+  // Generate the Node worker container for meta.queue JS functions if present
+  generateQueueArtifacts(curDir);
 
   // Process Docker images and inject image.json into the ZIP
   let dockerVersion = json.version;

--- a/tools/bin/utils/queue-worker-gen.ts
+++ b/tools/bin/utils/queue-worker-gen.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+import * as color from './color-utils';
+
+// Matches `//meta.queue: true` in package.ts — functions executed as celery tasks
+// in the Node worker (see help/develop/how-to/packages/js-server-functions.md).
+const queueTrueRegex = /^\s*\/\/\s*meta\.queue\s*:\s*true\s*$/m;
+
+const QUEUE_DIR = 'queue';
+
+const TEMPLATE_NODE_DOCKER = `FROM datagrok/celery_node_worker:bleeding-edge
+EXPOSE 8000
+`;
+
+/** Generates dockerfiles/queue/ for packages with \`meta.queue: true\` functions so the
+ *  standard docker build/push/image.json flow covers the auto-created Node worker
+ *  container (mirror of generateCeleryArtifacts for python/). The worker fetches the
+ *  package bundle at runtime, so the image is just the stock worker base. */
+export function generateQueueArtifacts(packageDir: string): boolean {
+  const candidates = ['package.ts', 'package.g.ts']
+    .map((f) => path.join(packageDir, 'src', f))
+    .filter((f) => fs.existsSync(f));
+  const hasQueueFuncs = candidates.some((f) => queueTrueRegex.test(fs.readFileSync(f, 'utf-8')));
+  if (!hasQueueFuncs)
+    return false;
+
+  const dockerfilesDir = path.join(packageDir, 'dockerfiles', QUEUE_DIR);
+  const dockerfilePath = path.join(dockerfilesDir, 'Dockerfile');
+  fs.mkdirSync(dockerfilesDir, {recursive: true});
+  if (!fs.existsSync(dockerfilePath))
+    fs.writeFileSync(dockerfilePath, TEMPLATE_NODE_DOCKER);
+
+  // Resource config lives in the reserved queue/ package folder
+  const containerJsonSrc = path.join(packageDir, QUEUE_DIR, 'container.json');
+  const containerJsonDest = path.join(dockerfilesDir, 'container.json');
+  if (fs.existsSync(containerJsonSrc) && !fs.existsSync(containerJsonDest))
+    fs.copyFileSync(containerJsonSrc, containerJsonDest);
+
+  color.log(`Generated Node worker Docker artifacts in dockerfiles/${QUEUE_DIR}/`);
+  return true;
+}


### PR DESCRIPTION
## Summary

- New `datagrok-celery-worker` npm lib: celery-protocol Node worker executing published package JS functions (AMQP consumer w/ ack-on-receipt + ACCEPTED, calls_fanout publisher with retry, grok_pipe CSV streaming, pidbox cancellation, lazy `startDatagrok({detached}) + loadPackage()` with per-call token, direct module-export invocation, `DG_TASK_PROGRESS` surface, health endpoint; 41 jest tests)
- js-api: typed `queue` decorator meta option; regenerated Node Dart bundle + `FuncOptions.Queue` in generated API
- CVMTests: `jsCvm*` queue functions + `Celery: node worker` E2E suite (scalars/df round-trips, error, progress, cancel, dapi token, custom `dockerfiles/node-worker` container)
- Help: `develop/how-to/packages/js-server-functions.md`

Server-side counterpart: Bitbucket PR on branch `claude/GROK-20452` (reddata). Ticket: GROK-20452.

Generated with [Claude Code](https://claude.com/claude-code)