### PR TITLE
[report 2296] GROK-16674: SequenceTranslator: Delete the pattern selected in the Load block's Pattern combobox instead of the live editor name

### DIFF
--- a/packages/SequenceTranslator/CHANGELOG.md
+++ b/packages/SequenceTranslator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* 2296: Delete the pattern selected in the Load block's Pattern combobox instead of the live editor name
 * Moved the SequenceTranslator Playwright E2E suite into the package (playwright/); helpers from @datagrok-libraries/test/src/playwright
 
 ## 1.11.4 (2026-07-03)

--- a/packages/SequenceTranslator/src/apps/pattern/view/components/load-block-controls.ts
+++ b/packages/SequenceTranslator/src/apps/pattern/view/components/load-block-controls.ts
@@ -14,6 +14,7 @@ import {EventBus} from '../../model/event-bus';
 export class PatternLoadControlsManager {
   private subscriptions = new SubscriptionManager();
   private authorSelectedByUser = false;
+  private patternChoiceInput: StringInput;
 
   constructor(
     private eventBus: EventBus,
@@ -159,6 +160,8 @@ export class PatternLoadControlsManager {
       })
     );
 
+    this.patternChoiceInput = choiceInput;
+
     return choiceInput;
   }
 
@@ -176,11 +179,12 @@ export class PatternLoadControlsManager {
     const button = ui.button(
       ui.iconFA('trash-alt'),
       () => {
-        if (this.eventBus.getPatternName() === this.dataManager.getDefaultPatternName()) {
+        const patternName = this.patternChoiceInput.value!;
+        if (patternName === this.dataManager.getDefaultPatternName()) {
           grok.shell.warning('Cannot delete example pattern');
           return;
         }
-        this.showDeletePatternDialog();
+        this.showDeletePatternDialog(patternName);
       }
     );
 
@@ -195,9 +199,8 @@ export class PatternLoadControlsManager {
     return button;
   }
 
-  private showDeletePatternDialog(): void {
+  private showDeletePatternDialog(patternName: string): void {
     const dialog = ui.dialog('Delete pattern');
-    const patternName = this.eventBus.getPatternName();
     dialog.add(ui.divText(`Are you sure you want to delete pattern ${patternName}?`));
     dialog.onOK(() => this.eventBus.requestPatternDeletion(patternName));
     dialog.show();

--- a/packages/SequenceTranslator/src/package.g.ts
+++ b/packages/SequenceTranslator/src/package.g.ts
@@ -100,10 +100,12 @@ export async function getPolyToolConvertEditor(call: DG.FuncCall) : Promise<any>
   return await PackageFunctions.getPolyToolConvertEditor(call);
 }
 
+//name: PolyTool: Convert Notation
+//description: Convert a column of sequences in custom notation to HELM and/or molfiles
 //input: dataframe table 
 //input: column seqCol { caption: Sequence }
-//input: bool generateHelm = true 
-//input: bool chiralityEngine = true 
+//input: bool generateHelm = true { description: Also produce a HELM column alongside the molfiles }
+//input: bool chiralityEngine = true { description: Use the chirality engine when building structures }
 //input: object rules 
 //output: column result
 //editor: SequenceTranslator:getPolyToolConvertEditor
@@ -259,6 +261,7 @@ export function copyOligoAsImage(value: DG.SemanticValue) : void {
   PackageFunctions.copyOligoAsImage(value);
 }
 
+//name: HELM to Oligonucleotide
 //description: Create a new column tagged as OligoNucleotide so HELM duplex cells render with the oligo view
 //input: dataframe table 
 //input: column helmCol { caption: HELM column; semType: Macromolecule }
@@ -267,6 +270,7 @@ export async function convertHelmToOligoNucleotide(table: DG.DataFrame, helmCol:
   return await PackageFunctions.convertHelmToOligoNucleotide(table, helmCol);
 }
 
+//name: Combine Sense + Antisense to Oligonucleotide
 //description: Combine separate sense + antisense HELM columns into one OligoNucleotide column
 //input: dataframe table 
 //input: column senseCol { caption: Sense; semType: Macromolecule }


### PR DESCRIPTION
Renaming a pattern in the Oligo Pattern editor without saving and then clicking the trash icon threw an unhandled "Pattern with name X not found" error, because the Load block's delete button identified its target by the live editor name rather than by the saved pattern selected in that block.

The button and its confirmation dialog now use the pattern selected in the Load block's "Pattern" combobox, so deletion always targets an actually stored pattern.

---
**Diff:** +14/-6 · 3 files

**Verified:** reproduction recipe replayed on the patched build — the original error no longer fires

**Full analysis:** [GROK-16674](https://reddata.atlassian.net/browse/GROK-16674)


[GROK-16674]: https://reddata.atlassian.net/browse/GROK-16674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ