### PR TITLE
GROK-20452: Celery Node worker: native d42 dataframe transfer

### DIFF
--- a/datagrok-celery-worker/README.md
+++ b/datagrok-celery-worker/README.md
@@ -27,7 +27,9 @@ result back.
    Inputs: send `PARAM <name>`, receive `SENDING DATAFRAME <size> <tagsJson>` + binary
    chunks (each acked with `PART OK`), terminated by `PARAM_SENT <name>`. Outputs: the
    same `SENDING`/chunks/`PART OK` exchange in the other direction. Dataframes travel as
-   UTF-8 CSV (`DG.DataFrame.fromCsv` / `df.toCsv()`).
+   native d42 binary (`DG.DataFrame.fromByteArray` / `df.toByteArray()`, pipe tag
+   `.type: 'dataframe'`); CSV input (`.type: 'csv'`) is still accepted for compatibility
+   with older datlas versions that send CSV to js-lang funcs.
 4. **Result** — a `CALL <funcCallJson>` text frame over the pipe when one is open,
    otherwise a `call` message on `calls_fanout`. Progress reports go out as
    `PROGRESS {json}` frames / `progress` fanout messages; package code can call
@@ -85,8 +87,9 @@ npm start
 
 ## Limitations
 
-- **CSV-only dataframe transfer** — no parquet; the server sends CSV for js-lang funcs
-  (a call with `options.isParquet = true` fails fast).
+- **No parquet dataframe transfer** — dataframes travel as native d42 binary in both
+  directions (preserving column types and tags); CSV input is still accepted from an
+  older datlas. A call with `options.isParquet = true` fails fast.
 - **Single in-flight task** — tasks are acked immediately and drained from an in-memory
   FIFO one at a time.
 - **Cooperative cancellation** — a revoke publishes the `Canceled` result right away,

--- a/datagrok-celery-worker/src/func-call.ts
+++ b/datagrok-celery-worker/src/func-call.ts
@@ -36,6 +36,9 @@ export class FuncCallParam {
   isInput: boolean;
   value: any;
   originalValue: any;
+  /** grok_pipe '.type' tag received with a streamed input ('dataframe' = d42 binary,
+   *  'csv', 'blob', ...), null for non-streamed params. */
+  receivedType: string | null = null;
 
   constructor(name: string, propertyType: string, isInput: boolean, value: any) {
     this.name = name;

--- a/datagrok-celery-worker/src/index.ts
+++ b/datagrok-celery-worker/src/index.ts
@@ -4,7 +4,7 @@ export {FanoutPublisher, CALLS_FANOUT} from './fanout-publisher';
 export type {FanoutType} from './fanout-publisher';
 export {CeleryConsumer} from './celery-consumer';
 export {PipeClient, Const} from './pipe-client';
-export type {PipeClientOptions} from './pipe-client';
+export type {PipeClientOptions, ReceivedParam} from './pipe-client';
 export {marshalInput, marshalOutput, validateCall} from './marshal';
 export type {MarshaledOutput} from './marshal';
 export {PackageHost} from './package-host';

--- a/datagrok-celery-worker/src/marshal.ts
+++ b/datagrok-celery-worker/src/marshal.ts
@@ -9,7 +9,7 @@ export function validateCall(call: FuncCall): void {
   // The server sets options.isParquet = false for js-lang funcs (docker_func.dart
   // executeCall); a parquet payload means a misconfigured deployment.
   if (call.useParquetTransfer)
-    throw new Error('Parquet transfer is not supported by the JS worker: the server must send dataframes as CSV (call.options.isParquet must be false)');
+    throw new Error('Parquet transfer is not supported by the JS worker: the server must send dataframes as d42 or CSV (call.options.isParquet must be false)');
   if (call.outputParams.length > 1)
     throw new Error('Only one return parameter is allowed, but more are present in the Datagrok function declaration.');
 }
@@ -75,10 +75,17 @@ export function marshalInput(param: FuncCallParam, dg?: any): any {
     }
     case Type.DATA_FRAME: {
       if (!(value instanceof Uint8Array))
-        throw inputError(param, 'bytes (streamed CSV)');
-      if (dg?.DataFrame?.fromCsv == null)
+        throw inputError(param, 'bytes (streamed dataframe)');
+      if (dg?.DataFrame == null)
         throw new Error('DG runtime is not initialized: cannot parse a dataframe input');
-      param.value = dg.DataFrame.fromCsv(Buffer.from(value.buffer, value.byteOffset, value.byteLength).toString('utf8'));
+      // the pipe '.type' tag picks the decoder: 'dataframe' is native d42 (what
+      // server_action.dart sends to js-lang funcs), 'csv' comes from older datlas versions
+      if (param.receivedType === Type.DATA_FRAME)
+        param.value = dg.DataFrame.fromByteArray(value);
+      else if (param.receivedType === 'csv')
+        param.value = dg.DataFrame.fromCsv(Buffer.from(value.buffer, value.byteOffset, value.byteLength).toString('utf8'));
+      else
+        throw new Error(`Unsupported dataframe transfer type '${param.receivedType}' for ${param.name}: expected 'dataframe' (d42 binary) or 'csv'`);
       break;
     }
     case Type.FILE:
@@ -106,8 +113,8 @@ function returnError(param: FuncCallParam, expected: string, value: any): Error 
 
 /** Sets param.value to the serialized value that goes into the result CALL json
  *  (mirrors ReturnValueProcessor + _send_param_grok_pipe: dataframe -> {id: uuid} with
- *  tags {'.id': id, '.type': 'csv'}, blob -> param name with {'.id': name, '.type': 'blob'})
- *  and returns the bytes to stream for streamable outputs. */
+ *  tags {'.id': id, '.type': 'dataframe'} and d42 bytes, blob -> param name with
+ *  {'.id': name, '.type': 'blob'}) and returns the bytes to stream for streamable outputs. */
 export function marshalOutput(param: FuncCallParam, value: any, dg?: any): MarshaledOutput {
   if (value == null) {
     param.value = null;
@@ -115,12 +122,13 @@ export function marshalOutput(param: FuncCallParam, value: any, dg?: any): Marsh
   }
   switch (param.propertyType) {
     case Type.DATA_FRAME: {
-      if (typeof value?.toCsv !== 'function')
+      if (typeof value?.toByteArray !== 'function')
         throw returnError(param, 'DG.DataFrame', value);
-      const bytes = new Uint8Array(Buffer.from(value.toCsv(), 'utf8'));
       const id = randomUUID();
       param.value = {'id': id};
-      return {bytes: bytes, tags: {'.id': id, '.type': 'csv'}};
+      // native d42 — the Dart receiver (sockets.dart GrokSocketDecoder) decodes any
+      // non-csv dataframe with DataFrame.fromByteArray
+      return {bytes: value.toByteArray(), tags: {'.id': id, '.type': Type.DATA_FRAME}};
     }
     // python's ReturnValueProcessor supports blob only; the Dart server handles FILE
     // identically to BLOB (server_action.dart getParamsFromRemoteCall), so file outputs

--- a/datagrok-celery-worker/src/pipe-client.ts
+++ b/datagrok-celery-worker/src/pipe-client.ts
@@ -33,6 +33,12 @@ interface Waiter {
   timer: NodeJS.Timeout;
 }
 
+export interface ReceivedParam {
+  bytes: Uint8Array;
+  /** Tags from the 'SENDING DATAFRAME <size> <tagsJson>' header ('.id', '.type', ...). */
+  tags: {[key: string]: string};
+}
+
 export interface PipeClientOptions {
   /** Per-message wait timeout, ms (DATAGROK_WS_MESSAGE_TIMEOUT). */
   messageTimeoutMs: number;
@@ -160,14 +166,17 @@ export class PipeClient {
 
   /** Requests an input param ('PARAM <name>') and collects the peer's
    *  'SENDING DATAFRAME <size> <tags>' + binary chunks (each acked with 'PART OK'),
-   *  terminated by 'PARAM_SENT <name>'. Returns null when no data was sent. */
-  async receiveParam(name: string): Promise<Uint8Array | null> {
+   *  terminated by 'PARAM_SENT <name>'. Returns the assembled bytes together with the
+   *  SENDING header tags (the '.type' tag picks the decoder — 'dataframe'/'csv'/'blob'),
+   *  or null when no data was sent. */
+  async receiveParam(name: string): Promise<ReceivedParam | null> {
     logInfo(`Receiving param ${name}`);
     const start = Date.now();
     this.sendText(`${Const.PARAM} ${name}`);
     const chunks: Uint8Array[] = [];
     let expectedSize: number | null = null;
     let received = 0;
+    let tags: {[key: string]: string} = {};
     for (;;) {
       if (Date.now() - start > this.options.paramTimeoutMs)
         throw new Error(`Timeout receiving param ${name}`);
@@ -175,8 +184,10 @@ export class PipeClient {
       if (typeof message === 'string') {
         if (message.startsWith(`${Const.PARAM_SENT} ${name}`))
           break;
-        else if (message.startsWith('SENDING'))
+        else if (message.startsWith('SENDING')) {
           expectedSize = PipeClient.parseExpectedSize(message);
+          tags = PipeClient.parseTags(message);
+        }
         else if (message === Const.PART_ERROR || message === Const.ERROR)
           throw new Error(`Peer reported an error while sending param ${name}`);
         // unrelated frames (LOG/PROGRESS/relay echoes) are tolerated and skipped
@@ -194,7 +205,7 @@ export class PipeClient {
     if (chunks.length === 0)
       return null;
     logInfo(`Received param ${name} (${received} bytes in ${chunks.length} chunks)`);
-    return chunks.length === 1 ? chunks[0] : PipeClient.concat(chunks, received);
+    return {bytes: chunks.length === 1 ? chunks[0] : PipeClient.concat(chunks, received), tags: tags};
   }
 
   /** Sends an output param: 'SENDING DATAFRAME <size> <tagsJson>' followed by binary
@@ -246,6 +257,19 @@ export class PipeClient {
     if (!Number.isFinite(size))
       throw new Error(`Could not parse size from SENDING message: ${message.substring(0, 50)}`);
     return size;
+  }
+
+  /** The tags json is everything after the size token: 'SENDING DATAFRAME <size> <tagsJson>'.
+   *  A missing/broken json yields empty tags (Dart SocketReceiver falls back the same way). */
+  private static parseTags(message: string): {[key: string]: string} {
+    const start = message.indexOf(' ', Const.SENDING.length + 1);
+    try {
+      const tags = start >= 0 ? JSON.parse(message.substring(start + 1)) : null;
+      return tags != null && typeof tags === 'object' ? tags : {};
+    }
+    catch (_) {
+      return {};
+    }
   }
 
   private static concat(chunks: Uint8Array[], totalLength: number): Uint8Array {

--- a/datagrok-celery-worker/src/task-runner.ts
+++ b/datagrok-celery-worker/src/task-runner.ts
@@ -48,8 +48,11 @@ export class TaskRunner {
         context.pipe = pipe;
       }
       for (const param of call.inputParams)
-        if (param.isStreamable)
-          param.value = await pipe!.receiveParam(param.name);
+        if (param.isStreamable) {
+          const received = await pipe!.receiveParam(param.name);
+          param.value = received?.bytes ?? null;
+          param.receivedType = received?.tags['.type'] ?? null;
+        }
       const dg = this.host.dg;
       for (const param of call.inputParams)
         marshalInput(param, dg);

--- a/datagrok-celery-worker/src/tests/marshal.test.ts
+++ b/datagrok-celery-worker/src/tests/marshal.test.ts
@@ -62,13 +62,33 @@ describe('marshalInput', () => {
     expect(() => marshalInput(param(Type.DATE_TIME, 'not-a-date'))).toThrow(/ISO datetime/);
   });
 
-  test('dataframe: UTF-8 CSV bytes through DG.DataFrame.fromCsv', () => {
+  test('dataframe: d42 bytes through DG.DataFrame.fromByteArray', () => {
+    const fromByteArray = jest.fn().mockReturnValue({'fake': 'df'});
+    const dg = {DataFrame: {fromByteArray: fromByteArray}};
+    const bytes = new Uint8Array([0xd4, 0x20, 0xa0, 1]);
+    const p = param(Type.DATA_FRAME, bytes);
+    p.receivedType = 'dataframe';
+    expect(marshalInput(p, dg)).toEqual({'fake': 'df'});
+    expect(fromByteArray).toHaveBeenCalledWith(bytes);
+    expect(() => marshalInput(param(Type.DATA_FRAME, 'not-bytes'), dg)).toThrow(/Incorrect input type/);
+  });
+
+  test('dataframe: UTF-8 CSV bytes through DG.DataFrame.fromCsv (older datlas)', () => {
     const fromCsv = jest.fn().mockReturnValue({'fake': 'df'});
     const dg = {DataFrame: {fromCsv: fromCsv}};
     const p = param(Type.DATA_FRAME, new Uint8Array(Buffer.from('a,b\n1,2\n', 'utf8')));
+    p.receivedType = 'csv';
     expect(marshalInput(p, dg)).toEqual({'fake': 'df'});
     expect(fromCsv).toHaveBeenCalledWith('a,b\n1,2\n');
-    expect(() => marshalInput(param(Type.DATA_FRAME, 'not-bytes'), dg)).toThrow(/Incorrect input type/);
+  });
+
+  test('dataframe: unknown transfer type fails with a clear error', () => {
+    const dg = {DataFrame: {fromCsv: jest.fn(), fromByteArray: jest.fn()}};
+    const parquet = param(Type.DATA_FRAME, new Uint8Array([1]));
+    parquet.receivedType = 'parquet';
+    expect(() => marshalInput(parquet, dg)).toThrow(/Unsupported dataframe transfer type 'parquet'/);
+    const untyped = param(Type.DATA_FRAME, new Uint8Array([1]));
+    expect(() => marshalInput(untyped, dg)).toThrow(/Unsupported dataframe transfer type/);
   });
 
   test('blob passes bytes through', () => {
@@ -83,13 +103,14 @@ describe('marshalInput', () => {
 });
 
 describe('marshalOutput', () => {
-  test('dataframe: csv bytes + value {id} + tags', () => {
+  test('dataframe: d42 bytes + value {id} + tags', () => {
     const p = param(Type.DATA_FRAME, null, false);
-    const df = {toCsv: () => 'a,b\n1,2\n'};
+    const bytes = new Uint8Array([0xd4, 0x20, 0xa0, 1]);
+    const df = {toByteArray: () => bytes};
     const out = marshalOutput(p, df);
-    expect(Buffer.from(out.bytes!).toString('utf8')).toBe('a,b\n1,2\n');
+    expect(out.bytes).toBe(bytes);
     expect(p.value).toEqual({'id': out.tags!['.id']});
-    expect(out.tags!['.type']).toBe('csv');
+    expect(out.tags!['.type']).toBe('dataframe');
     expect(() => marshalOutput(param(Type.DATA_FRAME, null, false), 'not-a-df')).toThrow(/Incorrect return type/);
   });
 

--- a/datagrok-celery-worker/src/tests/pipe-client.test.ts
+++ b/datagrok-celery-worker/src/tests/pipe-client.test.ts
@@ -97,7 +97,7 @@ describe('PipeClient', () => {
 
     expect((await peer.nextFrame()).data).toBe('PARAM df');
     peer.send('LOG {"message":"unrelated"}'); // must be tolerated and skipped
-    peer.send(`${Const.SENDING} 5 {".id":"x",".type":"csv"}`);
+    peer.send(`${Const.SENDING} 5 {".id":"x",".type":"dataframe"}`);
     peer.send(chunk1);
     expect((await peer.nextFrame()).data).toBe(Const.PART_OK);
     peer.send(chunk2);
@@ -105,7 +105,28 @@ describe('PipeClient', () => {
     peer.send('PARAM_SENT df');
 
     const result = await resultPromise;
-    expect(Array.from(result!)).toEqual([1, 2, 3, 4, 5]);
+    expect(Array.from(result!.bytes)).toEqual([1, 2, 3, 4, 5]);
+    expect(result!.tags).toEqual({'.id': 'x', '.type': 'dataframe'});
+  });
+
+  test('receiveParam surfaces the csv type tag and tolerates a broken tags json', async () => {
+    const resultPromise = client.receiveParam('df');
+    expect((await peer.nextFrame()).data).toBe('PARAM df');
+    peer.send(`${Const.SENDING} 2 {".id":"x",".type":"csv"}`);
+    peer.send(new Uint8Array([1, 2]));
+    expect((await peer.nextFrame()).data).toBe(Const.PART_OK);
+    peer.send('PARAM_SENT df');
+    expect((await resultPromise)!.tags['.type']).toBe('csv');
+
+    const brokenPromise = client.receiveParam('df2');
+    expect((await peer.nextFrame()).data).toBe('PARAM df2');
+    peer.send(`${Const.SENDING} 1 {not-json`);
+    peer.send(new Uint8Array([7]));
+    expect((await peer.nextFrame()).data).toBe(Const.PART_OK);
+    peer.send('PARAM_SENT df2');
+    const broken = await brokenPromise;
+    expect(Array.from(broken!.bytes)).toEqual([7]);
+    expect(broken!.tags).toEqual({});
   });
 
   test('receiveParam returns null when the peer sends no data', async () => {
@@ -131,10 +152,10 @@ describe('PipeClient', () => {
 
   test('sendParam: chunks by batchSize and waits for PART OK after each chunk', async () => {
     const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]); // batchSize 4 -> 4+4+2
-    const sendPromise = client.sendParam(data, {'.id': 'out', '.type': 'csv'});
+    const sendPromise = client.sendParam(data, {'.id': 'out', '.type': 'dataframe'});
 
     const header = await peer.nextFrame();
-    expect(header.data).toBe(`${Const.SENDING} 10 {".id":"out",".type":"csv"}`);
+    expect(header.data).toBe(`${Const.SENDING} 10 {".id":"out",".type":"dataframe"}`);
 
     const received: number[] = [];
     for (let i = 0; i < 3; i++) {

--- a/packages/CVMTests/CHANGELOG.md
+++ b/packages/CVMTests/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v.next
 
 * Tests: Added `Celery: node worker` suite — JS queue functions (`meta.queue` / `meta.server`) executed server-side in the celery Node worker: scalar/string/dataframe round-trips, error propagation, progress, cancellation, dapi token pass-through, and a custom `dockerfiles/node-worker` container
+* Tests: Celery node worker — added `DataFrame binary fidelity` (`jsCvmDataframeTypes`): the d42 binary transfer preserves int/float/string/bool/datetime column types and column tags round-trip
 
 * Tests: env scripts now declare `#meta.timeout: 600` (the 300s server exec default fired at ~318s under merged-stage load) and env-test client budgets sit above it at 660s — real hangs still surface, a busy stand doesn't flake
 * GROK-20445: Env tests: dropped the obsolete `numpy < 2` assertion (base env now resolves numpy-2-native pyarrow); made the two DG-idiom nodejs scripts (Column list, Lines count) runtime-agnostic until the Node js-api runtime lands on master

--- a/packages/CVMTests/src/celery/node_celery_tests.ts
+++ b/packages/CVMTests/src/celery/node_celery_tests.ts
@@ -1,5 +1,6 @@
 import * as grok from 'datagrok-api/grok';
 import * as DG from 'datagrok-api/dg';
+import dayjs from 'dayjs';
 
 import {category, test, expect, expectTable, expectExceptionAsync} from '@datagrok-libraries/test/src/test';
 
@@ -32,6 +33,23 @@ category('Celery: node worker', () => {
       DG.Column.fromList(DG.COLUMN_TYPE.BOOL, 'b', [true, false, true]),
     ]);
     expectTable(await grok.functions.call('CVMTests:jsCvmDataframe', {df}), df);
+  }, {timeout: 90000});
+
+  test('DataFrame binary fidelity', async () => {
+    const df = DG.DataFrame.fromColumns([
+      DG.Column.fromList(DG.COLUMN_TYPE.INT, 'i', [1, 2, 3]),
+      DG.Column.fromList(DG.COLUMN_TYPE.FLOAT, 'd', [1.5, 2.5, 3.5]),
+      DG.Column.fromList(DG.COLUMN_TYPE.STRING, 's', ['a', 'b', 'c']),
+      DG.Column.fromList(DG.COLUMN_TYPE.BOOL, 'b', [true, false, true]),
+      DG.Column.fromList(DG.COLUMN_TYPE.DATE_TIME, 'dt',
+        [dayjs('2020-01-01T00:00:00Z'), dayjs('2021-06-15T12:30:45Z'), dayjs('2022-12-31T23:59:59Z')]),
+    ]);
+    df.col('i')!.setTag('foo', 'bar'); // d42 keeps column tags, CSV did not
+    const result: DG.DataFrame = await grok.functions.call('CVMTests:jsCvmDataframeTypes', {df});
+    for (const col of df.columns)
+      expect(result.col(col.name)!.type, col.type);
+    expectTable(result, df);
+    expect(result.col('i')!.getTag('foo'), 'bar');
   }, {timeout: 90000});
 
   test('Empty dataframe', async () => {

--- a/packages/CVMTests/src/package.ts
+++ b/packages/CVMTests/src/package.ts
@@ -71,6 +71,14 @@ export function jsCvmDataframe(df: DG.DataFrame): DG.DataFrame {
   return df;
 }
 
+//name: jsCvmDataframeTypes
+//meta.queue: true
+//input: dataframe df
+//output: dataframe result
+export function jsCvmDataframeTypes(df: DG.DataFrame): DG.DataFrame {
+  return df;
+}
+
 //name: jsCvmEmptyDataframe
 //meta.queue: true
 //output: dataframe result


### PR DESCRIPTION
## Summary

- Worker decodes input dataframes tagged `.type: 'dataframe'` via `DG.DataFrame.fromByteArray` (d42); CSV input kept for older datlas; unknown type → clear error
- Output dataframes now stream as d42 (`toByteArray`) — column types and tags survive the round trip (CSV lost them)
- Regenerated js-api Node Dart bundle (sender change lives in grok_shared)
- CVMTests: `jsCvmDataframeTypes` + 'DataFrame binary fidelity' test (types incl. datetime, column tags)
- Worker jest: 44 tests green

Server counterpart: reddata `claude/GROK-20452-binary` (CSV fallback in sendParam scoped to python workers). Ticket: GROK-20452.

Generated with [Claude Code](https://claude.com/claude-code)