### PR TITLE
GROK-20452: CVMTests: benchmark cold start via explicit run(await)

### DIFF
--- a/datagrok-celery-worker/README.md
+++ b/datagrok-celery-worker/README.md
@@ -27,7 +27,9 @@ result back.
    Inputs: send `PARAM <name>`, receive `SENDING DATAFRAME <size> <tagsJson>` + binary
    chunks (each acked with `PART OK`), terminated by `PARAM_SENT <name>`. Outputs: the
    same `SENDING`/chunks/`PART OK` exchange in the other direction. Dataframes travel as
-   UTF-8 CSV (`DG.DataFrame.fromCsv` / `df.toCsv()`).
+   native d42 binary (`DG.DataFrame.fromByteArray` / `df.toByteArray()`, pipe tag
+   `.type: 'dataframe'`); CSV input (`.type: 'csv'`) is still accepted for compatibility
+   with older datlas versions that send CSV to js-lang funcs.
 4. **Result** — a `CALL <funcCallJson>` text frame over the pipe when one is open,
    otherwise a `call` message on `calls_fanout`. Progress reports go out as
    `PROGRESS {json}` frames / `progress` fanout messages; package code can call
@@ -85,8 +87,9 @@ npm start
 
 ## Limitations
 
-- **CSV-only dataframe transfer** — no parquet; the server sends CSV for js-lang funcs
-  (a call with `options.isParquet = true` fails fast).
+- **No parquet dataframe transfer** — dataframes travel as native d42 binary in both
+  directions (preserving column types and tags); CSV input is still accepted from an
+  older datlas. A call with `options.isParquet = true` fails fast.
 - **Single in-flight task** — tasks are acked immediately and drained from an in-memory
   FIFO one at a time.
 - **Cooperative cancellation** — a revoke publishes the `Canceled` result right away,

--- a/datagrok-celery-worker/src/func-call.ts
+++ b/datagrok-celery-worker/src/func-call.ts
@@ -36,6 +36,9 @@ export class FuncCallParam {
   isInput: boolean;
   value: any;
   originalValue: any;
+  /** grok_pipe '.type' tag received with a streamed input ('dataframe' = d42 binary,
+   *  'csv', 'blob', ...), null for non-streamed params. */
+  receivedType: string | null = null;
 
   constructor(name: string, propertyType: string, isInput: boolean, value: any) {
     this.name = name;

--- a/datagrok-celery-worker/src/index.ts
+++ b/datagrok-celery-worker/src/index.ts
@@ -4,7 +4,7 @@ export {FanoutPublisher, CALLS_FANOUT} from './fanout-publisher';
 export type {FanoutType} from './fanout-publisher';
 export {CeleryConsumer} from './celery-consumer';
 export {PipeClient, Const} from './pipe-client';
-export type {PipeClientOptions} from './pipe-client';
+export type {PipeClientOptions, ReceivedParam} from './pipe-client';
 export {marshalInput, marshalOutput, validateCall} from './marshal';
 export type {MarshaledOutput} from './marshal';
 export {PackageHost} from './package-host';

--- a/datagrok-celery-worker/src/marshal.ts
+++ b/datagrok-celery-worker/src/marshal.ts
@@ -9,7 +9,7 @@ export function validateCall(call: FuncCall): void {
   // The server sets options.isParquet = false for js-lang funcs (docker_func.dart
   // executeCall); a parquet payload means a misconfigured deployment.
   if (call.useParquetTransfer)
-    throw new Error('Parquet transfer is not supported by the JS worker: the server must send dataframes as CSV (call.options.isParquet must be false)');
+    throw new Error('Parquet transfer is not supported by the JS worker: the server must send dataframes as d42 or CSV (call.options.isParquet must be false)');
   if (call.outputParams.length > 1)
     throw new Error('Only one return parameter is allowed, but more are present in the Datagrok function declaration.');
 }
@@ -75,10 +75,17 @@ export function marshalInput(param: FuncCallParam, dg?: any): any {
     }
     case Type.DATA_FRAME: {
       if (!(value instanceof Uint8Array))
-        throw inputError(param, 'bytes (streamed CSV)');
-      if (dg?.DataFrame?.fromCsv == null)
+        throw inputError(param, 'bytes (streamed dataframe)');
+      if (dg?.DataFrame == null)
         throw new Error('DG runtime is not initialized: cannot parse a dataframe input');
-      param.value = dg.DataFrame.fromCsv(Buffer.from(value.buffer, value.byteOffset, value.byteLength).toString('utf8'));
+      // the pipe '.type' tag picks the decoder: 'dataframe' is native d42 (what
+      // server_action.dart sends to js-lang funcs), 'csv' comes from older datlas versions
+      if (param.receivedType === Type.DATA_FRAME)
+        param.value = dg.DataFrame.fromByteArray(value);
+      else if (param.receivedType === 'csv')
+        param.value = dg.DataFrame.fromCsv(Buffer.from(value.buffer, value.byteOffset, value.byteLength).toString('utf8'));
+      else
+        throw new Error(`Unsupported dataframe transfer type '${param.receivedType}' for ${param.name}: expected 'dataframe' (d42 binary) or 'csv'`);
       break;
     }
     case Type.FILE:
@@ -106,8 +113,8 @@ function returnError(param: FuncCallParam, expected: string, value: any): Error 
 
 /** Sets param.value to the serialized value that goes into the result CALL json
  *  (mirrors ReturnValueProcessor + _send_param_grok_pipe: dataframe -> {id: uuid} with
- *  tags {'.id': id, '.type': 'csv'}, blob -> param name with {'.id': name, '.type': 'blob'})
- *  and returns the bytes to stream for streamable outputs. */
+ *  tags {'.id': id, '.type': 'dataframe'} and d42 bytes, blob -> param name with
+ *  {'.id': name, '.type': 'blob'}) and returns the bytes to stream for streamable outputs. */
 export function marshalOutput(param: FuncCallParam, value: any, dg?: any): MarshaledOutput {
   if (value == null) {
     param.value = null;
@@ -115,12 +122,13 @@ export function marshalOutput(param: FuncCallParam, value: any, dg?: any): Marsh
   }
   switch (param.propertyType) {
     case Type.DATA_FRAME: {
-      if (typeof value?.toCsv !== 'function')
+      if (typeof value?.toByteArray !== 'function')
         throw returnError(param, 'DG.DataFrame', value);
-      const bytes = new Uint8Array(Buffer.from(value.toCsv(), 'utf8'));
       const id = randomUUID();
       param.value = {'id': id};
-      return {bytes: bytes, tags: {'.id': id, '.type': 'csv'}};
+      // native d42 — the Dart receiver (sockets.dart GrokSocketDecoder) decodes any
+      // non-csv dataframe with DataFrame.fromByteArray
+      return {bytes: value.toByteArray(), tags: {'.id': id, '.type': Type.DATA_FRAME}};
     }
     // python's ReturnValueProcessor supports blob only; the Dart server handles FILE
     // identically to BLOB (server_action.dart getParamsFromRemoteCall), so file outputs

--- a/datagrok-celery-worker/src/pipe-client.ts
+++ b/datagrok-celery-worker/src/pipe-client.ts
@@ -33,6 +33,12 @@ interface Waiter {
   timer: NodeJS.Timeout;
 }
 
+export interface ReceivedParam {
+  bytes: Uint8Array;
+  /** Tags from the 'SENDING DATAFRAME <size> <tagsJson>' header ('.id', '.type', ...). */
+  tags: {[key: string]: string};
+}
+
 export interface PipeClientOptions {
   /** Per-message wait timeout, ms (DATAGROK_WS_MESSAGE_TIMEOUT). */
   messageTimeoutMs: number;
@@ -160,14 +166,17 @@ export class PipeClient {
 
   /** Requests an input param ('PARAM <name>') and collects the peer's
    *  'SENDING DATAFRAME <size> <tags>' + binary chunks (each acked with 'PART OK'),
-   *  terminated by 'PARAM_SENT <name>'. Returns null when no data was sent. */
-  async receiveParam(name: string): Promise<Uint8Array | null> {
+   *  terminated by 'PARAM_SENT <name>'. Returns the assembled bytes together with the
+   *  SENDING header tags (the '.type' tag picks the decoder — 'dataframe'/'csv'/'blob'),
+   *  or null when no data was sent. */
+  async receiveParam(name: string): Promise<ReceivedParam | null> {
     logInfo(`Receiving param ${name}`);
     const start = Date.now();
     this.sendText(`${Const.PARAM} ${name}`);
     const chunks: Uint8Array[] = [];
     let expectedSize: number | null = null;
     let received = 0;
+    let tags: {[key: string]: string} = {};
     for (;;) {
       if (Date.now() - start > this.options.paramTimeoutMs)
         throw new Error(`Timeout receiving param ${name}`);
@@ -175,8 +184,10 @@ export class PipeClient {
       if (typeof message === 'string') {
         if (message.startsWith(`${Const.PARAM_SENT} ${name}`))
           break;
-        else if (message.startsWith('SENDING'))
+        else if (message.startsWith('SENDING')) {
           expectedSize = PipeClient.parseExpectedSize(message);
+          tags = PipeClient.parseTags(message);
+        }
         else if (message === Const.PART_ERROR || message === Const.ERROR)
           throw new Error(`Peer reported an error while sending param ${name}`);
         // unrelated frames (LOG/PROGRESS/relay echoes) are tolerated and skipped
@@ -194,7 +205,7 @@ export class PipeClient {
     if (chunks.length === 0)
       return null;
     logInfo(`Received param ${name} (${received} bytes in ${chunks.length} chunks)`);
-    return chunks.length === 1 ? chunks[0] : PipeClient.concat(chunks, received);
+    return {bytes: chunks.length === 1 ? chunks[0] : PipeClient.concat(chunks, received), tags: tags};
   }
 
   /** Sends an output param: 'SENDING DATAFRAME <size> <tagsJson>' followed by binary
@@ -246,6 +257,19 @@ export class PipeClient {
     if (!Number.isFinite(size))
       throw new Error(`Could not parse size from SENDING message: ${message.substring(0, 50)}`);
     return size;
+  }
+
+  /** The tags json is everything after the size token: 'SENDING DATAFRAME <size> <tagsJson>'.
+   *  A missing/broken json yields empty tags (Dart SocketReceiver falls back the same way). */
+  private static parseTags(message: string): {[key: string]: string} {
+    const start = message.indexOf(' ', Const.SENDING.length + 1);
+    try {
+      const tags = start >= 0 ? JSON.parse(message.substring(start + 1)) : null;
+      return tags != null && typeof tags === 'object' ? tags : {};
+    }
+    catch (_) {
+      return {};
+    }
   }
 
   private static concat(chunks: Uint8Array[], totalLength: number): Uint8Array {

--- a/datagrok-celery-worker/src/task-runner.ts
+++ b/datagrok-celery-worker/src/task-runner.ts
@@ -48,8 +48,11 @@ export class TaskRunner {
         context.pipe = pipe;
       }
       for (const param of call.inputParams)
-        if (param.isStreamable)
-          param.value = await pipe!.receiveParam(param.name);
+        if (param.isStreamable) {
+          const received = await pipe!.receiveParam(param.name);
+          param.value = received?.bytes ?? null;
+          param.receivedType = received?.tags['.type'] ?? null;
+        }
       const dg = this.host.dg;
       for (const param of call.inputParams)
         marshalInput(param, dg);

--- a/datagrok-celery-worker/src/tests/marshal.test.ts
+++ b/datagrok-celery-worker/src/tests/marshal.test.ts
@@ -62,13 +62,33 @@ describe('marshalInput', () => {
     expect(() => marshalInput(param(Type.DATE_TIME, 'not-a-date'))).toThrow(/ISO datetime/);
   });
 
-  test('dataframe: UTF-8 CSV bytes through DG.DataFrame.fromCsv', () => {
+  test('dataframe: d42 bytes through DG.DataFrame.fromByteArray', () => {
+    const fromByteArray = jest.fn().mockReturnValue({'fake': 'df'});
+    const dg = {DataFrame: {fromByteArray: fromByteArray}};
+    const bytes = new Uint8Array([0xd4, 0x20, 0xa0, 1]);
+    const p = param(Type.DATA_FRAME, bytes);
+    p.receivedType = 'dataframe';
+    expect(marshalInput(p, dg)).toEqual({'fake': 'df'});
+    expect(fromByteArray).toHaveBeenCalledWith(bytes);
+    expect(() => marshalInput(param(Type.DATA_FRAME, 'not-bytes'), dg)).toThrow(/Incorrect input type/);
+  });
+
+  test('dataframe: UTF-8 CSV bytes through DG.DataFrame.fromCsv (older datlas)', () => {
     const fromCsv = jest.fn().mockReturnValue({'fake': 'df'});
     const dg = {DataFrame: {fromCsv: fromCsv}};
     const p = param(Type.DATA_FRAME, new Uint8Array(Buffer.from('a,b\n1,2\n', 'utf8')));
+    p.receivedType = 'csv';
     expect(marshalInput(p, dg)).toEqual({'fake': 'df'});
     expect(fromCsv).toHaveBeenCalledWith('a,b\n1,2\n');
-    expect(() => marshalInput(param(Type.DATA_FRAME, 'not-bytes'), dg)).toThrow(/Incorrect input type/);
+  });
+
+  test('dataframe: unknown transfer type fails with a clear error', () => {
+    const dg = {DataFrame: {fromCsv: jest.fn(), fromByteArray: jest.fn()}};
+    const parquet = param(Type.DATA_FRAME, new Uint8Array([1]));
+    parquet.receivedType = 'parquet';
+    expect(() => marshalInput(parquet, dg)).toThrow(/Unsupported dataframe transfer type 'parquet'/);
+    const untyped = param(Type.DATA_FRAME, new Uint8Array([1]));
+    expect(() => marshalInput(untyped, dg)).toThrow(/Unsupported dataframe transfer type/);
   });
 
   test('blob passes bytes through', () => {
@@ -83,13 +103,14 @@ describe('marshalInput', () => {
 });
 
 describe('marshalOutput', () => {
-  test('dataframe: csv bytes + value {id} + tags', () => {
+  test('dataframe: d42 bytes + value {id} + tags', () => {
     const p = param(Type.DATA_FRAME, null, false);
-    const df = {toCsv: () => 'a,b\n1,2\n'};
+    const bytes = new Uint8Array([0xd4, 0x20, 0xa0, 1]);
+    const df = {toByteArray: () => bytes};
     const out = marshalOutput(p, df);
-    expect(Buffer.from(out.bytes!).toString('utf8')).toBe('a,b\n1,2\n');
+    expect(out.bytes).toBe(bytes);
     expect(p.value).toEqual({'id': out.tags!['.id']});
-    expect(out.tags!['.type']).toBe('csv');
+    expect(out.tags!['.type']).toBe('dataframe');
     expect(() => marshalOutput(param(Type.DATA_FRAME, null, false), 'not-a-df')).toThrow(/Incorrect return type/);
   });
 

--- a/datagrok-celery-worker/src/tests/pipe-client.test.ts
+++ b/datagrok-celery-worker/src/tests/pipe-client.test.ts
@@ -97,7 +97,7 @@ describe('PipeClient', () => {
 
     expect((await peer.nextFrame()).data).toBe('PARAM df');
     peer.send('LOG {"message":"unrelated"}'); // must be tolerated and skipped
-    peer.send(`${Const.SENDING} 5 {".id":"x",".type":"csv"}`);
+    peer.send(`${Const.SENDING} 5 {".id":"x",".type":"dataframe"}`);
     peer.send(chunk1);
     expect((await peer.nextFrame()).data).toBe(Const.PART_OK);
     peer.send(chunk2);
@@ -105,7 +105,28 @@ describe('PipeClient', () => {
     peer.send('PARAM_SENT df');
 
     const result = await resultPromise;
-    expect(Array.from(result!)).toEqual([1, 2, 3, 4, 5]);
+    expect(Array.from(result!.bytes)).toEqual([1, 2, 3, 4, 5]);
+    expect(result!.tags).toEqual({'.id': 'x', '.type': 'dataframe'});
+  });
+
+  test('receiveParam surfaces the csv type tag and tolerates a broken tags json', async () => {
+    const resultPromise = client.receiveParam('df');
+    expect((await peer.nextFrame()).data).toBe('PARAM df');
+    peer.send(`${Const.SENDING} 2 {".id":"x",".type":"csv"}`);
+    peer.send(new Uint8Array([1, 2]));
+    expect((await peer.nextFrame()).data).toBe(Const.PART_OK);
+    peer.send('PARAM_SENT df');
+    expect((await resultPromise)!.tags['.type']).toBe('csv');
+
+    const brokenPromise = client.receiveParam('df2');
+    expect((await peer.nextFrame()).data).toBe('PARAM df2');
+    peer.send(`${Const.SENDING} 1 {not-json`);
+    peer.send(new Uint8Array([7]));
+    expect((await peer.nextFrame()).data).toBe(Const.PART_OK);
+    peer.send('PARAM_SENT df2');
+    const broken = await brokenPromise;
+    expect(Array.from(broken!.bytes)).toEqual([7]);
+    expect(broken!.tags).toEqual({});
   });
 
   test('receiveParam returns null when the peer sends no data', async () => {
@@ -131,10 +152,10 @@ describe('PipeClient', () => {
 
   test('sendParam: chunks by batchSize and waits for PART OK after each chunk', async () => {
     const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]); // batchSize 4 -> 4+4+2
-    const sendPromise = client.sendParam(data, {'.id': 'out', '.type': 'csv'});
+    const sendPromise = client.sendParam(data, {'.id': 'out', '.type': 'dataframe'});
 
     const header = await peer.nextFrame();
-    expect(header.data).toBe(`${Const.SENDING} 10 {".id":"out",".type":"csv"}`);
+    expect(header.data).toBe(`${Const.SENDING} 10 {".id":"out",".type":"dataframe"}`);
 
     const received: number[] = [];
     for (let i = 0; i < 3; i++) {

--- a/packages/CVMTests/CHANGELOG.md
+++ b/packages/CVMTests/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v.next
 
 * Tests: Added `Celery: node worker` suite — JS queue functions (`meta.queue` / `meta.server`) executed server-side in the celery Node worker: scalar/string/dataframe round-trips, error propagation, progress, cancellation, dapi token pass-through, and a custom `dockerfiles/node-worker` container
+* Tests: Celery node worker — added `DataFrame binary fidelity` (`jsCvmDataframeTypes`): the d42 binary transfer preserves int/float/string/bool/datetime column types and column tags round-trip
 
 * Tests: env scripts now declare `#meta.timeout: 600` (the 300s server exec default fired at ~318s under merged-stage load) and env-test client budgets sit above it at 660s — real hangs still surface, a busy stand doesn't flake
 * GROK-20445: Env tests: dropped the obsolete `numpy < 2` assertion (base env now resolves numpy-2-native pyarrow); made the two DG-idiom nodejs scripts (Column list, Lines count) runtime-agnostic until the Node js-api runtime lands on master

--- a/packages/CVMTests/dockerfiles/celery/Dockerfile
+++ b/packages/CVMTests/dockerfiles/celery/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.11-slim-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libc-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+RUN useradd -m datagrok
+
+WORKDIR /app
+COPY . /app
+ENV PYTHONPATH="/app:${PYTHONPATH}"
+RUN chown -R datagrok:datagrok /app
+
+# Install Python dependencies using uv
+RUN uv pip install --system celery datagrok-celery-task pyyaml && \
+    if [ -f requirements.in ]; then uv pip install --system --no-cache -r requirements.in; \
+    elif [ -f requirements.txt ]; then uv pip install --system --no-cache -r requirements.txt; fi
+
+USER datagrok
+
+EXPOSE 8000
+
+CMD celery -A $DATAGROK_CELERY_NAME worker \
+    --loglevel=info \
+    --hostname=$CELERY_HOSTNAME \
+    --concurrency=$WORKERS_PROCESSES \
+    -Q $TASK_QUEUE_NAME

--- a/packages/CVMTests/dockerfiles/celery/container.json
+++ b/packages/CVMTests/dockerfiles/celery/container.json
@@ -1,0 +1,1 @@
+{"cpu": 1, "memory": 1024, "on_demand": true}

--- a/packages/CVMTests/dockerfiles/celery/cvm_tests_celery.py
+++ b/packages/CVMTests/dockerfiles/celery/cvm_tests_celery.py
@@ -1,0 +1,24 @@
+import os
+import importlib
+import logging
+
+import yaml
+from celery import Celery
+from datagrok_celery_task import DatagrokTask, Settings
+
+import sys
+sys.path.insert(0, os.getcwd())
+
+settings = Settings(log_level=logging.DEBUG)
+app = Celery(settings.celery_name, broker=settings.broker_url)
+
+with open("tasks.yaml") as f:
+    tasks = yaml.safe_load(f)
+
+if not isinstance(tasks, dict) or not isinstance(tasks['tasks'], list):
+    raise RuntimeError('Incorrect format for tasks.yaml. It should contain tasks field.')
+
+for task_def in tasks['tasks']:
+    mod = importlib.import_module(task_def["module"])
+    fn = getattr(mod, task_def["name"])
+    app.task(name=task_def["name"], base=DatagrokTask)(fn)

--- a/packages/CVMTests/dockerfiles/celery/dataframe.py
+++ b/packages/CVMTests/dockerfiles/celery/dataframe.py
@@ -1,0 +1,27 @@
+import pandas as pd
+
+#name: cvmDataframe
+#input: dataframe df
+#output: dataframe result
+def cvmDataframe(df):
+    return df
+
+#name: cvmDataframeNulls
+#output: dataframe result
+def cvmDataframeNulls():
+    return pd.DataFrame({'f': [1.0, float('nan'), 3.0]})
+
+#name: cvmIntInBound
+#output: dataframe result
+def cvmIntInBound():
+    return pd.DataFrame.from_dict({'col1': [1000, 10000, 100000]})
+
+#name: cvmIntOutBound
+#output: dataframe result
+def cvmIntOutBound():
+    return pd.DataFrame.from_dict({'col1': [1000, 10000, 2 ** 31]})
+
+#name: cvmEmptyDataframe
+#output: dataframe result
+def cvmEmptyDataframe():
+    return pd.DataFrame({'col1': pd.Series([], dtype='float64')})

--- a/packages/CVMTests/dockerfiles/celery/misc.py
+++ b/packages/CVMTests/dockerfiles/celery/misc.py
@@ -1,0 +1,19 @@
+import time
+
+#name: cvmApiKey
+#output: string result
+def cvmApiKey(**kwargs):
+    return str(kwargs.get('USER_API_KEY', ''))
+
+#name: cvmCancel
+#input: int seconds
+#output: string result
+def cvmCancel(seconds):
+    time.sleep(seconds)
+    return 'done'
+
+#name: cvmTwoOutputs
+#output: int a
+#output: int b
+def cvmTwoOutputs():
+    return 1, 2

--- a/packages/CVMTests/dockerfiles/celery/scalars.py
+++ b/packages/CVMTests/dockerfiles/celery/scalars.py
@@ -1,0 +1,37 @@
+from datetime import timedelta
+
+#name: cvmInt
+#input: int x
+#output: int result
+def cvmInt(x):
+    return x
+
+#name: cvmDouble
+#input: double x
+#output: double result
+def cvmDouble(x):
+    return x
+
+#name: cvmBool
+#input: bool x
+#output: bool result
+def cvmBool(x):
+    return x
+
+#name: cvmString
+#input: string x
+#output: string result
+def cvmString(x):
+    return x
+
+#name: cvmBigInt
+#input: bigint x
+#output: bigint result
+def cvmBigInt(x):
+    return x
+
+#name: cvmDate
+#input: datetime dt
+#output: datetime result
+def cvmDate(dt):
+    return dt + timedelta(days=1)

--- a/packages/CVMTests/dockerfiles/celery/streaming.py
+++ b/packages/CVMTests/dockerfiles/celery/streaming.py
@@ -1,0 +1,18 @@
+#name: cvmBlob
+#input: blob blob
+#output: blob result
+def cvmBlob(blob):
+    return blob
+
+#name: cvmFile
+#input: file file
+#output: blob result
+def cvmFile(file):
+    return file
+
+#name: cvmMultiInput
+#input: blob blob
+#input: dataframe df
+#output: string result
+def cvmMultiInput(blob, df):
+    return f"{len(blob)}:{df.shape[0]}:{df.shape[1]}"

--- a/packages/CVMTests/dockerfiles/celery/tasks.yaml
+++ b/packages/CVMTests/dockerfiles/celery/tasks.yaml
@@ -1,0 +1,72 @@
+{
+  "tasks": [
+    {
+      "name": "cvmDataframe",
+      "module": "dataframe"
+    },
+    {
+      "name": "cvmDataframeNulls",
+      "module": "dataframe"
+    },
+    {
+      "name": "cvmIntInBound",
+      "module": "dataframe"
+    },
+    {
+      "name": "cvmIntOutBound",
+      "module": "dataframe"
+    },
+    {
+      "name": "cvmEmptyDataframe",
+      "module": "dataframe"
+    },
+    {
+      "name": "cvmApiKey",
+      "module": "misc"
+    },
+    {
+      "name": "cvmCancel",
+      "module": "misc"
+    },
+    {
+      "name": "cvmTwoOutputs",
+      "module": "misc"
+    },
+    {
+      "name": "cvmInt",
+      "module": "scalars"
+    },
+    {
+      "name": "cvmDouble",
+      "module": "scalars"
+    },
+    {
+      "name": "cvmBool",
+      "module": "scalars"
+    },
+    {
+      "name": "cvmString",
+      "module": "scalars"
+    },
+    {
+      "name": "cvmBigInt",
+      "module": "scalars"
+    },
+    {
+      "name": "cvmDate",
+      "module": "scalars"
+    },
+    {
+      "name": "cvmBlob",
+      "module": "streaming"
+    },
+    {
+      "name": "cvmFile",
+      "module": "streaming"
+    },
+    {
+      "name": "cvmMultiInput",
+      "module": "streaming"
+    }
+  ]
+}

--- a/packages/CVMTests/dockerfiles/queue/Dockerfile
+++ b/packages/CVMTests/dockerfiles/queue/Dockerfile
@@ -1,0 +1,2 @@
+FROM datagrok/celery_node_worker:bleeding-edge
+EXPOSE 8000

--- a/packages/CVMTests/package-lock.json
+++ b/packages/CVMTests/package-lock.json
@@ -56,6 +56,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -948,6 +949,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -1381,6 +1383,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2202,6 +2205,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2785,7 +2789,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz",
       "integrity": "sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -2976,6 +2981,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5011,6 +5017,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5200,6 +5207,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
         "cosmiconfig": "9.0.0",
@@ -5649,6 +5657,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6319,6 +6328,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6453,6 +6463,7 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -6502,6 +6513,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/packages/CVMTests/src/celery/node_celery_benchmark.ts
+++ b/packages/CVMTests/src/celery/node_celery_benchmark.ts
@@ -52,10 +52,18 @@ category('Celery: node worker benchmark', () => {
   }
 
   test('Cold start: spin-up + first call', async () => {
+    // stop → explicit run(await) → first call: call-triggered auto-start only
+    // exists for on-demand containers, the auto queue container is a regular one
     const container = await queueContainer();
-    await grok.dapi.docker.dockerContainers.stop(container.id, true);
-    const ms = await timedCall('CVMTests:jsCvmInt', {x: 42});
-    log('cold start (container start + worker init + loadPackage + call)', ms);
+    if (!`${container.status}`.includes('stopped'))
+      await grok.dapi.docker.dockerContainers.stop(container.id, true);
+    const t0 = performance.now();
+    await grok.dapi.docker.dockerContainers.run(container.id, true);
+    const startMs = performance.now() - t0;
+    const callMs = await timedCall('CVMTests:jsCvmInt', {x: 42});
+    log('cold start: container start', startMs);
+    log('cold start: first call (worker init + loadPackage)', callMs);
+    log('cold start: total', startMs + callMs);
   }, {benchmark: true, timeout: 600000});
 
   test('Warm scalar call', async () => {

--- a/packages/CVMTests/src/celery/node_celery_benchmark.ts
+++ b/packages/CVMTests/src/celery/node_celery_benchmark.ts
@@ -1,0 +1,98 @@
+import * as grok from 'datagrok-api/grok';
+import * as DG from 'datagrok-api/dg';
+import dayjs from 'dayjs';
+
+import {category, test, expect} from '@datagrok-libraries/test/src/test';
+
+// Benchmark of the celery Node worker path (meta.queue / meta.server functions).
+// Runs only with `grok test --benchmark`. Timings are printed as `BENCH:` console
+// lines (and each test's own duration in the report approximates the same number).
+category('Celery: node worker benchmark', () => {
+  const containerNames = ['cvm-tests-queue', 'cvm-tests-queue-celery'];
+
+  async function queueContainer(): Promise<DG.DockerContainer> {
+    for (const name of containerNames) {
+      const c = await grok.dapi.docker.dockerContainers.filter(`name = "${name}"`).first();
+      if (c) return c;
+    }
+    throw new Error('CVMTests queue worker container not found');
+  }
+
+  function log(name: string, ms: number, extra: string = ''): void {
+    console.log(`BENCH: ${name}: ${Math.round(ms)} ms${extra ? ' ' + extra : ''}`);
+  }
+
+  function makeTable(rows: number): DG.DataFrame {
+    const ints = new Int32Array(rows);
+    const floats = new Float32Array(rows);
+    const strs = new Array<string>(rows);
+    const bools = new Array<boolean>(rows);
+    const dates = new Array<dayjs.Dayjs>(rows);
+    const t0 = dayjs('2020-01-01T00:00:00Z');
+    for (let i = 0; i < rows; i++) {
+      ints[i] = i;
+      floats[i] = i * 0.5;
+      strs[i] = `row ${i % 1000}`;
+      bools[i] = i % 2 === 0;
+      dates[i] = t0.add(i % 86400, 'second');
+    }
+    return DG.DataFrame.fromColumns([
+      DG.Column.fromInt32Array('i', ints),
+      DG.Column.fromFloat32Array('d', floats),
+      DG.Column.fromList(DG.COLUMN_TYPE.STRING, 's', strs),
+      DG.Column.fromList(DG.COLUMN_TYPE.BOOL, 'b', bools),
+      DG.Column.fromList(DG.COLUMN_TYPE.DATE_TIME, 'dt', dates),
+    ]);
+  }
+
+  async function timedCall(fn: string, params: object): Promise<number> {
+    const t0 = performance.now();
+    await grok.functions.call(fn, params);
+    return performance.now() - t0;
+  }
+
+  test('Cold start: spin-up + first call', async () => {
+    const container = await queueContainer();
+    await grok.dapi.docker.dockerContainers.stop(container.id, true);
+    const ms = await timedCall('CVMTests:jsCvmInt', {x: 42});
+    log('cold start (container start + worker init + loadPackage + call)', ms);
+  }, {benchmark: true, timeout: 600000});
+
+  test('Warm scalar call', async () => {
+    const ms = await timedCall('CVMTests:jsCvmInt', {x: 42});
+    log('warm scalar call', ms);
+  }, {benchmark: true, timeout: 90000});
+
+  test('Scalars x20', async () => {
+    const times: number[] = [];
+    for (let i = 0; i < 20; i++)
+      times.push(await timedCall('CVMTests:jsCvmInt', {x: i}));
+    times.sort((a, b) => a - b);
+    const avg = times.reduce((a, b) => a + b, 0) / times.length;
+    log('scalar x20', avg, `avg (min ${Math.round(times[0])}, ` +
+      `median ${Math.round(times[10])}, max ${Math.round(times[19])})`);
+  }, {benchmark: true, timeout: 300000});
+
+  test('Small table round trip (1k x 5)', async () => {
+    const df = makeTable(1000);
+    const payload = df.toByteArray().length;
+    const times: number[] = [];
+    for (let i = 0; i < 5; i++)
+      times.push(await timedCall('CVMTests:jsCvmDataframe', {df}));
+    times.sort((a, b) => a - b);
+    const avg = times.reduce((a, b) => a + b, 0) / times.length;
+    log('small table (1k x 5) round trip', avg,
+      `avg of 5 (min ${Math.round(times[0])}, max ${Math.round(times[4])}), d42 payload ${(payload / 1024).toFixed(1)} KB`);
+    expect(times.length, 5);
+  }, {benchmark: true, timeout: 300000});
+
+  test('Large table round trip (500k x 5)', async () => {
+    const df = makeTable(500000);
+    const payload = df.toByteArray().length;
+    const ms = await timedCall('CVMTests:jsCvmDataframe', {df});
+    log('large table (500k x 5) round trip', ms,
+      `d42 payload ${(payload / 1024 / 1024).toFixed(1)} MB`);
+    const ms2 = await timedCall('CVMTests:jsCvmDataframe', {df});
+    log('large table (500k x 5) round trip, 2nd', ms2);
+  }, {benchmark: true, timeout: 600000});
+});

--- a/packages/CVMTests/src/celery/node_celery_tests.ts
+++ b/packages/CVMTests/src/celery/node_celery_tests.ts
@@ -1,5 +1,6 @@
 import * as grok from 'datagrok-api/grok';
 import * as DG from 'datagrok-api/dg';
+import dayjs from 'dayjs';
 
 import {category, test, expect, expectTable, expectExceptionAsync} from '@datagrok-libraries/test/src/test';
 
@@ -32,6 +33,23 @@ category('Celery: node worker', () => {
       DG.Column.fromList(DG.COLUMN_TYPE.BOOL, 'b', [true, false, true]),
     ]);
     expectTable(await grok.functions.call('CVMTests:jsCvmDataframe', {df}), df);
+  }, {timeout: 90000});
+
+  test('DataFrame binary fidelity', async () => {
+    const df = DG.DataFrame.fromColumns([
+      DG.Column.fromList(DG.COLUMN_TYPE.INT, 'i', [1, 2, 3]),
+      DG.Column.fromList(DG.COLUMN_TYPE.FLOAT, 'd', [1.5, 2.5, 3.5]),
+      DG.Column.fromList(DG.COLUMN_TYPE.STRING, 's', ['a', 'b', 'c']),
+      DG.Column.fromList(DG.COLUMN_TYPE.BOOL, 'b', [true, false, true]),
+      DG.Column.fromList(DG.COLUMN_TYPE.DATE_TIME, 'dt',
+        [dayjs('2020-01-01T00:00:00Z'), dayjs('2021-06-15T12:30:45Z'), dayjs('2022-12-31T23:59:59Z')]),
+    ]);
+    df.col('i')!.setTag('foo', 'bar'); // d42 keeps column tags, CSV did not
+    const result: DG.DataFrame = await grok.functions.call('CVMTests:jsCvmDataframeTypes', {df});
+    for (const col of df.columns)
+      expect(result.col(col.name)!.type, col.type);
+    expectTable(result, df);
+    expect(result.col('i')!.getTag('foo'), 'bar');
   }, {timeout: 90000});
 
   test('Empty dataframe', async () => {

--- a/packages/CVMTests/src/package-api.ts
+++ b/packages/CVMTests/src/package-api.ts
@@ -536,6 +536,10 @@ export namespace funcs {
     return await grok.functions.call('CVMTests:JsCvmDataframe', { df });
   }
 
+  export async function jsCvmDataframeTypes(df: DG.DataFrame ): Promise<DG.DataFrame> {
+    return await grok.functions.call('CVMTests:JsCvmDataframeTypes', { df });
+  }
+
   export async function jsCvmEmptyDataframe(): Promise<DG.DataFrame> {
     return await grok.functions.call('CVMTests:JsCvmEmptyDataframe', {});
   }
@@ -554,6 +558,10 @@ export namespace funcs {
 
   export async function jsCvmCurrentUser(): Promise<string> {
     return await grok.functions.call('CVMTests:JsCvmCurrentUser', {});
+  }
+
+  export async function jsCvmServer(x: string ): Promise<string> {
+    return await grok.functions.call('CVMTests:JsCvmServer', { x });
   }
 
   export async function jsCvmCustomContainer(): Promise<string> {

--- a/packages/CVMTests/src/package-test.ts
+++ b/packages/CVMTests/src/package-test.ts
@@ -5,6 +5,7 @@ import './shell/ml';
 import './scripts/scripts_tests';
 import './celery/celery_tests';
 import './celery/node_celery_tests';
+import './celery/node_celery_benchmark';
 import './docker/docker';
 import './files/files';
 // import './gui/dialogs'; To fix!

--- a/packages/CVMTests/src/package.ts
+++ b/packages/CVMTests/src/package.ts
@@ -71,6 +71,14 @@ export function jsCvmDataframe(df: DG.DataFrame): DG.DataFrame {
   return df;
 }
 
+//name: jsCvmDataframeTypes
+//meta.queue: true
+//input: dataframe df
+//output: dataframe result
+export function jsCvmDataframeTypes(df: DG.DataFrame): DG.DataFrame {
+  return df;
+}
+
 //name: jsCvmEmptyDataframe
 //meta.queue: true
 //output: dataframe result

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -85,6 +85,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -3052,6 +3053,7 @@
       "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3163,6 +3165,7 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -3722,6 +3725,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4192,6 +4196,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4726,7 +4731,8 @@
       "version": "0.0.1608973",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
       "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.375",
@@ -4902,6 +4908,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7126,6 +7133,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7471,6 +7479,7 @@
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -7710,6 +7719,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7845,6 +7855,7 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8050,6 +8061,7 @@
       "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -8097,6 +8109,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",


### PR DESCRIPTION
stop→call auto-start only exists for on-demand containers; the auto queue container is a regular one — the cold-start test now does stop → run(await) → first call and reports container-start and first-call (worker init + loadPackage) separately. Verified on sandbox (5/5 benchmark, 12/12 functional). Ticket: GROK-20452.

Generated with [Claude Code](https://claude.com/claude-code)