### PR TITLE
GROK-20479: d4: Set the Reports DataFrame name so it is not listed as "null" in the Table selector

### DIFF
--- a/packages/UsageAnalysis/CHANGELOG.md
+++ b/packages/UsageAnalysis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Usage Analysis changelog
 
+## v.next
+
+* GROK-20479: Set the Reports DataFrame name so it is not listed as "null" in the Table selector
+
 ## 2.7.1 (2026-07-23)
 
 * Restored the npm release channel: `datagrok-api` local path dependency replaced with the published `^1.27.7` (path deps block CI publishing, so 2.5.2–2.7.0 never reached npm and environments tracking `latest` kept downgrading to 2.5.1)

--- a/packages/UsageAnalysis/src/reporting/reporting_app.ts
+++ b/packages/UsageAnalysis/src/reporting/reporting_app.ts
@@ -48,6 +48,7 @@ export class ReportingApp {
     }
 
     let table: DG.DataFrame = await allReportsPromise;
+    table.name = ReportingApp.APP_NAME;
     this.view.table = table;
 
     if (reportNumber) {


### PR DESCRIPTION
The Usage Analysis Reports app assigned the reports DataFrame to its view (reporting_app.ts:51) but never set the DataFrame's name, while only the view's name was set to "Reports"; because the d4 Table / choose-data selector lists open tables by DataFrame.name, the nameless report table rendered as the literal text "null" in the dropdown.

This sets `table.name = ReportingApp.APP_NAME` on the report DataFrame before it is assigned to the view, so the selector shows "Reports" instead of "null".

---
**Diff:** +5/-0 · 2 files

**Verified:** reproduction recipe replayed on the patched build — the original error no longer fires

**Full analysis:** [GROK-20479](https://reddata.atlassian.net/browse/GROK-20479)


[GROK-20479]: https://reddata.atlassian.net/browse/GROK-20479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ