### PR TITLE
Playwright: Bio top-menu suite

### DIFF
--- a/packages/Bio/playwright/bio-annotate-dialogs.test.ts
+++ b/packages/Bio/playwright/bio-annotate-dialogs.test.ts
@@ -1,0 +1,200 @@
+/* ---
+sub_features_covered: [bio.analyze.compare-sequences, bio.analyze.compare-sequences.top-menu, bio.annotate.manage-annotations, bio.annotate.manage-annotations.top-menu, bio.annotate.scan-liabilities, bio.annotate.scan-liabilities.rules, bio.annotate.scan-liabilities.top-menu]
+--- */
+import {test, expect, Page} from '@playwright/test';
+import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '@datagrok-libraries/test/src/playwright/spec-login';
+import {finishSpec} from '@datagrok-libraries/test/src/playwright/viewers';
+import {openBioMenu, dialog, cancelDialog, setChoice, setText, setBool, loadBioTable} from './helpers';
+
+test.use(specTestOptions);
+
+// Antibody variable regions: two Macromolecule columns in one notation and alphabet, so the pair
+// drives Compare Sequences, and real liability motifs (NG/NS/M/NxS) make the scanner produce hits.
+const ANTIBODIES = 'System:AppData/Bio/samples/antibodies.csv';
+const ROWS = 40;
+
+const colNames = (page: Page): Promise<string[]> =>
+  page.evaluate(() => grok.shell.tv.dataFrame.columns.names());
+
+// Clearing the last annotation leaves the tag as an empty string, not '[]'.
+const storedAnnotations = (page: Page): Promise<number> => page.evaluate(() => {
+  const tag = grok.shell.tv.dataFrame.col('AntibodyHC')!.getTag('.annotations');
+  return tag ? JSON.parse(tag).length : 0;
+});
+
+test('Bio Analyze | Compare sequences — defaults, custom result name, identical-column guard', async ({page}) => {
+  test.setTimeout(300_000);
+  stepErrors.length = 0;
+  await loginToDatagrok(page);
+  await loadBioTable(page, ANTIBODIES, ROWS, 'antibodies');
+
+  await softStep('Compare sequences with defaults appends an auto-named difference column', async () => {
+    const before = await colNames(page);
+    await openBioMenu(page, 'Analyze', 'Compare-sequences...');
+    const dlg = dialog(page, 'Compare-Sequences');
+    await dlg.waitFor({timeout: 60_000});
+    expect((await dlg.locator('.d4-dialog-title').textContent())?.trim()).toContain('Compare Sequences');
+    // Both pickers defaulting to one column would make OK fail by construction.
+    const c1 = await dlg.locator('[name="input-host-Sequence-column-1"] select').inputValue();
+    const c2 = await dlg.locator('[name="input-host-Sequence-column-2"] select').inputValue();
+    expect(c1).not.toBe(c2);
+    await dlg.locator('[name="button-OK"]').click();
+    await dlg.waitFor({state: 'detached', timeout: 30_000});
+
+    await page.waitForFunction((n) => grok.shell.tv.dataFrame.columns.length > n, before.length,
+      {timeout: 60_000});
+    const added = (await colNames(page)).filter((n) => !before.includes(n));
+    expect(added).toEqual([c1 + ' vs ' + c2]);
+    const renderer = await page.evaluate((n) =>
+      grok.shell.tv.dataFrame.col(n)!.getTag('cell.renderer'), added[0]);
+    expect(renderer).toBe('MacromoleculeDifference');
+  });
+
+  await softStep('A custom result name and swapped columns are both honoured', async () => {
+    const before = await colNames(page);
+    await openBioMenu(page, 'Analyze', 'Compare-sequences...');
+    const dlg = dialog(page, 'Compare-Sequences');
+    await dlg.waitFor({timeout: 60_000});
+    await setChoice(page, 'Compare-Sequences', 'Sequence-column-1', 'AntibodyLC');
+    await setChoice(page, 'Compare-Sequences', 'Sequence-column-2', 'AntibodyHC');
+    await setText(page, 'Compare-Sequences', 'Result-column-name', 'LC minus HC');
+    await dlg.locator('[name="button-OK"]').click();
+    await dlg.waitFor({state: 'detached', timeout: 30_000});
+
+    await page.waitForFunction((n) => grok.shell.tv.dataFrame.columns.length > n, before.length,
+      {timeout: 60_000});
+    expect((await colNames(page)).filter((n) => !before.includes(n))).toEqual(['LC minus HC']);
+  });
+
+  await softStep('Choosing the same column twice is rejected and adds nothing', async () => {
+    const before = await colNames(page);
+    await page.evaluate(() => {
+      for (const b of Array.from(document.querySelectorAll('.d4-balloon, .grok-balloon-error'))) b.remove();
+    });
+    await openBioMenu(page, 'Analyze', 'Compare-sequences...');
+    const dlg = dialog(page, 'Compare-Sequences');
+    await dlg.waitFor({timeout: 60_000});
+    await setChoice(page, 'Compare-Sequences', 'Sequence-column-2', 'AntibodyHC');
+    await setChoice(page, 'Compare-Sequences', 'Sequence-column-1', 'AntibodyHC');
+    await dlg.locator('[name="button-OK"]').click();
+    await dlg.waitFor({state: 'detached', timeout: 30_000});
+
+    await expect(page.locator('.d4-balloon.error, .grok-balloon-error').first())
+      .toContainText(/distinct columns/i, {timeout: 30_000});
+    expect(await colNames(page)).toEqual(before);
+  });
+
+  finishSpec();
+});
+
+test('Bio Annotate | Scan Liabilities — default rules, then a narrowed rule set with a summary column',
+  async ({page}) => {
+    test.setTimeout(300_000);
+    stepErrors.length = 0;
+    await loginToDatagrok(page);
+    await loadBioTable(page, ANTIBODIES, ROWS, 'antibodies');
+
+    let defaultHits = 0;
+    await softStep('Default rule set writes the companion annotation column', async () => {
+      await openBioMenu(page, 'Annotate', 'Scan-Liabilities...');
+      const dlg = dialog(page, 'Scan-Sequence-Liabilities');
+      await dlg.waitFor({timeout: 60_000});
+      // Free Cysteine ships off, everything else on — pin the shipped defaults before changing them.
+      await expect(dlg.locator('[name="input-host-Deamidation-(NG)"] input')).toBeChecked();
+      await expect(dlg.locator('[name="input-host-Free-Cysteine"] input')).not.toBeChecked();
+      await expect(dlg.locator('[name="input-host-Create-annotation-column"] input')).toBeChecked();
+      await expect(dlg.locator('[name="input-host-Create-summary-count-column"] input')).not.toBeChecked();
+      await dlg.locator('[name="button-OK"]').click();
+      await dlg.waitFor({state: 'detached', timeout: 60_000});
+
+      await page.waitForFunction(() => grok.shell.tv.dataFrame.columns.names()
+        .includes('~AntibodyHC_annotations'), null, {timeout: 60_000});
+      defaultHits = await page.evaluate(() => {
+        const col = grok.shell.tv.dataFrame.col('~AntibodyHC_annotations')!;
+        let n = 0;
+        for (let i = 0; i < col.length; i++) {
+          const raw = col.get(i);
+          if (raw) n += JSON.parse(raw).length;
+        }
+        return n;
+      });
+      expect(defaultHits).toBeGreaterThan(0);
+      expect(await colNames(page)).not.toContain('AntibodyHC_liability_count');
+    });
+
+    await softStep('Only the oxidation rules, output switched to the summary count column', async () => {
+      await openBioMenu(page, 'Annotate', 'Scan-Liabilities...');
+      const dlg = dialog(page, 'Scan-Sequence-Liabilities');
+      await dlg.waitFor({timeout: 60_000});
+      for (const rule of ['Deamidation-(NG)', 'Deamidation-(NS)', 'Deamidation-(NA)', 'Deamidation-(ND)',
+        'Deamidation-(NT)', 'Isomerization-(DG)', 'Isomerization-(DS)', 'N-glycosylation'])
+        await setBool(page, 'Scan-Sequence-Liabilities', rule, false);
+      await setBool(page, 'Scan-Sequence-Liabilities', 'Create-annotation-column', false);
+      await setBool(page, 'Scan-Sequence-Liabilities', 'Create-summary-count-column', true);
+      await dlg.locator('[name="button-OK"]').click();
+      await dlg.waitFor({state: 'detached', timeout: 60_000});
+
+      await page.waitForFunction(() => grok.shell.tv.dataFrame.columns.names()
+        .includes('AntibodyHC_liability_count'), null, {timeout: 60_000});
+      const summary = await page.evaluate(() => {
+        const col = grok.shell.tv.dataFrame.col('AntibodyHC_liability_count')!;
+        let total = 0;
+        for (let i = 0; i < col.length; i++) total += col.get(i) ?? 0;
+        return {type: col.type, total};
+      });
+      expect(summary.type).toBe('int');
+      // Two oxidation rules out of ten can only match a subset of what the full set matched.
+      expect(summary.total).toBeGreaterThan(0);
+      expect(summary.total).toBeLessThan(defaultHits);
+    });
+
+    finishSpec();
+  });
+
+test('Bio Annotate | Manage Annotations — lists, deletes and clears the scanned annotations',
+  async ({page}) => {
+    test.setTimeout(300_000);
+    stepErrors.length = 0;
+    await loginToDatagrok(page);
+    await loadBioTable(page, ANTIBODIES, ROWS, 'antibodies');
+
+    await softStep('Seed annotations through Scan Liabilities', async () => {
+      await openBioMenu(page, 'Annotate', 'Scan-Liabilities...');
+      const dlg = dialog(page, 'Scan-Sequence-Liabilities');
+      await dlg.waitFor({timeout: 60_000});
+      await dlg.locator('[name="button-OK"]').click();
+      await dlg.waitFor({state: 'detached', timeout: 60_000});
+      await page.waitForFunction(() => {
+        const tag = grok.shell.tv.dataFrame.col('AntibodyHC')!.getTag('.annotations');
+        return !!tag && JSON.parse(tag).length > 0;
+      }, null, {timeout: 60_000});
+    });
+
+    await softStep('The dialog lists one row per annotation and offers Clear All', async () => {
+      await openBioMenu(page, 'Annotate', 'Manage-Annotations...');
+      const dlg = dialog(page, 'Manage-Annotations');
+      await dlg.waitFor({timeout: 60_000});
+      const stored = await storedAnnotations(page);
+      expect(stored).toBeGreaterThan(0);
+      expect(await dlg.locator('i[class*="fa-trash"]').count()).toBe(stored);
+      expect(await dlg.locator('[name="button-Clear-All"]').count()).toBe(1);
+    });
+
+    await softStep('The trash icon drops exactly one annotation', async () => {
+      const before = await storedAnnotations(page);
+      await dialog(page, 'Manage-Annotations').locator('i[class*="fa-trash"]').first().click();
+      await expect(dialog(page, 'Manage-Annotations').locator('i[class*="fa-trash"]'))
+        .toHaveCount(before - 1, {timeout: 30_000});
+      expect(await storedAnnotations(page)).toBe(before - 1);
+    });
+
+    await softStep('Clear All empties both the list and the column tag', async () => {
+      await dialog(page, 'Manage-Annotations').locator('[name="button-Clear-All"]').click();
+      await expect(dialog(page, 'Manage-Annotations'))
+        .toContainText('No annotations on this column.', {timeout: 30_000});
+      expect(await storedAnnotations(page)).toBe(0);
+    });
+
+    await cancelDialog(page, 'Manage-Annotations');
+    finishSpec();
+  });

--- a/packages/Bio/playwright/bio-annotate-dialogs.test.ts
+++ b/packages/Bio/playwright/bio-annotate-dialogs.test.ts
@@ -45,9 +45,19 @@ test('Bio Analyze | Compare sequences — defaults, custom result name, identica
       {timeout: 60_000});
     const added = (await colNames(page)).filter((n) => !before.includes(n));
     expect(added).toEqual([c1 + ' vs ' + c2]);
-    const renderer = await page.evaluate((n) =>
-      grok.shell.tv.dataFrame.col(n)!.getTag('cell.renderer'), added[0]);
-    expect(renderer).toBe('MacromoleculeDifference');
+    const diff = await page.evaluate((n) => {
+      const df = grok.shell.tv.dataFrame;
+      const col = df.col(n)!;
+      const hc = df.col('AntibodyHC')!;
+      const lc = df.col('AntibodyLC')!;
+      let mismatched = 0;
+      for (let i = 0; i < col.length; i++)
+        if ((col.get(i) ?? '') !== `${hc.get(i)}#${lc.get(i)}`) mismatched++;
+      return {renderer: col.getTag('cell.renderer'), mismatched};
+    }, added[0]);
+    expect(diff.renderer).toBe('MacromoleculeDifference');
+    // The column is the two sources paired per row — that pairing is the whole feature.
+    expect(diff.mismatched).toBe(0);
   });
 
   await softStep('A custom result name and swapped columns are both honoured', async () => {
@@ -120,6 +130,27 @@ test('Bio Annotate | Scan Liabilities — default rules, then a narrowed rule se
       });
       expect(defaultHits).toBeGreaterThan(0);
       expect(await colNames(page)).not.toContain('AntibodyHC_liability_count');
+      // Each hit must point at the motif it claims to have matched, at the position it reports.
+      const misplaced = await page.evaluate(() => {
+        const df = grok.shell.tv.dataFrame;
+        const seq = df.col('AntibodyHC')!;
+        const ann = df.col('~AntibodyHC_annotations')!;
+        let bad = 0;
+        let checked = 0;
+        for (let i = 0; i < ann.length; i++) {
+          const raw = ann.get(i);
+          if (!raw) continue;
+          for (const hit of JSON.parse(raw)) {
+            if (!hit.matchedMonomers) continue;
+            checked++;
+            if ((seq.get(i) ?? '').substr(hit.positionIndex, hit.matchedMonomers.length) !== hit.matchedMonomers)
+              bad++;
+          }
+        }
+        return {bad, checked};
+      });
+      expect(misplaced.checked).toBeGreaterThan(0);
+      expect(misplaced.bad).toBe(0);
     });
 
     await softStep('Only the oxidation rules, output switched to the summary count column', async () => {

--- a/packages/Bio/playwright/bio-top-menu-settings.test.ts
+++ b/packages/Bio/playwright/bio-top-menu-settings.test.ts
@@ -48,6 +48,19 @@ test('Bio top menu on antibodies — Composition, numbering scheme and region ru
         return wl?.props?.sequenceColumnName ?? wl?.sequenceColumnName ?? null;
       });
       expect(boundTo).toBe('AntibodyLC');
+      // A docked-but-blank WebLogo would still satisfy the binding check, so prove it painted.
+      const painted = await page.evaluate(async () => {
+        for (let i = 0; i < 60; i++) {
+          const cnv = document.querySelector('[name="viewer-WebLogo"] canvas') as HTMLCanvasElement | null;
+          if (cnv && cnv.width > 0) {
+            const px = cnv.getContext('2d')!.getImageData(0, 0, cnv.width, cnv.height).data;
+            for (let j = 3; j < px.length; j += 4) if (px[j] !== 0) return true;
+          }
+          await new Promise((r) => setTimeout(r, 500));
+        }
+        return false;
+      });
+      expect(painted).toBe(true);
       await closeExtraViewers(page);
     });
 
@@ -64,9 +77,19 @@ test('Bio top menu on antibodies — Composition, numbering scheme and region ru
         });
         const aligned = added.find((n) => n.includes('aligned'));
         expect(aligned).toBeTruthy();
-        const scheme = await page.evaluate((n) =>
-          grok.shell.tv.dataFrame.col(n)!.getTag('.numberingScheme'), aligned!);
-        expect(scheme).toBe('kabat');
+        const alignedCol = await page.evaluate((n) => {
+          const col = grok.shell.tv.dataFrame.col(n)!;
+          const vals: string[] = [];
+          for (let i = 0; i < col.length; i++) vals.push(col.get(i) ?? '');
+          const filled = vals.filter((v) => v.replace(/-/g, '').length > 0);
+          return {scheme: col.getTag('.numberingScheme'), positionNames: col.getTag('.positionNames') ?? '',
+            lengths: Array.from(new Set(vals.map((v) => v.length))), filled: filled.length, rows: vals.length};
+        }, aligned!);
+        expect(alignedCol.scheme).toBe('kabat');
+        // The point of an aligned column: every row padded to one width, and actually numbered.
+        expect(alignedCol.lengths).toHaveLength(1);
+        expect(alignedCol.filled).toBe(alignedCol.rows);
+        expect(alignedCol.positionNames.split(',').length).toBeGreaterThan(10);
       });
 
     await softStep('Extract Region honours a custom range and column name', async () => {
@@ -90,6 +113,14 @@ test('Bio top menu on antibodies — Composition, numbering scheme and region ru
       // Positions 20..60 inclusive — sequences shorter than 60 residues yield a shorter slice.
       expect(Math.max(...lengths)).toBe(41);
       expect(Math.min(...lengths)).toBeGreaterThan(0);
+      const slicesMatchSource = await page.evaluate(() => {
+        const src = grok.shell.tv.dataFrame.col('AntibodyHC')!;
+        const reg = grok.shell.tv.dataFrame.col('HC 20-60')!;
+        for (let i = 0; i < reg.length; i++)
+          if ((reg.get(i) ?? '') !== (src.get(i) ?? '').substring(19, 60)) return i;
+        return -1;
+      });
+      expect(slicesMatchSource).toBe(-1);
     });
 
     finishSpec();
@@ -115,7 +146,17 @@ test('Bio top menu on peptides — scoring references, HELM conversion and atomi
           await dlg.waitFor({state: 'detached', timeout: 60_000});
         });
         expect(added).toHaveLength(1);
-        expect(await page.evaluate((n) => grok.shell.tv.dataFrame.col(n)!.get(0), added[0])).toBe(1);
+        const scores = await page.evaluate((n) => {
+          const col = grok.shell.tv.dataFrame.col(n)!;
+          const vals: number[] = [];
+          for (let i = 0; i < col.length; i++) vals.push(col.get(i));
+          return {type: col.type, first: vals[0], min: Math.min(...vals), max: Math.max(...vals),
+            nulls: vals.filter((v) => v == null || Number.isNaN(v)).length};
+        }, added[0]);
+        expect(scores.first).toBe(1);
+        expect(scores.nulls).toBe(0);
+        expect(scores.min).toBeGreaterThanOrEqual(0);
+        expect(scores.max).toBeLessThanOrEqual(1);
       });
 
     await softStep('Similarity against the same reference peaks on the reference row', async () => {
@@ -132,9 +173,13 @@ test('Bio top menu on peptides — scoring references, HELM conversion and atomi
         const col = grok.shell.tv.dataFrame.col(n)!;
         const vals: number[] = [];
         for (let i = 0; i < col.length; i++) vals.push(col.get(i));
-        return {first: vals[0], max: Math.max(...vals)};
+        return {first: vals[0], min: Math.min(...vals), max: Math.max(...vals),
+          nulls: vals.filter((v) => v == null || Number.isNaN(v)).length};
       }, added[0]);
       expect(stats.first).toBe(stats.max);
+      expect(stats.nulls).toBe(0);
+      expect(stats.min).toBeGreaterThanOrEqual(0);
+      expect(stats.max).toBeLessThanOrEqual(1);
     });
 
     await softStep('Convert Sequence Notation to HELM instead of the default separator', async () => {
@@ -150,11 +195,19 @@ test('Bio top menu on peptides — scoring references, HELM conversion and atomi
       expect(added).toHaveLength(1);
       const meta = await page.evaluate((n) => {
         const col = grok.shell.tv.dataFrame.col(n)!;
-        return {units: col.meta.units, semType: col.semType, sample: col.get(0)};
+        const src = grok.shell.tv.dataFrame.col('sequence')!;
+        const vals: string[] = [];
+        for (let i = 0; i < col.length; i++) vals.push(col.get(i) ?? '');
+        return {units: col.meta.units, semType: col.semType, sample: vals[0],
+          allHelm: vals.every((v) => v.startsWith('PEPTIDE1{') && v.includes('}$')),
+          monomers: vals[0].substring(vals[0].indexOf('{') + 1, vals[0].indexOf('}')).split('.').length,
+          srcLength: (src.get(0) ?? '').length};
       }, added[0]);
       expect(meta.units).toBe('helm');
       expect(meta.semType).toBe('Macromolecule');
-      expect(meta.sample).toContain('PEPTIDE1{');
+      expect(meta.allHelm).toBe(true);
+      // One HELM monomer per residue of the source peptide.
+      expect(meta.monomers).toBe(meta.srcLength);
     });
 
     await softStep('To Atomic Level with monomer highlighting on and non-linear off', async () => {
@@ -167,9 +220,20 @@ test('Bio top menu on peptides — scoring references, HELM conversion and atomi
         await dlg.locator('[name="button-OK"]').click();
         await dlg.waitFor({state: 'detached', timeout: 60_000});
       });
-      const semTypes = await page.evaluate((names) => names
-        .map((n: string) => grok.shell.tv.dataFrame.col(n)!.semType), added);
-      expect(semTypes).toContain('Molecule');
+      const mol = await page.evaluate((names) => {
+        const cols = names.map((n: string) => grok.shell.tv.dataFrame.col(n)!);
+        const molCol = cols.find((c: any) => c.semType === 'Molecule');
+        return molCol ? {
+          // Set from the Highlight monomers checkbox — proves the changed setting reached the run.
+          highlight: molCol.getTag('.sequence-src-highlight-monomers'),
+          molblock: (molCol.get(0) ?? '').slice(0, 200),
+          empty: (() => { let n = 0; for (let i = 0; i < molCol.length; i++) if (!molCol.get(i)) n++; return n; })(),
+        } : null;
+      }, added);
+      expect(mol).not.toBeNull();
+      expect(mol!.highlight).toBe('true');
+      expect(mol!.molblock).toContain('V3000');
+      expect(mol!.empty).toBe(0);
     });
 
     finishSpec();

--- a/packages/Bio/playwright/bio-top-menu-settings.test.ts
+++ b/packages/Bio/playwright/bio-top-menu-settings.test.ts
@@ -1,0 +1,176 @@
+/* ---
+sub_features_covered: [bio.analyze.composition.column-choice, bio.annotate.numbering-scheme.kabat, bio.calculate.get-region.custom-range, bio.calculate.identity.reference, bio.calculate.similarity.reference, bio.transform.convert-notation.helm, bio.transform.to-atomic-level.options]
+--- */
+import {test, expect, Page} from '@playwright/test';
+import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '@datagrok-libraries/test/src/playwright/spec-login';
+import {finishSpec} from '@datagrok-libraries/test/src/playwright/viewers';
+import {openBioMenu, dialog, setChoice, setText, setBool, loadBioTable, closeExtraViewers} from './helpers';
+
+test.use(specTestOptions);
+
+// Every menu entry below is already exercised with its defaults elsewhere in this suite; here each
+// one runs with a changed setting, so a setting that is read but never applied shows up.
+const ANTIBODIES = 'System:AppData/Bio/samples/antibodies.csv';
+const PEPTIDES = 'System:AppData/Bio/samples/FASTA_PT_activity.csv';
+
+const colNames = (page: Page): Promise<string[]> =>
+  page.evaluate(() => grok.shell.tv.dataFrame.columns.names());
+
+/** Runs `body` and returns the columns it appended to the table. */
+async function addedColumns(page: Page, body: () => Promise<void>): Promise<string[]> {
+  const before = await colNames(page);
+  await body();
+  await page.waitForFunction((n) => grok.shell.tv.dataFrame.columns.length > n, before.length,
+    {timeout: 180_000});
+  return (await colNames(page)).filter((n) => !before.includes(n));
+}
+
+test('Bio top menu on antibodies — Composition, numbering scheme and region run with changed settings',
+  async ({page}) => {
+    test.setTimeout(600_000);
+    stepErrors.length = 0;
+    await loginToDatagrok(page);
+    await loadBioTable(page, ANTIBODIES, 40, 'antibodies');
+
+    await softStep('Composition on the non-default column docks a WebLogo bound to that column', async () => {
+      await openBioMenu(page, 'Analyze', 'Composition');
+      const dlg = dialog(page, 'Composition-Analysis');
+      await dlg.waitFor({timeout: 60_000});
+      await setChoice(page, 'Composition-Analysis', 'Column', 'AntibodyLC');
+      await dlg.locator('[name="button-OK"]').click();
+      await dlg.waitFor({state: 'detached', timeout: 30_000});
+
+      await page.waitForFunction(() => Array.from(((grok.shell.tv as any)?.viewers ?? []) as any[])
+        .some((v: any) => v.type === 'WebLogo'), null, {timeout: 120_000});
+      const boundTo = await page.evaluate(() => {
+        const wl = Array.from(((grok.shell.tv as any)?.viewers ?? []) as any[])
+          .find((v: any) => v.type === 'WebLogo');
+        return wl?.props?.sequenceColumnName ?? wl?.sequenceColumnName ?? null;
+      });
+      expect(boundTo).toBe('AntibodyLC');
+      await closeExtraViewers(page);
+    });
+
+    await softStep('Apply Numbering Scheme with Kabat tags the result as Kabat, not the default IMGT',
+      async () => {
+        const added = await addedColumns(page, async () => {
+          await openBioMenu(page, 'Annotate', 'Apply-Numbering-Scheme...');
+          const dlg = dialog(page, 'Apply-Antibody-Numbering');
+          await dlg.waitFor({timeout: 60_000});
+          expect(await dlg.locator('[name="input-host-Scheme"] select').inputValue()).toBe('imgt');
+          await setChoice(page, 'Apply-Antibody-Numbering', 'Scheme', 'kabat');
+          await dlg.locator('[name="button-OK"]').click();
+          await dlg.waitFor({state: 'detached', timeout: 60_000});
+        });
+        const aligned = added.find((n) => n.includes('aligned'));
+        expect(aligned).toBeTruthy();
+        const scheme = await page.evaluate((n) =>
+          grok.shell.tv.dataFrame.col(n)!.getTag('.numberingScheme'), aligned!);
+        expect(scheme).toBe('kabat');
+      });
+
+    await softStep('Extract Region honours a custom range and column name', async () => {
+      const added = await addedColumns(page, async () => {
+        await openBioMenu(page, 'Calculate', 'Extract-Region...');
+        const dlg = dialog(page, 'Get-Sequence-Region');
+        await dlg.waitFor({timeout: 60_000});
+        await setChoice(page, 'Get-Sequence-Region', 'Start', '20');
+        await setChoice(page, 'Get-Sequence-Region', 'End', '60');
+        await setText(page, 'Get-Sequence-Region', 'Column-name', 'HC 20-60');
+        await dlg.locator('[name="button-OK"]').click();
+        await dlg.waitFor({state: 'detached', timeout: 60_000});
+      });
+      expect(added).toContain('HC 20-60');
+      const lengths = await page.evaluate(() => {
+        const col = grok.shell.tv.dataFrame.col('HC 20-60')!;
+        const out: number[] = [];
+        for (let i = 0; i < col.length; i++) out.push((col.get(i) ?? '').length);
+        return out;
+      });
+      // Positions 20..60 inclusive — sequences shorter than 60 residues yield a shorter slice.
+      expect(Math.max(...lengths)).toBe(41);
+      expect(Math.min(...lengths)).toBeGreaterThan(0);
+    });
+
+    finishSpec();
+  });
+
+test('Bio top menu on peptides — scoring references, HELM conversion and atomic-level options',
+  async ({page}) => {
+    test.setTimeout(600_000);
+    stepErrors.length = 0;
+    await loginToDatagrok(page);
+    await loadBioTable(page, PEPTIDES, 20, 'peptides');
+
+    const reference = await page.evaluate(() => grok.shell.tv.dataFrame.col('sequence')!.get(0)!);
+
+    await softStep('Identity against an explicit reference scores that very row as a perfect match',
+      async () => {
+        const added = await addedColumns(page, async () => {
+          await openBioMenu(page, 'Calculate', 'Identity...');
+          const dlg = dialog(page, 'Identity');
+          await dlg.waitFor({timeout: 60_000});
+          await setText(page, 'Identity', 'Reference', reference);
+          await dlg.locator('[name="button-OK"]').click();
+          await dlg.waitFor({state: 'detached', timeout: 60_000});
+        });
+        expect(added).toHaveLength(1);
+        expect(await page.evaluate((n) => grok.shell.tv.dataFrame.col(n)!.get(0), added[0])).toBe(1);
+      });
+
+    await softStep('Similarity against the same reference peaks on the reference row', async () => {
+      const added = await addedColumns(page, async () => {
+        await openBioMenu(page, 'Calculate', 'Similarity...');
+        const dlg = dialog(page, 'Similarity');
+        await dlg.waitFor({timeout: 60_000});
+        await setText(page, 'Similarity', 'Reference', reference);
+        await dlg.locator('[name="button-OK"]').click();
+        await dlg.waitFor({state: 'detached', timeout: 60_000});
+      });
+      expect(added).toHaveLength(1);
+      const stats = await page.evaluate((n) => {
+        const col = grok.shell.tv.dataFrame.col(n)!;
+        const vals: number[] = [];
+        for (let i = 0; i < col.length; i++) vals.push(col.get(i));
+        return {first: vals[0], max: Math.max(...vals)};
+      }, added[0]);
+      expect(stats.first).toBe(stats.max);
+    });
+
+    await softStep('Convert Sequence Notation to HELM instead of the default separator', async () => {
+      const added = await addedColumns(page, async () => {
+        await openBioMenu(page, 'Transform', 'Convert-Sequence-Notation...');
+        const dlg = dialog(page, 'Convert-Sequence-Notation');
+        await dlg.waitFor({timeout: 60_000});
+        expect(await dlg.locator('[name="input-host-Convert-to"] select').inputValue()).toBe('separator');
+        await setChoice(page, 'Convert-Sequence-Notation', 'Convert-to', 'helm');
+        await dlg.locator('[name="button-OK"]').click();
+        await dlg.waitFor({state: 'detached', timeout: 60_000});
+      });
+      expect(added).toHaveLength(1);
+      const meta = await page.evaluate((n) => {
+        const col = grok.shell.tv.dataFrame.col(n)!;
+        return {units: col.meta.units, semType: col.semType, sample: col.get(0)};
+      }, added[0]);
+      expect(meta.units).toBe('helm');
+      expect(meta.semType).toBe('Macromolecule');
+      expect(meta.sample).toContain('PEPTIDE1{');
+    });
+
+    await softStep('To Atomic Level with monomer highlighting on and non-linear off', async () => {
+      const added = await addedColumns(page, async () => {
+        await openBioMenu(page, 'Transform', 'To-Atomic-Level...');
+        const dlg = dialog(page, 'To-Atomic-Level');
+        await dlg.waitFor({timeout: 60_000});
+        await setBool(page, 'To-Atomic-Level', 'Non-linear', false);
+        await setBool(page, 'To-Atomic-Level', 'Highlight-monomers', true);
+        await dlg.locator('[name="button-OK"]').click();
+        await dlg.waitFor({state: 'detached', timeout: 60_000});
+      });
+      const semTypes = await page.evaluate((names) => names
+        .map((n: string) => grok.shell.tv.dataFrame.col(n)!.semType), added);
+      expect(semTypes).toContain('Molecule');
+    });
+
+    finishSpec();
+  });

--- a/packages/Bio/playwright/bio-top-menu-sweep.test.ts
+++ b/packages/Bio/playwright/bio-top-menu-sweep.test.ts
@@ -4,7 +4,7 @@ sub_features_covered: [bio.analyze.activity-cliffs.top-menu, bio.analyze.compare
 import {test, expect, Page} from '@playwright/test';
 import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '@datagrok-libraries/test/src/playwright/spec-login';
 import {finishSpec} from '@datagrok-libraries/test/src/playwright/viewers';
-import {openBioGroup, openBioMenu, dialog, cancelDialog, loadBioTable} from './helpers';
+import {openBioGroup, openBioMenu, dialog, cancelDialog, loadBioTable, closeExtraViewers} from './helpers';
 
 test.use(specTestOptions);
 
@@ -12,14 +12,16 @@ const ANTIBODIES = 'System:AppData/Bio/samples/antibodies.csv';
 const TABLE = 'antibodies';
 const ROWS = 40;
 
-/** What a Bio top-menu leaf is expected to produce. Exactly one of dialog/viewer/view is set —
- * the dialog `name` attribute is the function's friendly name, which is not always the menu label. */
+/** What a Bio top-menu leaf is expected to produce. Exactly one of dialog/viewer/view/filter is
+ * set — the dialog `name` attribute is the function's friendly name, which is not always the menu
+ * label. */
 interface Leaf {
   group: string;
   leaf: string;
   dialog?: string;
   viewer?: string;
   view?: string;
+  filter?: boolean;
 }
 
 const BIO_LEAVES: Leaf[] = [
@@ -43,7 +45,9 @@ const BIO_LEAVES: Leaf[] = [
   {group: 'Manage', leaf: 'Monomers', view: 'Manage Monomers'},
   {group: 'Search', leaf: 'Similarity-Search', viewer: 'Sequence Similarity Search'},
   {group: 'Search', leaf: 'Diversity-Search', viewer: 'Sequence Diversity Search'},
-  {group: 'Search', leaf: 'Subsequence-Search-...', dialog: 'Substructure-Search'},
+  // Adds a macromolecule filter rather than opening anything. The column-picker dialog only
+  // appears because this table has two Macromolecule columns; with one it filters straight away.
+  {group: 'Search', leaf: 'Subsequence-Search-...', filter: true},
 ];
 
 /** Leaves other packages contribute to the Bio menu. They are smoke-checked only when their
@@ -103,6 +107,16 @@ test('Bio top menu — every leaf opens its dialog, viewer or view and closes cl
         expect(await dlg.locator('[name="button-OK"]').count()).toBe(1);
         await cancelDialog(page, l.dialog);
       }
+      else if (l.filter) {
+        // Two Macromolecule columns here, so the platform asks which one first.
+        const picker = dialog(page, 'Substructure-Search');
+        await picker.waitFor({state: 'visible', timeout: 15_000});
+        await picker.locator('[name="button-OK"]').click();
+        await picker.waitFor({state: 'detached', timeout: 30_000});
+        // What the run actually produces is asserted by the dedicated test below — today it
+        // produces nothing, so the sweep only pins that the entry point opens and dismisses.
+        await closeExtraViewers(page);
+      }
       else if (l.viewer) {
         await page.waitForFunction((t) => Array.from(((grok.shell.tv as any)?.viewers ?? []) as any[])
           .some((v: any) => v.type === t), l.viewer, {timeout: 120_000});
@@ -157,4 +171,31 @@ test('Bio top menu — leaves contributed by other packages open when those pack
     if (skipped.length > 0)
       console.log(`[note] not installed on this stand, so not exercised: ${skipped.join(', ')}`);
     finishSpec();
+  });
+
+test('Bio Search | Subsequence Search adds the filter whichever column count the table has',
+  async ({page}) => {
+    test.setTimeout(300_000);
+    test.fail(true, 'Subsequence Search is a no-op once the table has more than one Macromolecule ' +
+      'column: the column-picker dialog appears, OK closes it, the Filters panel docks empty and no ' +
+      'macromolecule filter is added. Calling Bio:SubsequenceSearchTopMenu directly on the same ' +
+      'table does add it. Remove test.fail when fixed.');
+    stepErrors.length = 0;
+    await loginToDatagrok(page);
+    await loadBioTable(page, ANTIBODIES, ROWS, TABLE);
+
+    await openBioMenu(page, 'Search', 'Subsequence-Search-...');
+    const picker = dialog(page, 'Substructure-Search');
+    await picker.waitFor({state: 'visible', timeout: 60_000});
+    // The picker preselects a column, so OK alone is a complete, valid run.
+    expect(await picker.locator('.d4-column-selector-column').first().textContent()).toBe('AntibodyHC');
+    await picker.locator('[name="button-OK"]').click();
+    await picker.waitFor({state: 'detached', timeout: 30_000});
+
+    await page.waitForFunction(() => ((grok.shell.tv as any)
+      .getFiltersGroup({createDefaultFilters: false}).filters ?? []).length > 0,
+    null, {timeout: 60_000});
+    const columns = await page.evaluate(() => (grok.shell.tv as any)
+      .getFiltersGroup({createDefaultFilters: false}).filters.map((f: any) => f.columnName ?? null));
+    expect(columns).toContain('AntibodyHC');
   });

--- a/packages/Bio/playwright/bio-top-menu-sweep.test.ts
+++ b/packages/Bio/playwright/bio-top-menu-sweep.test.ts
@@ -4,7 +4,7 @@ sub_features_covered: [bio.analyze.activity-cliffs.top-menu, bio.analyze.compare
 import {test, expect, Page} from '@playwright/test';
 import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '@datagrok-libraries/test/src/playwright/spec-login';
 import {finishSpec} from '@datagrok-libraries/test/src/playwright/viewers';
-import {openBioGroup, openBioMenu, dialog, cancelDialog, loadBioTable, closeExtraViewers} from './helpers';
+import {openBioGroup, openBioMenu, dialog, cancelDialog, setText, loadBioTable, closeExtraViewers} from './helpers';
 
 test.use(specTestOptions);
 
@@ -20,6 +20,9 @@ interface Leaf {
   leaf: string;
   dialog?: string;
   viewer?: string;
+  /** Property the viewer fills once it has finished computing — a docked but empty viewer is
+   * not a working menu entry. */
+  viewerReady?: string;
   view?: string;
   filter?: boolean;
 }
@@ -43,10 +46,10 @@ const BIO_LEAVES: Leaf[] = [
   {group: 'Manage', leaf: 'Match-with-Monomer-Library...', dialog: 'matchWithMonomerLibrary'},
   {group: 'Manage', leaf: 'Monomer-Libraries', view: 'Manage Monomer Libraries'},
   {group: 'Manage', leaf: 'Monomers', view: 'Manage Monomers'},
-  {group: 'Search', leaf: 'Similarity-Search', viewer: 'Sequence Similarity Search'},
-  {group: 'Search', leaf: 'Diversity-Search', viewer: 'Sequence Diversity Search'},
-  // Adds a macromolecule filter rather than opening anything. The column-picker dialog only
-  // appears because this table has two Macromolecule columns; with one it filters straight away.
+  {group: 'Search', leaf: 'Similarity-Search', viewer: 'Sequence Similarity Search', viewerReady: 'idxs'},
+  {group: 'Search', leaf: 'Diversity-Search', viewer: 'Sequence Diversity Search', viewerReady: 'renderMolIds'},
+  // Filters rows rather than adding a column or a viewer. With a single Macromolecule column the
+  // filter is added straight away; with several, a search dialog asks which column and what to find.
   {group: 'Search', leaf: 'Subsequence-Search-...', filter: true},
 ];
 
@@ -108,18 +111,37 @@ test('Bio top menu — every leaf opens its dialog, viewer or view and closes cl
         await cancelDialog(page, l.dialog);
       }
       else if (l.filter) {
-        // Two Macromolecule columns here, so the platform asks which one first.
-        const picker = dialog(page, 'Substructure-Search');
-        await picker.waitFor({state: 'visible', timeout: 15_000});
-        await picker.locator('[name="button-OK"]').click();
-        await picker.waitFor({state: 'detached', timeout: 30_000});
-        // What the run actually produces is asserted by the dedicated test below — today it
-        // produces nothing, so the sweep only pins that the entry point opens and dismisses.
+        // One Macromolecule column would filter straight away; two make the entry point open its
+        // search dialog first. OK narrows the row filter — an empty query matches everything, so
+        // the search only means anything with a real subsequence typed in.
+        const dlg = dialog(page, 'Substructure-Search');
+        await dlg.waitFor({state: 'visible', timeout: 60_000});
+        const query: string = await page.evaluate(() =>
+          grok.shell.tv.dataFrame.col('AntibodyHC')!.get(0)!.substring(30, 40));
+        await setText(page, 'Substructure-Search', 'Substructure', query);
+        await dlg.locator('[name="button-OK"]').click();
+        await dlg.waitFor({state: 'detached', timeout: 30_000});
+
+        await page.waitForFunction(() => grok.shell.tv.dataFrame.filter.trueCount <
+          grok.shell.tv.dataFrame.rowCount, null, {timeout: 60_000});
+        const kept = await page.evaluate((q) => {
+          const df = grok.shell.tv.dataFrame;
+          const col = df.col('AntibodyHC')!;
+          const rows: string[] = [];
+          for (let i = 0; i < df.rowCount; i++) if (df.filter.get(i)) rows.push(col.get(i) ?? '');
+          return {count: rows.length, allMatch: rows.every((r) => r.includes(q))};
+        }, query);
+        expect(kept.count).toBeGreaterThan(0);
+        expect(kept.allMatch).toBe(true);
+        await page.evaluate(() => grok.shell.tv.dataFrame.filter.setAll(true));
         await closeExtraViewers(page);
       }
       else if (l.viewer) {
-        await page.waitForFunction((t) => Array.from(((grok.shell.tv as any)?.viewers ?? []) as any[])
-          .some((v: any) => v.type === t), l.viewer, {timeout: 120_000});
+        await page.waitForFunction(({t, ready}) => {
+          const v = Array.from(((grok.shell.tv as any)?.viewers ?? []) as any[])
+            .find((vw: any) => vw.type === t);
+          return !!v && (v as any)[ready] != null;
+        }, {t: l.viewer, ready: l.viewerReady!}, {timeout: 120_000});
         await page.evaluate((t) => {
           for (const v of Array.from(((grok.shell.tv as any)?.viewers ?? []) as any[]))
             if (v.type === t) v.close();
@@ -127,6 +149,14 @@ test('Bio top menu — every leaf opens its dialog, viewer or view and closes cl
       }
       else {
         await page.waitForFunction((n) => grok.shell.v?.name === n, l.view, {timeout: 120_000});
+        // A view that opens empty is as broken as one that does not open.
+        const rendered = await page.evaluate(() => {
+          const root = grok.shell.v.root;
+          return {height: Math.round(root.getBoundingClientRect().height),
+            nodes: root.querySelectorAll('*').length};
+        });
+        expect(rendered.height).toBeGreaterThan(0);
+        expect(rendered.nodes).toBeGreaterThan(10);
         await page.evaluate((n) => { if (grok.shell.v?.name === n) grok.shell.v.close(); }, l.view);
       }
 
@@ -171,31 +201,4 @@ test('Bio top menu — leaves contributed by other packages open when those pack
     if (skipped.length > 0)
       console.log(`[note] not installed on this stand, so not exercised: ${skipped.join(', ')}`);
     finishSpec();
-  });
-
-test('Bio Search | Subsequence Search adds the filter whichever column count the table has',
-  async ({page}) => {
-    test.setTimeout(300_000);
-    test.fail(true, 'Subsequence Search is a no-op once the table has more than one Macromolecule ' +
-      'column: the column-picker dialog appears, OK closes it, the Filters panel docks empty and no ' +
-      'macromolecule filter is added. Calling Bio:SubsequenceSearchTopMenu directly on the same ' +
-      'table does add it. Remove test.fail when fixed.');
-    stepErrors.length = 0;
-    await loginToDatagrok(page);
-    await loadBioTable(page, ANTIBODIES, ROWS, TABLE);
-
-    await openBioMenu(page, 'Search', 'Subsequence-Search-...');
-    const picker = dialog(page, 'Substructure-Search');
-    await picker.waitFor({state: 'visible', timeout: 60_000});
-    // The picker preselects a column, so OK alone is a complete, valid run.
-    expect(await picker.locator('.d4-column-selector-column').first().textContent()).toBe('AntibodyHC');
-    await picker.locator('[name="button-OK"]').click();
-    await picker.waitFor({state: 'detached', timeout: 30_000});
-
-    await page.waitForFunction(() => ((grok.shell.tv as any)
-      .getFiltersGroup({createDefaultFilters: false}).filters ?? []).length > 0,
-    null, {timeout: 60_000});
-    const columns = await page.evaluate(() => (grok.shell.tv as any)
-      .getFiltersGroup({createDefaultFilters: false}).filters.map((f: any) => f.columnName ?? null));
-    expect(columns).toContain('AntibodyHC');
   });

--- a/packages/Bio/playwright/bio-top-menu-sweep.test.ts
+++ b/packages/Bio/playwright/bio-top-menu-sweep.test.ts
@@ -1,0 +1,160 @@
+/* ---
+sub_features_covered: [bio.analyze.activity-cliffs.top-menu, bio.analyze.compare-sequences.top-menu, bio.analyze.composition.top-menu, bio.analyze.msa.top-menu, bio.analyze.sequence-space.top-menu, bio.annotate.manage-annotations.top-menu, bio.annotate.numbering-scheme.top-menu, bio.annotate.scan-liabilities.top-menu, bio.calculate.get-region.top-menu, bio.calculate.identity.top-menu, bio.calculate.similarity.top-menu, bio.manage.libraries-view.top-menu, bio.manage.match-with-library.top-menu, bio.manage.monomers-view.top-menu, bio.search.diversity.top-menu, bio.search.similarity.top-menu, bio.search.subsequence.top-menu, bio.top-menu.registration, bio.transform.convert-notation.top-menu, bio.transform.molecules-to-helm.top-menu, bio.transform.split-to-monomers.top-menu, bio.transform.to-atomic-level.top-menu]
+--- */
+import {test, expect, Page} from '@playwright/test';
+import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '@datagrok-libraries/test/src/playwright/spec-login';
+import {finishSpec} from '@datagrok-libraries/test/src/playwright/viewers';
+import {openBioGroup, openBioMenu, dialog, cancelDialog, loadBioTable} from './helpers';
+
+test.use(specTestOptions);
+
+const ANTIBODIES = 'System:AppData/Bio/samples/antibodies.csv';
+const TABLE = 'antibodies';
+const ROWS = 40;
+
+/** What a Bio top-menu leaf is expected to produce. Exactly one of dialog/viewer/view is set —
+ * the dialog `name` attribute is the function's friendly name, which is not always the menu label. */
+interface Leaf {
+  group: string;
+  leaf: string;
+  dialog?: string;
+  viewer?: string;
+  view?: string;
+}
+
+const BIO_LEAVES: Leaf[] = [
+  {group: 'Transform', leaf: 'Molecules-to-HELM...', dialog: 'Molecules-to-HELM'},
+  {group: 'Transform', leaf: 'To-Atomic-Level...', dialog: 'To-Atomic-Level'},
+  {group: 'Transform', leaf: 'Convert-Sequence-Notation...', dialog: 'Convert-Sequence-Notation'},
+  {group: 'Transform', leaf: 'Split-to-Monomers...', dialog: 'Split-to-Monomers'},
+  {group: 'Analyze', leaf: 'Activity-Cliffs...', dialog: 'Sequence-Activity-Cliffs'},
+  {group: 'Analyze', leaf: 'Sequence-Space...', dialog: 'Sequence-Space'},
+  {group: 'Analyze', leaf: 'MSA...', dialog: 'MSA'},
+  {group: 'Analyze', leaf: 'Compare-sequences...', dialog: 'Compare-Sequences'},
+  {group: 'Analyze', leaf: 'Composition', dialog: 'Composition-Analysis'},
+  {group: 'Calculate', leaf: 'Extract-Region...', dialog: 'Get-Sequence-Region'},
+  {group: 'Calculate', leaf: 'Identity...', dialog: 'Identity'},
+  {group: 'Calculate', leaf: 'Similarity...', dialog: 'Similarity'},
+  {group: 'Annotate', leaf: 'Apply-Numbering-Scheme...', dialog: 'Apply-Antibody-Numbering'},
+  {group: 'Annotate', leaf: 'Scan-Liabilities...', dialog: 'Scan-Sequence-Liabilities'},
+  {group: 'Annotate', leaf: 'Manage-Annotations...', dialog: 'Manage-Annotations'},
+  {group: 'Manage', leaf: 'Match-with-Monomer-Library...', dialog: 'matchWithMonomerLibrary'},
+  {group: 'Manage', leaf: 'Monomer-Libraries', view: 'Manage Monomer Libraries'},
+  {group: 'Manage', leaf: 'Monomers', view: 'Manage Monomers'},
+  {group: 'Search', leaf: 'Similarity-Search', viewer: 'Sequence Similarity Search'},
+  {group: 'Search', leaf: 'Diversity-Search', viewer: 'Sequence Diversity Search'},
+  {group: 'Search', leaf: 'Subsequence-Search-...', dialog: 'Substructure-Search'},
+];
+
+/** Leaves other packages contribute to the Bio menu. They are smoke-checked only when their
+ * package happens to be installed — Bio's suite must not demand SequenceTranslator or Peptides.
+ * Bio | Folding is deliberately absent: EsmFold/Boltz submit real inference jobs. */
+const FOREIGN_LEAVES: Leaf[] = [
+  {group: 'Analyze', leaf: 'Hierarchical-Clustering...', dialog: 'Hierarchical-Clustering'},
+  {group: 'Analyze', leaf: 'SAR...', dialog: 'Analyze-Peptides'},
+  {group: 'Transform', leaf: 'Fetch-PDB-Sequences...', dialog: 'Fetch-PDB-Sequences'},
+  {group: 'PolyTool', leaf: 'Enumerate-HELM...', dialog: 'PolyTool-Helm-Enumeration'},
+  {group: 'PolyTool', leaf: 'Combine-Sequences...', dialog: 'Combine-Sequences'},
+];
+
+const label = (l: Leaf): string => `Bio | ${l.group} | ${l.leaf.replace(/-/g, ' ').trim()}`;
+
+/** Returns to the table view and waits until the Bio menu is usable again. */
+async function backToTable(page: Page): Promise<void> {
+  await page.evaluate((n) => {
+    const tv = Array.from(grok.shell.tableViews).find((v: any) => v.name === n);
+    if (tv && grok.shell.v !== tv) grok.shell.v = tv as any;
+  }, TABLE);
+  await page.locator('[name="div-Bio"]').waitFor({state: 'visible', timeout: 30_000});
+}
+
+test('Bio top menu — every Bio-owned leaf is registered under its group', async ({page}) => {
+  test.setTimeout(300_000);
+  stepErrors.length = 0;
+  await loginToDatagrok(page);
+  await loadBioTable(page, ANTIBODIES, ROWS, TABLE);
+
+  for (const group of ['Transform', 'Analyze', 'Calculate', 'Annotate', 'Manage', 'Search']) {
+    await softStep(`Bio | ${group} lists its leaves`, async () => {
+      await openBioGroup(page, group);
+      for (const l of BIO_LEAVES.filter((x) => x.group === group))
+        await expect(page.locator(`[name="div-Bio---${group}---${l.leaf}"]`)).toBeVisible({timeout: 15_000});
+    });
+  }
+  await page.keyboard.press('Escape');
+  finishSpec();
+});
+
+test('Bio top menu — every leaf opens its dialog, viewer or view and closes cleanly', async ({page}) => {
+  test.setTimeout(900_000);
+  stepErrors.length = 0;
+  await loginToDatagrok(page);
+  await loadBioTable(page, ANTIBODIES, ROWS, TABLE);
+
+  for (const l of BIO_LEAVES) {
+    await softStep(`${label(l)} opens and closes`, async () => {
+      await backToTable(page);
+      await openBioMenu(page, l.group, l.leaf);
+
+      if (l.dialog) {
+        const dlg = dialog(page, l.dialog);
+        await dlg.waitFor({timeout: 90_000});
+        // A dialog with no OK cannot be run at all — that is a broken entry point, not a slow one.
+        expect(await dlg.locator('[name="button-OK"]').count()).toBe(1);
+        await cancelDialog(page, l.dialog);
+      }
+      else if (l.viewer) {
+        await page.waitForFunction((t) => Array.from(((grok.shell.tv as any)?.viewers ?? []) as any[])
+          .some((v: any) => v.type === t), l.viewer, {timeout: 120_000});
+        await page.evaluate((t) => {
+          for (const v of Array.from(((grok.shell.tv as any)?.viewers ?? []) as any[]))
+            if (v.type === t) v.close();
+        }, l.viewer);
+      }
+      else {
+        await page.waitForFunction((n) => grok.shell.v?.name === n, l.view, {timeout: 120_000});
+        await page.evaluate((n) => { if (grok.shell.v?.name === n) grok.shell.v.close(); }, l.view);
+      }
+
+      expect(await page.locator('.d4-dialog').count()).toBe(0);
+    });
+  }
+
+  await backToTable(page);
+  finishSpec();
+});
+
+test('Bio top menu — leaves contributed by other packages open when those packages are installed',
+  async ({page}) => {
+    test.setTimeout(600_000);
+    stepErrors.length = 0;
+    await loginToDatagrok(page);
+    await loadBioTable(page, ANTIBODIES, ROWS, TABLE);
+
+    const skipped: string[] = [];
+    for (const l of FOREIGN_LEAVES) {
+      await softStep(`${label(l)} (foreign) opens and closes`, async () => {
+        await backToTable(page);
+        await page.locator('[name="div-Bio"]').click();
+        const groupLoc = page.locator(`[name="div-Bio---${l.group}"]`);
+        if (await groupLoc.count() === 0) {
+          skipped.push(label(l));
+          await page.keyboard.press('Escape');
+          return;
+        }
+        await openBioGroup(page, l.group);
+        const leafLoc = page.locator(`[name="div-Bio---${l.group}---${l.leaf}"]`);
+        if (await leafLoc.count() === 0) {
+          skipped.push(label(l));
+          await page.keyboard.press('Escape');
+          return;
+        }
+        await leafLoc.click();
+        await dialog(page, l.dialog!).waitFor({timeout: 90_000});
+        await cancelDialog(page, l.dialog!);
+      });
+    }
+    if (skipped.length > 0)
+      console.log(`[note] not installed on this stand, so not exercised: ${skipped.join(', ')}`);
+    finishSpec();
+  });

--- a/packages/Bio/playwright/helpers.ts
+++ b/packages/Bio/playwright/helpers.ts
@@ -90,7 +90,7 @@ export async function setText(page: Page, dlgName: string, input: string, value:
   const inp = page.locator(`[name="dialog-${dlgName}"] [name="input-host-${input}"] input`);
   await inp.click();
   await inp.press('Control+a');
-  await inp.type(value);
+  await inp.pressSequentially(value);
   await inp.press('Tab');
 }
 

--- a/packages/Bio/playwright/helpers.ts
+++ b/packages/Bio/playwright/helpers.ts
@@ -1,3 +1,4 @@
+import {Page, expect} from '@playwright/test';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -34,4 +35,99 @@ export async function acquireMonomerLibLock(): Promise<void> {
 
 export function releaseMonomerLibLock(): void {
   fs.rmSync(LOCK_DIR, {recursive: true, force: true});
+}
+
+/** Expands a Bio top-menu group. `hover()` jumps straight to the element centre and d4 expands a
+ * submenu off the mouse path, so a jump leaves the container at display:none — walk the pointer in
+ * instead. Verified on dev: a stepped path expands all six groups within one open menu. */
+export async function openBioGroup(page: Page, group: string): Promise<void> {
+  const groupLoc = page.locator(`[name="div-Bio---${group}"]`);
+  // Clicking the menu bar item toggles, so a second click on an already-open menu closes it.
+  if (!await groupLoc.isVisible().catch(() => false))
+    await page.locator('[name="div-Bio"]').click();
+  await groupLoc.waitFor({state: 'visible', timeout: 15_000});
+  const box = (await groupLoc.boundingBox())!;
+  await page.mouse.move(box.x + 5, box.y + box.height / 2, {steps: 12});
+  await page.mouse.move(box.x + box.width - 15, box.y + box.height / 2, {steps: 12});
+  await page.locator(`[name^="div-Bio---${group}---"]`).first()
+    .waitFor({state: 'visible', timeout: 15_000});
+}
+
+/** Opens a Bio top-menu leaf. Unlike the shared `bio.openBioAnalyze` helper this walks any group,
+ * and uses real clicks/hovers — d4 menus ignore synthetic mouseover events. */
+export async function openBioMenu(page: Page, group: string, leaf: string): Promise<void> {
+  await openBioGroup(page, group);
+  const leafLoc = page.locator(`[name="div-Bio---${group}---${leaf}"]`);
+  await leafLoc.waitFor({state: 'visible', timeout: 15_000});
+  await leafLoc.click();
+}
+
+/** Waits for a d4 dialog by its `name` attribute and returns its locator. */
+export function dialog(page: Page, name: string) {
+  return page.locator(`[name="dialog-${name}"]`);
+}
+
+/** Cancels the named dialog and waits for it to detach — a dialog left open intercepts
+ * every later click. */
+export async function cancelDialog(page: Page, name: string): Promise<void> {
+  const dlg = dialog(page, name);
+  if (await dlg.count() === 0) return;
+  const cancel = dlg.locator('[name="button-CANCEL"]');
+  if (await cancel.count() > 0) await cancel.click();
+  else await page.keyboard.press('Escape');
+  await dlg.waitFor({state: 'detached', timeout: 15_000});
+}
+
+/** Sets a d4 choice input inside a dialog, verifying the selection stuck. */
+export async function setChoice(page: Page, dlgName: string, input: string, value: string): Promise<void> {
+  const sel = page.locator(`[name="dialog-${dlgName}"] [name="input-host-${input}"] select`);
+  await sel.selectOption({label: value});
+  await expect(sel).toHaveValue(value);
+}
+
+/** Types into a d4 text input and blurs — `fill()` updates the DOM but not the Dart value. */
+export async function setText(page: Page, dlgName: string, input: string, value: string): Promise<void> {
+  const inp = page.locator(`[name="dialog-${dlgName}"] [name="input-host-${input}"] input`);
+  await inp.click();
+  await inp.press('Control+a');
+  await inp.type(value);
+  await inp.press('Tab');
+}
+
+/** Toggles a checkbox input to the requested state (no-op when already there). */
+export async function setBool(page: Page, dlgName: string, input: string, value: boolean): Promise<void> {
+  const box = page.locator(`[name="dialog-${dlgName}"] [name="input-host-${input}"] input[type="checkbox"]`);
+  if (await box.isChecked() !== value) await box.click();
+  await expect(box).toBeChecked({checked: value});
+}
+
+/** Loads a CSV into a fresh table view, optionally keeping only the first `rows` rows, and
+ * waits until Bio has detected the Macromolecule columns and the grid has painted. */
+export async function loadBioTable(page: Page, path: string, rows?: number, name?: string): Promise<void> {
+  await page.evaluate(async ({p, r, n}) => {
+    document.body.classList.add('selenium');
+    grok.shell.windows.simpleMode = true;
+    grok.shell.closeAll();
+    const src = await grok.dapi.files.readCsv(p);
+    const df = r != null && r < src.rowCount ?
+      src.clone(DG.BitSet.create(src.rowCount, (i) => i < r)) : src;
+    df.name = n ?? df.name;
+    grok.shell.addTableView(df);
+    const detected = () => df.columns.toList().some((c: any) => c.semType === 'Macromolecule');
+    for (let i = 0; i < 200; i++) {
+      if (detected() && document.querySelector('[name="viewer-Grid"] canvas')) break;
+      await new Promise((res) => setTimeout(res, 200));
+    }
+  }, {p: path, r: rows, n: name});
+  await page.locator('.d4-grid[name="viewer-Grid"]').waitFor({timeout: 60_000});
+  await page.locator('[name="div-Bio"]').waitFor({state: 'visible', timeout: 60_000});
+  await page.evaluate(async () => { await (grok as any).functions.call('Bio:getSeqHelper', {}); });
+}
+
+/** Closes every viewer the test docked, leaving the grid — keeps specs independent. */
+export async function closeExtraViewers(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    for (const v of Array.from(((grok.shell.tv as any)?.viewers ?? []) as any[]))
+      if (v.type !== 'Grid') v.close();
+  });
 }


### PR DESCRIPTION
8 new tests that cover every entry of the Bio top menu, plus reusable helpers.

bio-top-menu-sweep.test.ts (3 tests)
- every Bio-owned leaf is registered under its group;
- every leaf opens its dialog / viewer / view and closes cleanly;
- leaves contributed by other packages open when those packages are installed.

bio-annotate-dialogs.test.ts (3 tests) — the three dialogs that had no coverage:
- Analyze | Compare sequences — defaults, custom result name, identical-column guard;
- Annotate | Scan Liabilities — default rule set, then a narrowed one with a summary column;
- Annotate | Manage Annotations — lists, deletes and clears scanned annotations.

bio-top-menu-settings.test.ts (2 tests) — the same entries re-run with non-default settings:
- on antibodies.csv: Composition, numbering scheme, Extract Region;
- on FASTA_PT_activity.csv: scoring references, HELM conversion, atomic-level options.

helpers.ts — openBioGroup / openBioMenu, dialog / cancelDialog, setChoice / setText / setBool, loadBioTable, closeExtraViewers.

Notable points for the reviewer

- Assertions are on results, not on "the dialog closed": WebLogo canvas pixels, aligned-column widths and .positionNames, region slice vs the source substring, score ranges, the .sequence-src-highlight-monomers tag, HC#LC pairing, liability hits re-verified against the motif at the reported position, search viewers awaited via idxs / renderMolIds.
- The Bio menu has 29 leaves, not 21. 8 come from other packages (BioNeMo, Boltz1, BiostructureViewer, Dendrogram, Peptides, SequenceTranslator). The suite hard-asserts the 21 Bio-owned leaves and only smoke-checks foreign ones when their package is installed; otherwise it logs a [note] skip.
- Bio | Folding is deliberately not touched — EsmFold/Boltz submit real inference jobs.
- Submenus are opened with a real pointer path (page.mouse.move(..., {steps: 12})), not locator.hover(): d4 expands a submenu along the mouse path, so a centre-jump leaves the container at display:none and half the groups look unregistered. Product behaviour is correct — this is a test-side fix.
- Search | Subsequence Search is a filter, not a plain dialog (custom editor Bio:SearchSubsequenceEditor). With one Macromolecule column it runs immediately; OK on an empty Substructure field is a legitimate no-op (an empty query matches every row). The test types a real subsequence and asserts the row filter narrows.
- Dialog name attributes follow the function's friendly name, not the menu label (e.g. Extract Region → dialog-Get-Sequence-Region, Apply Numbering Scheme → dialog-Apply-Antibody-Numbering).
- Dialog inputs are filled via pressSequentially — the d4 synthetic inputs ignore fill().

Test results

- Dev, full Bio package suite: 44/44 in 19.5 min (the three ✘ in the log are test.fail (GROK-16111) xfails).
- Dev, the 8 new tests alone: 8/8 in 2.4 min.
- CI Test-Playwright № 346, PLAYWRIGHT_DIR=public/packages/Bio, grep Bio top menu|Compare sequences|Scan Liabilities|Manage Annotations: 8/8 in 1.3 min.
- CI prerequisites: Bio,Chem,Helm,Dendrogram,EDA.