### PR TITLE
GROK-20510: Chem: Fix scatterplot crash on colored scaffold removal

### DIFF
--- a/packages/Chem/CHANGELOG.md
+++ b/packages/Chem/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* GROK-20510: Chem: Fixed removing a colored scaffold breaking the scatterplot with structure-colors legend
 * Docker (chem/chemprop): Cleared reported CVEs — pinned Flask/Werkzeug/gunicorn to fixed releases, upgraded pip/setuptools/wheel (build + runtime tooling), pinned urllib3/idna in chemprop, and added `apt upgrade` to patch base-image OS packages
 * Docker (chem/chemprop): Raised security floors (VEX) — torch/torchvision/torchaudio to 2.6.0+cu118 via PyPI wheels (CVE-2025-32434) and removed padelpy's bundled PaDEL-Descriptor jars (log4j 1.2.15, guava 17.0)
 * Moved the Chem Playwright E2E suite into the package (playwright/); helpers from @datagrok-libraries/test/src/playwright

--- a/packages/Chem/src/rendering/rdkit-cell-renderer.ts
+++ b/packages/Chem/src/rendering/rdkit-cell-renderer.ts
@@ -621,7 +621,15 @@ M  END
     cellStyle: DG.GridCellStyle, colTemp: any, molString: string, highlightScaffolds?: IColoredScaffold[], renderOpts?: Record<string, any>): void {
     let molRegenerateCoords = getSyncTag(gridCell.cell.column, REGENERATE_COORDS_SYNC, REGENERATE_COORDS) === 'true';
     let scaffoldRegenerateCoords = false;
-    const df = gridCell.cell.dataFrame;
+    // legend/tooltip cells can be created from a column detached from its dataframe
+    // (e.g. the scaffold tree colors column after the last colored scaffold is removed) —
+    // cell.dataFrame would crash on the null handle, so draw without scaffold-col highlighting
+    const df = gridCell.cell.column.dataFrame;
+    if (df == null) {
+      this._drawMolecule(x, y, w, h, g.canvas, molString, highlightScaffolds ?? [],
+        molRegenerateCoords, false, cellStyle, false, {}, undefined, renderOpts);
+      return;
+    }
     let rowScaffoldCol = null;
     let haveParentMol = false;
     let parentMolScaffoldMolString;


### PR DESCRIPTION
## Summary

- **Bug** (report [23238](https://dev.datagrok.ai/apps/usage/reports/23238)): coloring a scaffold in the Scaffold Tree, setting a scatterplot's Color to the generated "`<molColumn>` colors" column, then removing the colored scaffold crashed the scatterplot legend with `NullError: method not found on null`.
- **Root cause**: removing the last colored scaffold makes the scaffold tree detach its colors column from the dataframe. The scatterplot's legend refresh still renders items from the cached (now detached) column; the Dart legend builds renderable cells whose `dataFrame` is legitimately null (`getRenderableGridCell` falls back to `column.parentDataFrame`, which is null once detached). `RDKitCellRenderer.highlightByScaffoldCol` then called `gridCell.cell.dataFrame`, which constructs a `DataFrame` around the null handle and blows up in interop.
- **Fix**: resolve the dataframe via `gridCell.cell.column.dataFrame` (null-safe) and, when the cell has no dataframe, draw the molecule without scaffold-column highlighting — mirroring the existing no-scaffold-col path.

## Testing

- `tsc --noEmit` and ESLint pass (remaining warnings pre-existing).
- No unit test: the failing path needs a legend-constructed cell (column set, dataframe null), which the public JS API cannot create (`GridCell.fromValue` produces a column-less cell that takes the early value-based path).

Generated with [Claude Code](https://claude.com/claude-code)