### PR TITLE
GROK-20379: DBTests: ClickHouse streaming queries and connection

### DIFF
--- a/packages/DBTests/CHANGELOG.md
+++ b/packages/DBTests/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Tests: annotated API-only categories (queries, TableQueryBuilder, server cache, benchmarks, DB annotations, provider connectivity) with `node: true` — `grok test` now runs them headless in Node; the data-sync view test and the IndexedDB-backed client cache stay in the browser
 * Tests: the query `-- test:` auto tests (~200) also run headless now that the Node runtime provides the shared `OpenFile` fallback
 * Tests: moved the 5 browser-bound tests (data sync, client cache ×2, cached TestWide benchmarks ×2) to ApiTests (`DB: *` categories) — DBTests now runs fully headless, `grok test` never launches a browser for it
+* GROK-20379: Added ClickHouseStreaming connection (ClickHouse 26.3 on port 18125, routed via connectionType=ADBC) with multi-chunk streaming queries and a benchmark-only `ClickHouse Streaming` category
 * Tests: grouped connectivity tests by provider (`Providers: <dataSource>`) via `initPackageTests`; removed the dead `tests/categories.ts` whose provider categories held a `before` but no tests.
 * Tests: skip all ClickHouse tests — the connectivity check (`initPackageTests` skipReason) and the 31 query round-trip tests (`skip:` on the `-- test:` annotations in `clickhouse-*.sql`). The ClickHouse demo DB is down (failing on dev + CI since ~2026-07-12); remove the `skip:` tokens to re-enable once it's restored.
 * Security: pinned the DB test image to `postgres:17-bookworm` and added `apt-get upgrade` to clear stale Debian base CVEs (gnutls28/perl/glibc).

--- a/packages/DBTests/connections/clickhouse-streaming.json
+++ b/packages/DBTests/connections/clickhouse-streaming.json
@@ -1,0 +1,19 @@
+{
+  "#type": "DataConnection",
+  "name": "ClickHouseStreaming",
+  "friendlyName": "ClickHouse Streaming (ADBC)",
+  "parameters": {
+    "connectionType": "ADBC",
+    "server": "db.datagrok.ai",
+    "port": 18125,
+    "db": "test"
+  },
+  "credentials": {
+    "parameters": {
+      "login": "datagrok",
+      "password": "kNjsC8q830WHUBNC8VndhojSR4GAdqryiZhY"
+    }
+  },
+  "dataSource": "ClickHouse",
+  "description": "ClickHouse 26.3 test instance (clickhouse-test, port 18125), routed through the ADBC/Arrow connector via connectionType. Multi-chunk streaming queries."
+}

--- a/packages/DBTests/queries/clickhouse-streaming-test.sql
+++ b/packages/DBTests/queries/clickhouse-streaming-test.sql
@@ -1,0 +1,87 @@
+-- Multi-chunk streaming coverage for the ClickHouse ADBC/Arrow connector.
+--
+-- The Rust connector cuts a chunk every MAX_CHUNK_ROWS = 50_000 rows
+-- (grok_connect_adbc/src/routes/query_socket.rs), so every query here returns >= 200_000 rows
+-- and exercises the full SIZE -> ACK -> binary -> PART_OK pipeline rather than the
+-- single-chunk path the type-coverage suites in clickhouse-adbc-*.sql take.
+--
+-- All row sources are the `numbers()` generator, not stored tables: the queries are
+-- self-contained, need no DDL on the shared demo DB, and stay valid if the `test` database
+-- is ever reloaded. Flip the connection's `connectionType` to JDBC to run the identical SQL
+-- through the Java connector for an apples-to-apples comparison.
+--
+-- No `-- test:` annotations on purpose. These have no d42 baselines (a 1M-row baseline is not
+-- worth committing, and `generateUUIDv4` is non-deterministic); they are driven from the
+-- `ClickHouse Streaming` benchmark category in src/benchmarks/clickhouse-streaming.ts.
+
+-- name: ClickHouseStreamingInts
+-- friendlyName: Streaming: 1M ints
+-- connection: ClickHouseStreaming
+-- Narrowest possible row: isolates chunking/round-trip overhead from payload size. ~20 chunks.
+SELECT number AS id FROM numbers(1000000);
+-- end
+
+-- name: ClickHouseStreamingLowCardinality
+-- friendlyName: Streaming: 1M low-cardinality strings
+-- connection: ClickHouseStreaming
+-- LowCardinality(String) arrives as an Arrow Dictionary only because the connector sets
+-- output_format_arrow_low_cardinality_as_dictionary; this is the query that proves the setting
+-- survives across every chunk of a pooled session, not just the first.
+SELECT toLowCardinality(['Fail', 'Pending', 'Success'][(number % 3) + 1]) AS status
+FROM numbers(1000000);
+-- end
+
+-- name: ClickHouseStreamingMixed
+-- friendlyName: Streaming: 1M mixed types
+-- connection: ClickHouseStreaming
+-- The realistic shape: dictionary + plain string + narrow Date/DateTime + float, 1M rows.
+-- Date arrives as UInt16 and DateTime as UInt32, so this drives repair_temporal_columns on
+-- every chunk — the per-chunk transform most likely to break under streaming.
+SELECT
+  toUInt32(number) AS id,
+  toLowCardinality(['Fail', 'Pending', 'Success'][(number % 3) + 1]) AS status,
+  concat('user_', toString(number % 10000)) AS name,
+  toDate('2020-01-01') + toIntervalDay(number % 2000) AS created_date,
+  toDateTime('2020-01-01 00:00:00') + toIntervalSecond(number) AS created_at,
+  toFloat64(number) / 7 AS score
+FROM numbers(1000000);
+-- end
+
+-- name: ClickHouseStreamingWideStrings
+-- friendlyName: Streaming: 250K wide strings
+-- connection: ClickHouseStreaming
+-- 512 distinct chars per row (~128 MB), so dictionary encoding cannot help and the wire is
+-- dominated by plain Utf8. This is the case where externalDataFrameCompress on the ADBC
+-- endpoint costs the most, and where Arrow IPC is compared against Java's d42 head-on.
+SELECT
+  number AS id,
+  repeat(hex(MD5(toString(number))), 16) AS payload
+FROM numbers(250000);
+-- end
+
+-- name: ClickHouseStreamingUnsupportedTypes
+-- friendlyName: Streaming: 200K UUID + wide ints
+-- connection: ClickHouseStreaming
+-- UUID and Int128/UInt256 cannot be serialized to Arrow by ClickHouse, so the connector
+-- rewrites them to String via SELECT * REPLACE and re-tags the wide ints as bigint. Both
+-- transforms are driven off a single DESCRIBE and must stay aligned across all chunks.
+SELECT
+  number AS id,
+  generateUUIDv4() AS uuid_col,
+  toInt128(number) * toInt128(1000000000000000000) AS int128_col,
+  toUInt256(number) * toUInt256(1000000000000000000) AS uint256_col
+FROM numbers(200000);
+-- end
+
+-- name: ClickHouseStreamingRows
+-- friendlyName: Streaming: N rows
+-- connection: ClickHouseStreaming
+-- input: int rows = 1000000
+-- Dial the row count by hand when hunting for a chunk-boundary bug. toUInt64 because the
+-- connector inlines parameters as SQL literals and the platform renders JSON numbers as
+-- doubles (1000000.0).
+SELECT
+  number AS id,
+  toLowCardinality(['Fail', 'Pending', 'Success'][(number % 3) + 1]) AS status
+FROM numbers(toUInt64(@rows));
+-- end

--- a/packages/DBTests/src/benchmarks/benchmark.ts
+++ b/packages/DBTests/src/benchmarks/benchmark.ts
@@ -57,7 +57,7 @@ function getTestResult(times: number[], expectedCount: number): object {
   };
 }
 
-async function benchmarkQuery(query: string, count: number): Promise<object|undefined> {
+export async function benchmarkQuery(query: string, count: number): Promise<object|undefined> {
   const times = [];
   for (let i = 0; i < count; i++)
     times.push(await getDataQueryTime(query));

--- a/packages/DBTests/src/benchmarks/clickhouse-streaming.ts
+++ b/packages/DBTests/src/benchmarks/clickhouse-streaming.ts
@@ -1,0 +1,49 @@
+import {category, expect, test} from '@datagrok-libraries/test/src/test';
+import * as DG from 'datagrok-api/dg';
+import * as grok from 'datagrok-api/grok';
+import {benchmarkQuery} from './benchmark';
+
+/** Rows returned by each streaming query in queries/clickhouse-streaming-test.sql. */
+const EXPECTED_ROWS: {[query: string]: number} = {
+  'ClickHouseStreamingInts': 1000000,
+  'ClickHouseStreamingLowCardinality': 1000000,
+  'ClickHouseStreamingMixed': 1000000,
+  'ClickHouseStreamingWideStrings': 250000,
+  'ClickHouseStreamingUnsupportedTypes': 200000,
+};
+
+// Benchmark-only: every query here moves 100 MB+ and the connection targets a shared demo DB,
+// so these stay out of the normal CI run (same convention as the Benchmarks category).
+category('ClickHouse Streaming', () => {
+  for (const query of Object.keys(EXPECTED_ROWS))
+    test(query.replace('ClickHouseStreaming', ''), async () => {
+      const df: DG.DataFrame = await grok.functions.call('Dbtests:' + query);
+      expect(df.rowCount, EXPECTED_ROWS[query]);
+      return await benchmarkQuery(query, DG.Test.isInBenchmark ? 3 : 1);
+    }, {timeout: 600000, benchmark: true, stressTest: true});
+
+  // The chunk cut is every 50_000 rows, so these three land either side of the first boundary.
+  test('Chunk boundary', async () => {
+    for (const rows of [49999, 50000, 50001]) {
+      const df: DG.DataFrame = await grok.functions.call('Dbtests:ClickHouseStreamingRows', {rows});
+      expect(df.rowCount, rows);
+    }
+  }, {timeout: 600000, benchmark: true});
+
+  // Both connections point at the same server/db (db.datagrok.ai:18125, `test`); they differ
+  // only in the engine that carries the rows back, so the same SQL is a fair head-to-head.
+  test('ADBC vs JDBC on identical SQL', async () => {
+    const sql = 'SELECT number AS id, ' +
+      "toLowCardinality(['Fail', 'Pending', 'Success'][(number % 3) + 1]) AS status " +
+      'FROM numbers(1000000)';
+    const times: {[connectionName: string]: number} = {};
+    for (const name of ['ClickHouseStreaming', 'ClickHouseDBTests']) {
+      const connection = await grok.dapi.connections.filter(`name = "${name}"`).first();
+      const startTime = Date.now();
+      const call = await connection.query('adhoc', sql).prepare().call();
+      expect((call.getOutputParamValue() as DG.DataFrame).rowCount, 1000000);
+      times[`${name} (${connection.parameters['connectionType'] ?? 'JDBC'}), ms`] = Date.now() - startTime;
+    }
+    return times;
+  }, {timeout: 600000, benchmark: true});
+}, {node: true});

--- a/packages/DBTests/src/package-api.ts
+++ b/packages/DBTests/src/package-api.ts
@@ -256,6 +256,30 @@ export namespace queries {
     return await grok.data.query('DBTests:ClickHousePatternsAllParams', { first_name, id, bool, email, some_number, country, date });
   }
 
+  export async function clickHouseStreamingInts(): Promise<DG.DataFrame> {
+    return await grok.data.query('DBTests:ClickHouseStreamingInts', {});
+  }
+
+  export async function clickHouseStreamingLowCardinality(): Promise<DG.DataFrame> {
+    return await grok.data.query('DBTests:ClickHouseStreamingLowCardinality', {});
+  }
+
+  export async function clickHouseStreamingMixed(): Promise<DG.DataFrame> {
+    return await grok.data.query('DBTests:ClickHouseStreamingMixed', {});
+  }
+
+  export async function clickHouseStreamingWideStrings(): Promise<DG.DataFrame> {
+    return await grok.data.query('DBTests:ClickHouseStreamingWideStrings', {});
+  }
+
+  export async function clickHouseStreamingUnsupportedTypes(): Promise<DG.DataFrame> {
+    return await grok.data.query('DBTests:ClickHouseStreamingUnsupportedTypes', {});
+  }
+
+  export async function clickHouseStreamingRows(rows: number ): Promise<DG.DataFrame> {
+    return await grok.data.query('DBTests:ClickHouseStreamingRows', { rows });
+  }
+
   export async function mariaDbDateTypes(): Promise<DG.DataFrame> {
     return await grok.data.query('DBTests:MariaDbDateTypes', {});
   }

--- a/packages/DBTests/src/package-test.ts
+++ b/packages/DBTests/src/package-test.ts
@@ -4,6 +4,7 @@ import * as grok from 'datagrok-api/grok';
 import {runTests, tests, TestContext, test as _test, category, initAutoTests as initTests } from '@datagrok-libraries/test/src/test';
 import './connections/queries-test';
 import './benchmarks/benchmark';
+import './benchmarks/clickhouse-streaming';
 import './cache/cache-test';
 import './connections/table-query-test';
 import './db-annotations/db-annotations';


### PR DESCRIPTION
## Summary

Adds multi-chunk streaming coverage for the ClickHouse ADBC/Arrow connector, and unblocks
publishing DBTests on stands running the merged connector.

Every query returns >= 200K rows so it crosses the Rust connector's `MAX_CHUNK_ROWS = 50_000`
boundary — unlike the single-chunk type-coverage suites in `clickhouse-adbc-*.sql`.

Row sources are the `numbers()` generator rather than stored tables, so the queries need no DDL
on the shared demo DB and stay valid if the `test` database is ever reloaded.

Coverage:

| Query | Exercises |
|---|---|
| `ClickHouseStreamingInts` | chunking/round-trip overhead, narrowest possible row |
| `ClickHouseStreamingLowCardinality` | source-side dictionary across every chunk of a pooled session |
| `ClickHouseStreamingMixed` | narrow `Date`/`DateTime` temporal repair, per chunk |
| `ClickHouseStreamingWideStrings` | 512-char unique strings — dictionary encoding defeated |
| `ClickHouseStreamingUnsupportedTypes` | `SELECT * REPLACE` rewrite + bigint re-tagging (UUID, Int128/UInt256) |
| `ClickHouseStreamingRows` | parameterized row count, for chunk-boundary hunting |

The `ClickHouseStreaming` connection deliberately uses the **merged** spelling
(`dataSource: ClickHouse` + `connectionType: ADBC`), so the connection editor's dropdown flips
the same connection between engines and identical SQL runs through either connector.

No `-- test:` annotations: there are no d42 baselines for these, a 1M-row baseline is not worth
committing, and `generateUUIDv4()` is not deterministic. They run from the benchmark-only
`ClickHouse Streaming` category, which reuses `benchmarkQuery` from `benchmarks/benchmark.ts`
and is marked `{node: true}` to match the new headless convention.

## Depends on #3952

Publishing DBTests also requires the `ClickHouseADBC` data-source fix, split out into #3952 so it
can land on its own. This PR no longer contains it — merge #3952 first, or `grok publish` still
aborts with `Datasource ClickHouseADBC not found`.

## These queries found a real bug

Large results come back **silently truncated** — no error, no warning:

| Query | Requested | Returned |
|---|---:|---:|
| Mixed | 1,000,000 | **588,681** |
| UnsupportedTypes | 200,000 | **65,409** |
| Rows (2 narrow cols) | 3,000,000 | **1,504,407** |

Ruled out: ClickHouse (returns the full set directly; all result limits are `0`), the ADBC
connector (JDBC truncates at the *identical* row), a race or timeout (3/3 runs identical to the
row), a row cap (1M passes in three other queries), and a CSV-byte cap (14.9 MB passes, 5.98 MB
truncates). It tracks in-memory DataFrame size, ~20 MB.

Verified through the REST path only (`/public/v1/functions/{name}/call` → `toCsv()`); the browser
WebSocket path is **untested** and matters more. Full write-up with repro:
`docs_lpospelov/clickhouse-streaming-truncation.md` in the reddata repo.

## Test plan

- [x] Connection saves and tests `ok` through the ADBC engine on localdev
- [x] `grok publish` succeeds (with #3952 applied)
- [x] All six queries registered and executed end to end against ClickHouse 26.3.17.4 (db.datagrok.ai:18125)
- [x] Same query entity re-run on `connectionType: JDBC` for the engine comparison
- [x] `tsc --noEmit` — only the 11 pre-existing `node`-option errors from the stale local `@datagrok-libraries/test`
- [ ] Truncation reproduced (or not) through the browser WebSocket path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
