### PR TITLE
[ticket] GROK-8022: Samples: Load EfficientNet-B0 weights from Keras' maintained applications module instead of the dead qubvel URL

### DIFF
--- a/packages/Samples/CHANGELOG.md
+++ b/packages/Samples/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* GROK-8022: Load EfficientNet-B0 weights from Keras' maintained applications module instead of the dead qubvel URL
 * Scripts: Migrated nodejs sample scripts to the js-api (`grok`/`DG` globals) following the nodejs script runtime change
 
 * Docker: Raised conda env to Python 3.10 and added security floors (setuptools/wheel/urllib3/pyarrow/jaraco.context/brotli), plus removed stale ensurepip/pkgs-cache copies (VEX)

--- a/packages/Samples/scripts/python/image_classification.py
+++ b/packages/Samples/scripts/python/image_classification.py
@@ -9,9 +9,10 @@
 
 import numpy as np
 from skimage.io import imread
-from efficientnet.keras import EfficientNetB0
+from keras.applications.efficientnet import EfficientNetB0, preprocess_input
 from keras.applications.imagenet_utils import decode_predictions
-from efficientnet.keras import center_crop_and_resize, preprocess_input
+# qubvel supplies only the crop helper: its weights URL is dead and its preprocessing double-normalizes Keras' input
+from efficientnet.keras import center_crop_and_resize
 
 image = imread(file)
 model = EfficientNetB0(weights='imagenet')


### PR DESCRIPTION
> ⚠️ **Auto-fix needs human review.** The verify phase confirmed no error fired in the parts of the recipe it could replay, but it did not reach the exact post-fix state of the original reproduction (session glitch / redirect / UI change after fix). Please replay the bug recipe manually before merging.

The Image Classification file panel failed with a 404: EfficientNetB0 came from the abandoned qubvel package, whose ImageNet weights live in a GitHub release deleted upstream.

It now loads the same EfficientNet-B0 from Keras' built-in applications module on the maintained CDN; preprocess_input moves with it, since Keras normalizes inside the model and qubvel's torch-mode preprocessing would double-normalize.

Grayscale and RGBA PNG inputs remain unhandled, as they were before.

---
**Diff:** +4/-2 · 2 files

**Verified:** recipe partially replayed on the patched build — no error fired in the covered part (see note above)

**Full analysis:** [GROK-8022](https://reddata.atlassian.net/browse/GROK-8022)


[GROK-8022]: https://reddata.atlassian.net/browse/GROK-8022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ