### PR TITLE
GROK-18695: Tools: Release 6.5.3 with the adm-zip CVE fix

### DIFF
--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datagrok-tools changelog
 
+## 6.5.3 (2026-08-04)
+
+* GROK-18695: Security — bumped `adm-zip` to 0.6.0 (CVE-2026-39244). Below 0.6.0 it sized a buffer from the ZIP header's declared uncompressed size before validating it, so a ~120-byte crafted archive forced a multi-GB allocation; `grok report` opens archives fetched from a server. The APIs it uses are unchanged. Also refreshed the lockfile to clear five more high-severity audit findings (`brace-expansion`, `fast-uri`, `ip-address`, `js-yaml`, `postcss`), all within existing ranges.
+
 ## 6.5.2 (2026-07-27)
 
 * `grok publish` — a failed `docker push` is no longer reported as a successful one. `image.json` claimed the tag regardless, so the server recorded a container image that was never published and the spawner failed validation forever ("Image ... not found in any registry") with no recovery short of another publish. The push failure now falls back to an image that is actually in the registry, and says so.

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datagrok-tools",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "datagrok-tools",
-      "version": "6.5.2",
+      "version": "6.5.3",
       "dependencies": {
         "@babel/parser": "^7.29.7",
         "@babel/runtime": "^7.29.7",

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datagrok-tools",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "description": "Utility to upload and publish packages to Datagrok",
   "homepage": "https://github.com/datagrok-ai/public/tree/master/tools#readme",
   "dependencies": {


### PR DESCRIPTION
## What

Bumps `datagrok-tools` to **6.5.3** + CHANGELOG entry. No code changes.

## Why

The security fix merged in f58ea713f4 has not shipped. `tools.yml` gates
`npm publish` on `changed_version == 'true'`, and the version stayed at 6.5.2,
so npm still serves 6.5.2 and the nightly `grok_tester` image keeps installing
the vulnerable `adm-zip` 0.5.18.

Merging this publishes `datagrok-tools@6.5.3`, after which the Jenkins
`Tools/Scheduled/Docker/Grok-Tester` job picks it up and tags the image `6.5.3`.

## Contents of the release

- `adm-zip` `^0.5.17` → `^0.6.0` — CVE-2026-39244 (HIGH): a buffer sized from the
  ZIP header's declared uncompressed size before validation, so a ~120-byte
  crafted archive forces a multi-GB allocation. `grok report` opens report
  archives fetched from a server. The four APIs `report.ts` uses (constructor,
  `getEntries`, `getEntry`, `entry.getData`) are unchanged in 0.6.0, verified
  against a real archive.
- Lockfile refresh clearing 5 more high findings (`brace-expansion`, `fast-uri`,
  `ip-address`, `js-yaml`, `postcss`). `npm audit` reports 0.

Verified by rebuilding `grok_tester` against a pack of the merged branch:
Trivy findings fixable inside the `datagrok-tools` tree went 1 → 0, and `grok`
and `grok report` both run in the rebuilt image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)