### PR TITLE
Chem: add #meta.role: transform to stand-alone scripts for datasync support

### DIFF
--- a/packages/Chem/scripts/stand-alone/butina_cluster.py
+++ b/packages/Chem/scripts/stand-alone/butina_cluster.py
@@ -8,6 +8,7 @@
 #input: dataframe data [Input data table]
 #input: column molecules {semType: Molecule} [Molecules, in SMILES and MolBlock format]
 #input: double distanceCutoff = 0.4 [Tanimoto distance cutoff for clustering (0-1)]
+#meta.role: transform
 #output: dataframe clusters {action:join(data)} [Clusters]
 
 import numpy as np

--- a/packages/Chem/scripts/stand-alone/filter_catalogs.py
+++ b/packages/Chem/scripts/stand-alone/filter_catalogs.py
@@ -7,6 +7,7 @@
 #input: dataframe data [Input data table]
 #input: column smiles {type:categorical; semType: Molecule} [Molecules in SMILES format]
 #input: string catalog = "BRENK" {choices: ["BRENK", "NIH", "PAINS_A", "PAINS_B", "PAINS_C", "ZINC"]}
+#meta.role: transform
 #output: dataframe filter {action:join(data)} [Column with filter matches]
 
 import numpy as np

--- a/packages/Chem/scripts/stand-alone/murcko_scaffold.py
+++ b/packages/Chem/scripts/stand-alone/murcko_scaffold.py
@@ -6,6 +6,7 @@
 #meta.domain: chem
 #input: dataframe data [Input data table]
 #input: column smiles {type:categorical; semType: Molecule} [Molecules, in SMILES format]
+#meta.role: transform
 #output: dataframe scaffolds {action:join(data); semType: Molecule} [Murcko scaffolds, in SMILES format]
 
 import numpy as np


### PR DESCRIPTION
Drafted by Grokky from a Slack thread.

**Root cause:** **File:** `packages/Chem/scripts/stand-alone/butina_cluster.py` (and sibling scripts `murcko_scaffold.py`, `filter_catalogs.py`)

**What breaks:** When a project is saved with datasync enabled and then reopened, the Butina-cluster step is not replayed — the platform sees only a stale, frozen result column instead of re-running the function.

**Where:** The datasync subsystem decides whether a function result can be replayed by checking for the `#meta.role: transform` script header. Every biochemical-calculator script that correctly supports datasync carries this tag (`calc_logP.py`, `calc_logS.py`, `calc_pI.py`, `calc_pKas.py`). All three stand-alone scripts (`butina_cluster.py`, `murcko_scaffold.py`, `filter_catalogs.py`) are missing it, even though they also use `{action:join(data)}` in their `#output` directive (i.e. they produce joined result columns exactly like the calculators do).

**Why:** `butina_cluster.py` was added to the top-menu (`Chem | Analyze | Butina Cluster...`) without the matching datasync annotation. Without `#meta.role: transform`, the platform cannot identify the function as re-runnable during project restore, so it displays the state frozen at save-time rather than recalculating — producing "incorrect results for Butina cluster" as reported.

Note: `calc_logD.py` has the same annotation gap, but that is outside the scope of GROK-20508.

**Reproduced on dev:** Reproduction requires save/restore of a project with datasync through the full UI, which is not automatable through the JS API alone. Root cause is established purely by static code comparison.

**Thread:** https://datagrok.slack.com/archives/C04BF3YM6CF/p1785227533092579?thread_ts=1785227533.092579&cid=C04BF3YM6CF

> Auto-drafted fix — review and test before merging.