### PR TITLE
[ticket] GROK-20419: Tutorials: Point the Embedded Viewers final-step hint at the inline Trellis props host instead of a dead selector

### DIFF
--- a/packages/Tutorials/CHANGELOG.md
+++ b/packages/Tutorials/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* GROK-20419: Tutorials: Fixed the missing highlight on the Embedded Viewers tutorial's final step — pointed the hint at the inline Trellis inner-viewer properties (`.d4-trellis-plot-props-host`) instead of a dead `.grok-font-icon-settings.d4-viewer-icon` selector that matched no element
 * Demo app: Always clear the "Updating..." overlay when a demo finishes — moved `setUpdateIndicator(false)` into a `finally` so a failing demo no longer leaves the indicator covering the home page
 * Demo app: Fixed clipped/misplaced "Updating..." overlay — place it on the tab-content of the active view instead of `tab-content[0]`, so it stays bounded (tab-content is `position: relative`) and lands on the pane that's actually being replaced rather than a sibling (e.g. the home page) when the dock is split
 * Demo app: Made the "Updating..." overlay clearly readable during demo loading — scoped CSS (`.demo-app-loading > .d4-update-shadow`) gives the overlay a solid translucent white background with a subtle backdrop blur and renders the label/loader at full opacity, so widget text underneath no longer bleeds through

--- a/packages/Tutorials/src/tracks/eda/tutorials/embedded-viewers.ts
+++ b/packages/Tutorials/src/tracks/eda/tutorials/embedded-viewers.ts
@@ -75,8 +75,8 @@ export class EmbeddedViewersTutorial extends Tutorial {
       interval(1000).pipe(
         map((_) => (trellis.getOptions() as {[key: string]: any }).look.innerViewerLook.colorColumnName),
         filter((name: string | undefined) => name === 'AGE')),
-      $(trellis!.root).find('.grok-font-icon-settings.d4-viewer-icon')[0],
-      'Click on the gear icon to edit the scatter plot properties. ' +
-      'Find the <b>Color</b> property within the <b>Color</b> section.');
+      $(trellis!.root).find('.d4-trellis-plot-props-host')[0],
+      'Use the inner scatter plot properties shown above the Trellis plot, ' +
+      'and set the <b>Color</b> property to <b>AGE</b>.');
   }
 }


### PR DESCRIPTION
The Embedded Viewers tutorial's final step showed no highlight because its hint used `.grok-font-icon-settings.d4-viewer-icon`, matching no element (those classes live on unrelated elements), so Tutorial.action's null-guard skipped hint placement. The inner scatter plot's Color is edited inline in the Trellis properties host (`.d4-trellis-plot-props-host`); the fix points the hint there and updates the stale gear-icon instruction text. Verified with `npm run build` (exit 0).

---
**Diff:** +4/-3 · 2 files · full analysis: [GROK-20419](https://reddata.atlassian.net/browse/GROK-20419) · reviewer: Dmytro Kovalyov (package author)


[GROK-20419]: https://reddata.atlassian.net/browse/GROK-20419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ