### PR TITLE
[ticket] GROK-20719: Bio: Correct four mismatched Bio menu/dialog strings at their declaration sites

### DIFF
--- a/packages/Bio/CHANGELOG.md
+++ b/packages/Bio/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* GROK-20719: Correct four mismatched Bio menu/dialog strings at their declaration sites
 * Flow: Added table-aware twins of the `Bio | Transform` entries, which mutate the input frame and return void (or hand the same frame back) — unusable on a pipeline canvas, where the node shows a bare pass-through arrow instead of a named result: Extract Sequence Region, To Atomic Level Column, Molecules to HELM Column, and Split to Monomers Columns (which returns the per-position monomer columns as a table of their own). All share the original implementation
 * Flow: Added Convert Sequence Notation `(table, sequence, targetNotation{fasta,separator,helm}, separator?) -> column`, wrapping `ISeqHandler.convert()`. Notation conversion previously existed only behind a dialog
 * Flow: Added Tag as Macromolecule `(table, sequence) -> column`, which runs sequence detection on a plain string column. Nothing could tag a column built inside a flow, so every semType-dependent bio function silently no-opped on derived data

--- a/packages/Bio/CLAUDE.md
+++ b/packages/Bio/CLAUDE.md
@@ -57,11 +57,11 @@ Other packages depend on these implementations: **Helm**, **Peptides**, **Biostr
 | `Bio \| Calculate \| Similarity...` | `sequenceSimilarityScoring` | Sum of monomer fingerprint similarities vs reference |
 | `Bio \| Search \| Similarity Search` | `similaritySearchTopMenu` | K-nearest neighbor sequence search |
 | `Bio \| Search \| Diversity Search` | `diversitySearchTopMenu` | Maximally diverse subset selection |
-| `Bio \| Search \| Subsequence Search ...` | `SubsequenceSearchTopMenu` | Substructure filter (regex or RDKit) |
+| `Bio \| Search \| Subsequence Search...` | `SubsequenceSearchTopMenu` | Substructure filter (regex or RDKit) |
 | `Bio \| Manage \| Monomer Libraries` | `manageLibrariesView` | Full monomer library management UI |
 | `Bio \| Manage \| Monomers` | `manageMonomersView` | Individual monomer CRUD editor |
 | `Bio \| Manage \| Match with Monomer Library...` | `matchWithMonomerLibrary` | Matches molecules to library monomers |
-| `Bio \| Annotate \| Apply Numbering Scheme...` | `applyNumberingScheme` | Assigns antibody numbering (IMGT/Kabat/Chothia/AHo) via any registered engine |
+| `Bio \| Annotate \| Apply Numbering Scheme...` | `applyNumberingScheme` | Assigns antibody numbering (IMGT/Kabat) via any registered engine |
 | `Bio \| Annotate \| Scan Liabilities...` | `scanLiabilities` | Scans macromolecule sequences for deamidation / oxidation / other liabilities |
 | `Bio \| Annotate \| Manage Annotations...` | `manageAnnotations` | View and manage sequence annotations on macromolecule columns |
 

--- a/packages/Bio/playwright/bio-manage-libraries-crud.test.ts
+++ b/packages/Bio/playwright/bio-manage-libraries-crud.test.ts
@@ -284,9 +284,9 @@ test('Bio Manage Monomer Libraries CRUD (app + tree browser + Monomers view + Ma
         const leaf = await wait('[name="div-Bio---Manage---Match-with-Monomer-Library..."]');
         if (leaf) leaf.click();
       });
-      await page.locator('[name="dialog-matchWithMonomerLibrary"]').waitFor({state: 'visible', timeout: 30_000});
+      await page.locator('[name="dialog-Match-with-Monomer-Library"]').waitFor({state: 'visible', timeout: 30_000});
       const result = await page.evaluate(() => {
-        const dialog = document.querySelector('[name="dialog-matchWithMonomerLibrary"]');
+        const dialog = document.querySelector('[name="dialog-Match-with-Monomer-Library"]');
         const hostTable = dialog?.querySelector('[name="input-host-Table"]') ?? null;
         const hostMolecules = dialog?.querySelector('[name="input-host-Molecules"]') ?? null;
         const hostPolymer = dialog?.querySelector('[name="input-host-Polymer-Type"]') ?? null;

--- a/packages/Bio/playwright/search.test.ts
+++ b/packages/Bio/playwright/search.test.ts
@@ -97,7 +97,7 @@ test('Bio Subsequence Search filter and reset on filter_FASTA', async ({page}) =
       (document.querySelector('[name="div-Bio"]') as HTMLElement).click();
       (await waitEl('[name="div-Bio---Search"]'))
         .dispatchEvent(new MouseEvent('mouseenter', {bubbles: true}));
-      (await waitEl('[name="div-Bio---Search---Subsequence-Search-..."]')).click();
+      (await waitEl('[name="div-Bio---Search---Subsequence-Search..."]')).click();
     });
     await page.locator('[name="viewer-Filters"] input[placeholder="Substructure"]')
       .waitFor({timeout: 30_000});

--- a/packages/Bio/src/package-api.ts
+++ b/packages/Bio/src/package-api.ts
@@ -158,7 +158,7 @@ export namespace funcs {
   }
 
   /**
-  Assigns antibody numbering (IMGT/Kabat/Chothia/AHo)
+  Assigns antibody numbering (IMGT/Kabat)
   */
   export async function applyNumberingScheme(): Promise<void> {
     return await grok.functions.call('Bio:ApplyNumberingScheme', {});
@@ -341,8 +341,8 @@ export namespace funcs {
   /**
   Extracts a sub-region of each sequence between the given positions into a new column.
   */
-  export async function extractRegion(table: DG.DataFrame , sequence: DG.Column , start: string | null, end: string | null): Promise<DG.Column> {
-    return await grok.functions.call('Bio:ExtractRegion', { table, sequence, start, end });
+  export async function extractRegion(table: DG.DataFrame , sequence: DG.Column , start: string | null, end: string | null, name?: string ): Promise<DG.Column> {
+    return await grok.functions.call('Bio:ExtractRegion', { table, sequence, start, end, name });
   }
 
   /**

--- a/packages/Bio/src/package.g.ts
+++ b/packages/Bio/src/package.g.ts
@@ -27,6 +27,7 @@ export async function standardiseMonomerLibrary(library: string) : Promise<strin
   return await PackageFunctions.standardiseMonomerLibrary(library);
 }
 
+//name: Match with Monomer Library
 //description: Matches molecules in a column with monomers from the selected library(s)
 //input: dataframe table 
 //input: column molecules { semType: Molecule }
@@ -228,7 +229,7 @@ export async function getRegionTopMenu(table: DG.DataFrame, sequence: DG.Column,
 }
 
 //name: Apply Numbering Scheme
-//description: Assigns antibody numbering (IMGT/Kabat/Chothia/AHo)
+//description: Assigns antibody numbering (IMGT/Kabat)
 //top-menu: Bio | Annotate | Apply Numbering Scheme...
 export function applyNumberingScheme() : void {
   PackageFunctions.applyNumberingScheme();
@@ -674,7 +675,7 @@ export function searchSubsequenceEditor(call: DG.FuncCall) : void {
 
 //name: Subsequence Search
 //input: column macromolecules 
-//top-menu: Bio | Search | Subsequence Search ...
+//top-menu: Bio | Search | Subsequence Search...
 //editor: Bio:SearchSubsequenceEditor
 export function SubsequenceSearchTopMenu(macromolecules: DG.Column) : void {
   PackageFunctions.SubsequenceSearchTopMenu(macromolecules);

--- a/packages/Bio/src/package.ts
+++ b/packages/Bio/src/package.ts
@@ -177,7 +177,7 @@ export class PackageFunctions {
     return await standardizeMonomerLibrary(library);
   }
 
-  @grok.decorators.func({'top-menu': 'Bio | Manage | Match with Monomer Library...', description: 'Matches molecules in a column with monomers from the selected library(s)',})
+  @grok.decorators.func({name: 'Match with Monomer Library', 'top-menu': 'Bio | Manage | Match with Monomer Library...', description: 'Matches molecules in a column with monomers from the selected library(s)',})
   static async matchWithMonomerLibrary(table: DG.DataFrame,
       @grok.decorators.param({type: 'column', options: {semType: 'Molecule'}})molecules: DG.Column,
       @grok.decorators.param({type: 'string', options: {choices: ['PEPTIDE', 'RNA', 'CHEM'], initialValue: 'PEPTIDE', caption: 'Polymer Type'}})polymerType: PolymerType = 'PEPTIDE') {
@@ -504,7 +504,7 @@ export class PackageFunctions {
 
   @grok.decorators.func({
     name: 'Apply Numbering Scheme',
-    description: 'Assigns antibody numbering (IMGT/Kabat/Chothia/AHo)',
+    description: 'Assigns antibody numbering (IMGT/Kabat)',
     'top-menu': 'Bio | Annotate | Apply Numbering Scheme...',
   })
   static applyNumberingScheme(): void {
@@ -1487,7 +1487,7 @@ export class PackageFunctions {
 
   @grok.decorators.func({
     name: 'Subsequence Search',
-    'top-menu': 'Bio | Search | Subsequence Search ...',
+    'top-menu': 'Bio | Search | Subsequence Search...',
     editor: 'Bio:SearchSubsequenceEditor'
   })
   static SubsequenceSearchTopMenu(macromolecules: DG.Column): void {

--- a/packages/Bio/src/substructure-search/substructure-search.ts
+++ b/packages/Bio/src/substructure-search/substructure-search.ts
@@ -88,7 +88,7 @@ export class SubstructureSearchDialog {
     this.separator = this.col.getTag(bioTAGS.separator);
     this.updateInputs();
 
-    this.dialog = ui.dialog('Substructure Search')
+    this.dialog = ui.dialog('Subsequence Search')
       .add(ui.divV([
         ui.divText(`Notation: ${this.units}`, 'notation-text'),
         this.inputsDiv,


### PR DESCRIPTION
> ⚠️ **Code review unresolved.** The automated code-review gate flagged quality concerns the fix phase could not resolve within its revision budget. Review the fix carefully before merging:
>
> - `packages/UsageAnalysis/files/TestTrack/Bio/search-spec.ts:83` — This diff renames two automation hooks — `div-Bio---Search---Subsequence-Search-...` -> `div-Bio---Search---Subsequence-Search...` (from the `top-menu` label change at package.ts:1490) and `dialog-matchWithMonomerLibrary` -> `dialog-Match-with-Monomer-Library` (from the new `name:` at package.ts:180). I verified the derivation against `annotate()` in core/client/d4/lib/src/common/html_utils.dart:458-462 (it maps space and `|` to `-` and leaves `.` alone), so both new values are right, and the two Bio playwright tests were correctly updated. But three executable specs in the same repo still hardcode the old values and are the complete remaining consumer set (grep across /workspace and /workspace/public finds no others): `search-spec.ts:83` does `(document.querySelector('[name="div-Bio---Search---Subsequence-Search-..."]') as HTMLElement).click()` — unguarded, so it throws a TypeError on null; `bio-manage-libraries-crud-spec.ts:277,279` waits 30s on `[name="dialog-matchWithMonomerLibrary"]` and then reads a null dialog; `helm-bio-menu-integration-spec.ts:44` carries the old leaf inside its menu sweep. The fix author disclosed this and argued a pipeline scope gate forbids editing UsageAnalysis — that is a harness constraint, not a reason the breakage is acceptable in the merged change.

Four Bio menu strings contradicted the entries they label: a missing friendly name left a dialog headed with the raw identifier, the Subsequence Search dialog was titled 'Substructure Search', its label had a stray space, and the numbering tooltip promised four schemes while two ship.

Each is corrected at its declaration; Bio's Playwright specs follow the two renamed automation names.

Three UsageAnalysis TestTrack specs hardcode the old names and need the same swaps landed with this change.

---
**Diff:** +16/-14 · 8 files

**Verified:** reproduction recipe replayed on the patched build — the original error no longer fires

**Full analysis:** [GROK-20719](https://reddata.atlassian.net/browse/GROK-20719)


[GROK-20719]: https://reddata.atlassian.net/browse/GROK-20719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ