### PR TITLE
GROK-20379: DBTests: fix ClickHouseADBC data source breaking publish

### DIFF
--- a/packages/DBTests/CHANGELOG.md
+++ b/packages/DBTests/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Tests: skip all ClickHouse tests — the connectivity check (`initPackageTests` skipReason) and the 31 query round-trip tests (`skip:` on the `-- test:` annotations in `clickhouse-*.sql`). The ClickHouse demo DB is down (failing on dev + CI since ~2026-07-12); remove the `skip:` tokens to re-enable once it's restored.
 * Security: pinned the DB test image to `postgres:17-bookworm` and added `apt-get upgrade` to clear stale Debian base CVEs (gnutls28/perl/glibc).
 * Tests: added ClickHouseADBC coverage — connection, mock_data pattern tests, per-type output tests (full mirror of the ClickHouse suite), and category guard for the experimental ADBC/Arrow connector.
+* GROK-20379: Fixed DBTests failing to publish — migrated the ClickHouseADBC test connection to the merged `ClickHouse` data source (`connectionType: ADBC`), since the connector no longer advertises `ClickHouseADBC` once the engine suffix is stripped
 
 ## 1.3.0 (2025-07-28)
 

--- a/packages/DBTests/connections/clickhouse-adbc-db-tests.json
+++ b/packages/DBTests/connections/clickhouse-adbc-db-tests.json
@@ -3,6 +3,7 @@
   "name": "ClickHouseADBCDBTests",
   "friendlyName": "ClickHouseADBCDBTests",
   "parameters": {
+    "connectionType": "ADBC",
     "server": "db.datagrok.ai",
     "port": 18125,
     "db": "test"
@@ -13,6 +14,6 @@
       "password": "kNjsC8q830WHUBNC8VndhojSR4GAdqryiZhY"
     }
   },
-  "dataSource": "ClickHouseADBC",
+  "dataSource": "ClickHouse",
   "description": "Test data (routed to the experimental ADBC/Arrow connector)"
 }


### PR DESCRIPTION
## Problem

`grok publish` on DBTests aborts outright:

```
Datasource ClickHouseADBC not found
  at ProjectDeploy.deploy (deploy_demo_projects.dart:301)
```

The whole package fails to deploy — every connection and all ~200 query tests — on any stand
running the merged connector. Reproduced on a local stack; the failure goes away with this change.

## Cause

Datlas requests `/conn?stripEngineSuffix=true` **unconditionally**. The Rust connector therefore
advertises the base type `ClickHouse` carrying `engine: ADBC`, instead of a distinct
`ClickHouseADBC` type. Datlas groups providers by type and registers a single `ClickHouse` data
source whose descriptor gains a `connectionType` selector listing the engines that registered.

So `ClickHouseADBC` no longer exists as a data source, and a connection JSON naming it cannot
resolve. Rules: `core/docs/MULTIPLE_GROK_CONNECTS.md`.

## Fix

`dataSource: ClickHouse` + `parameters.connectionType: ADBC` — the spelling datlas now expects.

Same server, database and ADBC routing as before. The `clickhouse-adbc-*.sql` queries reference
the connection **by name** (`-- connection: ClickHouseADBCDBTests`), which is unchanged, so they
are unaffected.

## Test plan

- [x] `grok publish` succeeds (fails on master without this)
- [x] Connection tests `ok`, routed through the ADBC engine
- [x] Queries against it still execute end to end (ClickHouse 26.3.17.4, db.datagrok.ai:18125)

## Note

Split out of #3951 so it can land on its own — it is an unblock, not a feature. Other packages may
still carry connections naming an engine-suffixed data source; worth a sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
