### PR TITLE
[report 2245] GROK-20477: Notebooks: Guard mountNotebook against a null iframe browsing context and defer to the 'load' handler

### DIFF
--- a/packages/Notebooks/CHANGELOG.md
+++ b/packages/Notebooks/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* 2245: Guard mountNotebook against a null iframe browsing context and defer to the 'load' handler
 * GROK-18695: Security overrides for url-parse/marked/sanitize-html/codemirror (npm audit prod vulnerabilities 25 -> 0); added a marked default-export shim for @jupyterlab/rendermime 2.x
 * GROK-18695: jupyter-notebook container: Moved to python 3.11 and raised security floors (mlflow 3.x, torch 2.13 cpu, tensorflow 2.20+/keras 3, jupyter-server 2.20, nltk 3.9.4, pillow 12.2, urllib3 2.7, and the transitive VEX floors) to clear all fixable CRITICAL/HIGH CVEs
 * Moved the Notebooks Playwright E2E suite into the package (playwright/); helpers from @datagrok-libraries/test/src/playwright

--- a/packages/Notebooks/src/package.js
+++ b/packages/Notebooks/src/package.js
@@ -251,7 +251,10 @@ class NotebookView extends DG.ViewBase {
     // to reload it to a blank document. The notebook model lives in memory, so we rebuild the
     // iframe document and re-attach the existing widget on every load to preserve all cell data.
     const mountNotebook = () => {
-      const iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
+      const iframeDocument = iframe.contentDocument || (iframe.contentWindow && iframe.contentWindow.document);
+      // No browsing context yet (root not attached to the live DOM). The 'load' handler
+      // re-invokes mountNotebook once the iframe has a real document, so bail for now.
+      if (!iframeDocument) return;
       iframeDocument.open();
       iframeDocument.write('<html><head></head><body></body></html>');
       iframeDocument.close();


### PR DESCRIPTION
Opening a Jupyter notebook in edit mode crashed the editor mount with a client-side `TypeError: Cannot read properties of null (reading 'document')`. In `NotebookView.editMode()` (public/packages/Notebooks/src/package.js), the `mountNotebook` closure is invoked synchronously at line 289 immediately after `this.root.appendChild(iframe)`, before the iframe acquires a browsing context and fires its `'load'` event; line 254 then dereferences the still-null `iframe.contentWindow.document`.

This guards `mountNotebook` at its entry: it reads `iframe.contentDocument || (iframe.contentWindow && iframe.contentWindow.document)` (short-circuiting instead of dereferencing null) and returns early when no document is available yet. The `'load'` handler already registered on the iframe re-invokes `mountNotebook` once the iframe has a real document, so the notebook mounts normally with no cell data lost.

The guard covers both entry points (the synchronous call and the `'load'` event) and routes the "no browsing context yet" case into an early-out rather than fabricating a blank document, so the failing line can no longer be reached with the null-contentWindow state. See the JIRA reproduction comment for the captured stack trace (crash package Notebooks, method mountNotebook, pattern "Cannot read properties of null (reading 'document')").

---
**Diff:** +5/-1 · 2 files

**Verified:** verification could not produce a definitive verdict — replay the recipe manually before merging

**Full analysis:** [GROK-20477](https://reddata.atlassian.net/browse/GROK-20477)


[GROK-20477]: https://reddata.atlassian.net/browse/GROK-20477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ