### PR TITLE
GROK-20452: meta.server: true — alias for the default worker queue

### DIFF
--- a/help/develop/how-to/packages/js-server-functions.md
+++ b/help/develop/how-to/packages/js-server-functions.md
@@ -42,6 +42,9 @@ Or with a decorator:
 @grok.decorators.func({meta: {queue: true}})
 ```
 
+`//meta.server: true` (decorator: `meta: {server: true}`) is an alias of `meta.queue: true` —
+the function runs server-side in the default worker queue.
+
 Calling it is unchanged:
 
 ```typescript

--- a/js-api/src/api/ddt.api.g.ts
+++ b/js-api/src/api/ddt.api.g.ts
@@ -391,6 +391,10 @@ export class FuncOptions {
   /// 'true' — an auto-created Node worker container; a name — the package's dockerfiles/[name] container.
   static Queue = 'queue';
 
+  /// When set to 'true', runs a package JS function server-side in the default
+  /// worker queue — an alias of [Queue] = 'true'.
+  static Server = 'server';
+
   /// Function that should be cached
   static Cache = 'cache';
 

--- a/js-api/src/decorators/functions.ts
+++ b/js-api/src/decorators/functions.ts
@@ -166,6 +166,8 @@ export namespace decorators {
     /** Runs the function server-side as a celery task in a docker-based Node worker.
      * `true` — an auto-created worker container; a string — the package's `dockerfiles/<name>` container. */
     queue?: boolean | string;
+    /** Runs the function server-side in the default worker queue — an alias of `queue: true`. */
+    server?: boolean;
   }
 
   interface FunctionOptions {

--- a/packages/CVMTests/CHANGELOG.md
+++ b/packages/CVMTests/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v.next
 
-* Tests: Added `Celery: node worker` suite — JS queue functions (`meta.queue`) executed server-side in the celery Node worker: scalar/string/dataframe round-trips, error propagation, progress, cancellation, dapi token pass-through, and a custom `dockerfiles/node-worker` container
+* Tests: Added `Celery: node worker` suite — JS queue functions (`meta.queue` / `meta.server`) executed server-side in the celery Node worker: scalar/string/dataframe round-trips, error propagation, progress, cancellation, dapi token pass-through, and a custom `dockerfiles/node-worker` container
 
 * Tests: env scripts now declare `#meta.timeout: 600` (the 300s server exec default fired at ~318s under merged-stage load) and env-test client budgets sit above it at 660s — real hangs still surface, a busy stand doesn't flake
 * GROK-20445: Env tests: dropped the obsolete `numpy < 2` assertion (base env now resolves numpy-2-native pyarrow); made the two DG-idiom nodejs scripts (Column list, Lines count) runtime-agnostic until the Node js-api runtime lands on master

--- a/packages/CVMTests/src/celery/node_celery_tests.ts
+++ b/packages/CVMTests/src/celery/node_celery_tests.ts
@@ -65,6 +65,10 @@ category('Celery: node worker', () => {
     expect(call.status, 'Canceled');
   }, {timeout: 120000});
 
+  test('meta.server alias', async () => {
+    expect(await grok.functions.call('CVMTests:jsCvmServer', {x: 'srv'}), 'srv');
+  }, {timeout: 90000});
+
   test('Custom container', async () => {
     expect(await grok.functions.call('CVMTests:jsCvmCustomContainer', {}), 'custom');
   }, {timeout: 240000 /* separate container cold start */});

--- a/packages/CVMTests/src/package.ts
+++ b/packages/CVMTests/src/package.ts
@@ -109,6 +109,14 @@ export async function jsCvmCurrentUser(): Promise<string> {
   return (await grok.dapi.users.current()).login;
 }
 
+//name: jsCvmServer
+//meta.server: true
+//input: string x
+//output: string result
+export function jsCvmServer(x: string): string {
+  return x;
+}
+
 //name: jsCvmCustomContainer
 //meta.queue: node-worker
 //output: string result

--- a/tools/bin/utils/queue-worker-gen.ts
+++ b/tools/bin/utils/queue-worker-gen.ts
@@ -2,9 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import * as color from './color-utils';
 
-// Matches `//meta.queue: true` in package.ts — functions executed as celery tasks
-// in the Node worker (see help/develop/how-to/packages/js-server-functions.md).
-const queueTrueRegex = /^\s*\/\/\s*meta\.queue\s*:\s*true\s*$/m;
+// Matches `//meta.queue: true` (or its alias `//meta.server: true`) in package.ts —
+// functions executed as celery tasks in the Node worker
+// (see help/develop/how-to/packages/js-server-functions.md).
+const queueTrueRegex = /^\s*\/\/\s*meta\.(queue|server)\s*:\s*true\s*$/m;
 
 const QUEUE_DIR = 'queue';
 


### PR DESCRIPTION
## Summary

- `//meta.server: true` (decorator `meta: {server: true}`) — ergonomic alias of `meta.queue: true`: the function runs server-side in the default celery Node worker queue
- `grok publish` queue-artifact generation recognizes the alias; typed decorator option; `FuncOptions.Server` in the generated API
- CVMTests: `jsCvmServer` function + `meta.server alias` test

Server counterpart: reddata branch `claude/GROK-20452-server`. Ticket: GROK-20452.

Generated with [Claude Code](https://claude.com/claude-code)