### PR TITLE
Chem: Add ExcludedSketchers package property to hide sketchers from UI menu

### DIFF
--- a/js-api/src/chem.ts
+++ b/js-api/src/chem.ts
@@ -64,6 +64,7 @@ export namespace chem {
   }
 
   export let currentSketcherType = DEFAULT_SKETCHER;
+  export let excludedSketchers: string[] = [];
 
   export function isMolBlock(s: string | null) {
     return s != null && s.includes('M  END');
@@ -573,7 +574,7 @@ export namespace chem {
           .items(Sketcher.getCollection(Sketcher.FAVORITES_KEY).map((m) => ui.tools.click(this.drawToCanvas(150, 60, m), () => this.setMolecule(m))), () => { })
           .endGroup()
           .separator()
-          .items(this.sketcherFunctions.map((f) => f.friendlyName), (friendlyName: string) => {
+          .items(this.sketcherFunctions.filter((f) => !excludedSketchers.includes(f.friendlyName)).map((f) => f.friendlyName), (friendlyName: string) => {
             if (currentSketcherType === friendlyName)
               return;
             currentSketcherType = friendlyName;

--- a/packages/Chem/CHANGELOG.md
+++ b/packages/Chem/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* Added `ExcludedSketchers` package property to hide specific sketchers from the UI selection menu
 * Added `Filter by Substructure`, `Similarity To` and `Diverse Subset` — table-aware twins of `searchSubstructure`, `getSimilarities` and `getDiversities`, which take a bare column. They declare `(table, column {semType: Molecule}, …)` and return rows or a column added to the table, so a caller has something to carry on with instead of a detached frame or a boxed BitSet
 * Added `Apply Reaction` — the non-interactive twin of the Transformation dialog, applying a one-component reaction SMARTS to a molecule column
 * Added `To SDF`, which serializes a table to SDF text; the only SDF write path was a zero-argument file exporter reading the current table

--- a/packages/Chem/README.md
+++ b/packages/Chem/README.md
@@ -51,6 +51,20 @@ You can set the default Sketcher in the package property so that new users won't
 
 ![default sketcher](../../help/uploads/gifs/default-sketcher.gif)
 
+### Excluding sketchers from the menu
+
+Administrators can hide specific sketchers from the selection menu (☰ icon) without
+uninstalling them. Excluded sketchers remain available programmatically.
+
+1. Go to **Manage > Packages** > **Chem** > **Context Pane > Settings**.
+2. In **ExcludedSketchers**, enter a comma-separated list of sketcher names to hide
+   (e.g., `OpenChemLib, ChemDraw`).
+
+Valid names: `OpenChemLib`, `Ketcher`, `Marvin`, `ChemDraw`. Names are case-sensitive.
+
+If the user's current sketcher is excluded, the system automatically switches to
+the first available non-excluded sketcher.
+
 ## Favorite and recent structures
 
 Access the recently sketched structures from the `☰ -> Recent` menu.

--- a/packages/Chem/package.json
+++ b/packages/Chem/package.json
@@ -25,6 +25,13 @@
       ],
       "defaultValue": "",
       "nullable": true
+    },
+    {
+      "name": "ExcludedSketchers",
+      "propertyType": "string",
+      "defaultValue": "",
+      "nullable": true,
+      "description": "Comma-separated list of sketcher names to hide from the selection menu"
     }
   ],
   "dependencies": {

--- a/packages/Chem/src/package.ts
+++ b/packages/Chem/src/package.ts
@@ -200,23 +200,15 @@ async function initChemInt(): Promise<void> {
 
   const sketcherFunctions = DG.Func.find({meta: {role: DG.FUNC_TYPES.MOLECULE_SKETCHER}});
   const sketcherFunc = sketcherFunctions.find((e) => e.name === storedSketcherType || e.friendlyName === storedSketcherType);
-  if (sketcherFunc)
+  if (sketcherFunc && !DG.chem.excludedSketchers.includes(sketcherFunc.friendlyName)) {
     DG.chem.currentSketcherType = sketcherFunc.friendlyName;
-  else {
-    if (!!storedSketcherType) {
+  } else {
+    if (!sketcherFunc && !!storedSketcherType) {
       grok.shell.warning(
         `Package with ${storedSketcherType} function is not installed.Switching to ${DG.DEFAULT_SKETCHER}.`);
     }
-
-    DG.chem.currentSketcherType = DG.DEFAULT_SKETCHER;
-  }
-
-  if (DG.chem.excludedSketchers.includes(DG.chem.currentSketcherType)) {
-    const fallback = sketcherFunctions.find(
-      (f) => !DG.chem.excludedSketchers.includes(f.friendlyName)
-    );
-    if (fallback)
-      DG.chem.currentSketcherType = fallback.friendlyName;
+    const fallback = sketcherFunctions.find((f) => !DG.chem.excludedSketchers.includes(f.friendlyName));
+    DG.chem.currentSketcherType = fallback?.friendlyName ?? DG.DEFAULT_SKETCHER;
   }
 }
 

--- a/packages/Chem/src/package.ts
+++ b/packages/Chem/src/package.ts
@@ -185,6 +185,13 @@ async function initChemInt(): Promise<void> {
   _properties = await _package.getProperties();
   _rdRenderer = new RDKitCellRenderer(PackageFunctions.getRdKitModule());
   renderer = new GridCellRendererProxy(_rdRenderer, 'Molecule');
+
+  const excludedRaw: string = _properties.ExcludedSketchers ?? '';
+  DG.chem.excludedSketchers = excludedRaw
+    .split(',')
+    .map((s: string) => s.trim())
+    .filter((s: string) => s.length > 0);
+
   let storedSketcherType = grok.userSettings.getValue(DG.chem.STORAGE_NAME, DG.chem.KEY) ?? '';
   if (PREVIOUS_SKETCHER_NAMES[storedSketcherType])
     storedSketcherType = PREVIOUS_SKETCHER_NAMES[storedSketcherType];
@@ -202,6 +209,14 @@ async function initChemInt(): Promise<void> {
     }
 
     DG.chem.currentSketcherType = DG.DEFAULT_SKETCHER;
+  }
+
+  if (DG.chem.excludedSketchers.includes(DG.chem.currentSketcherType)) {
+    const fallback = sketcherFunctions.find(
+      (f) => !DG.chem.excludedSketchers.includes(f.friendlyName)
+    );
+    if (fallback)
+      DG.chem.currentSketcherType = fallback.friendlyName;
   }
 }
 

--- a/packages/Chem/src/tests/sketcher-tests.ts
+++ b/packages/Chem/src/tests/sketcher-tests.ts
@@ -229,9 +229,13 @@ category('sketcher exclusions', () => {
     if (funcs.length < 2) return;
     const toExclude = funcs[funcs.length - 1].friendlyName;
     DG.chem.excludedSketchers = [toExclude];
-    const visibleFuncs = funcs.filter((f) => !DG.chem.excludedSketchers.includes(f.friendlyName));
-    expect(visibleFuncs.length, funcs.length - 1);
-    expect(visibleFuncs.every((f) => f.friendlyName !== toExclude), true);
+    const s = new Sketcher();
+    const d = ui.dialog().add(s).show();
+    await awaitCheck(() => s.sketcher !== null, undefined, 5000);
+    const menuItems = s.sketcherFunctions.filter((f) => !DG.chem.excludedSketchers.includes(f.friendlyName));
+    expect(menuItems.length, funcs.length - 1);
+    expect(menuItems.every((f) => f.friendlyName !== toExclude), true);
+    d.close();
   });
 
   test('sketcherFunctions retains excluded entries', async () => {
@@ -254,7 +258,16 @@ category('sketcher exclusions', () => {
     const expected = funcs[1].friendlyName;
     DG.chem.excludedSketchers = [toExclude];
     DG.chem.currentSketcherType = toExclude;
-    const available = funcs.find((f) => !DG.chem.excludedSketchers.includes(f.friendlyName));
-    expect(available !== undefined, true);
+    // Mirror the initChemInt fallback: excluded current type → switch to first available
+    const fallback = funcs.find((f) => !DG.chem.excludedSketchers.includes(f.friendlyName));
+    if (fallback && DG.chem.excludedSketchers.includes(DG.chem.currentSketcherType))
+      DG.chem.currentSketcherType = fallback.friendlyName;
+    expect(DG.chem.currentSketcherType, expected);
+    expect(DG.chem.excludedSketchers.includes(DG.chem.currentSketcherType), false);
+    const s = new Sketcher();
+    const d = ui.dialog().add(s).show();
+    await awaitCheck(() => s.sketcher !== null, undefined, 5000);
+    expect(s.sketcherFunctions.filter((f) => !DG.chem.excludedSketchers.includes(f.friendlyName)).length, funcs.length - 1);
+    d.close();
   });
 });

--- a/packages/Chem/src/tests/sketcher-tests.ts
+++ b/packages/Chem/src/tests/sketcher-tests.ts
@@ -210,3 +210,51 @@ const exampleSmiles = 'CC(C(=O)OCCCc1cccnc1)c2cccc(c2)C(=O)c3ccccc3';
 const convertedSmarts = '[#6]1:[#6]:[#6]:[#6]:[#6]:[#6]:1';
 const exampleInchi = 'InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H';
 const exampleInchiSmiles = 'c1ccccc1';
+
+
+category('sketcher exclusions', () => {
+  let originalExcluded: string[];
+
+  before(async () => {
+    originalExcluded = [...DG.chem.excludedSketchers];
+  });
+
+  after(async () => {
+    DG.chem.excludedSketchers = originalExcluded;
+    grok.shell.closeAll();
+  });
+
+  test('excluded sketcher not in menu list', async () => {
+    const funcs = DG.Func.find({meta: {role: DG.FUNC_TYPES.MOLECULE_SKETCHER}});
+    if (funcs.length < 2) return;
+    const toExclude = funcs[funcs.length - 1].friendlyName;
+    DG.chem.excludedSketchers = [toExclude];
+    const visibleFuncs = funcs.filter((f) => !DG.chem.excludedSketchers.includes(f.friendlyName));
+    expect(visibleFuncs.length, funcs.length - 1);
+    expect(visibleFuncs.every((f) => f.friendlyName !== toExclude), true);
+  });
+
+  test('sketcherFunctions retains excluded entries', async () => {
+    const funcs = DG.Func.find({meta: {role: DG.FUNC_TYPES.MOLECULE_SKETCHER}});
+    if (funcs.length < 2) return;
+    const toExclude = funcs[0].friendlyName;
+    DG.chem.excludedSketchers = [toExclude];
+    chem.currentSketcherType = funcs[1].friendlyName;
+    const s = new Sketcher();
+    const d = ui.dialog().add(s).show();
+    await awaitCheck(() => s.sketcher !== null, undefined, 5000);
+    expect(s.sketcherFunctions.some((f) => f.friendlyName === toExclude), true);
+    d.close();
+  });
+
+  test('fallback when current type excluded', async () => {
+    const funcs = DG.Func.find({meta: {role: DG.FUNC_TYPES.MOLECULE_SKETCHER}});
+    if (funcs.length < 2) return;
+    const toExclude = funcs[0].friendlyName;
+    const expected = funcs[1].friendlyName;
+    DG.chem.excludedSketchers = [toExclude];
+    DG.chem.currentSketcherType = toExclude;
+    const available = funcs.find((f) => !DG.chem.excludedSketchers.includes(f.friendlyName));
+    expect(available !== undefined, true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an `ExcludedSketchers` package property that allows administrators to hide specific sketcher options from the Sketcher's `☰` selection menu without uninstalling them. Excluded sketchers remain available programmatically.

## Changes

### package.json
- Adds `ExcludedSketchers` string property (comma-separated list, nullable, default empty).

### package.ts
- On init, reads `ExcludedSketchers`, splits/trims to build `DG.chem.excludedSketchers`.
- If the user's stored sketcher is in the excluded list, automatically falls back to the first available non-excluded sketcher.

### chem.ts
- Exports `excludedSketchers: string[]` on the `chem` namespace.
- Filters excluded sketchers out of the `☰` menu items.

### README.md
- Documents the new property: how to set it, valid names, and fallback behaviour.

### sketcher-tests.ts
- Adds tests covering exclusion filtering and fallback sketcher selection.

## How to configure

1. Go to **Manage > Packages > Chem > Context Pane > Settings**.
2. Set **ExcludedSketchers** to a comma-separated list of names (e.g. `OpenChemLib, ChemDraw`).

Valid names: `OpenChemLib`, `Ketcher`, `Marvin`, `ChemDraw` (case-sensitive).