### PR TITLE
Grokky: Gate AI UI on claude-runtime availability (audit F-39)

### DIFF
--- a/packages/Grokky/docs/AUDIT-2026-08-03.md
+++ b/packages/Grokky/docs/AUDIT-2026-08-03.md
@@ -608,13 +608,16 @@ wrong.~~ **(resolved 2026-08-17: override removed; `Developers` and `Administrat
 — rewritable, racy across tabs, no server-side limit — see the platform ask below.
 
 <a id="f-39"></a>
-**F-39 · MEDIUM · the whole UI is gated on the wrong configuration flag.**
-All five entry points bail on `grok.ai.config.configured`, which means only that the *core admin
+**F-39 · MEDIUM · ~~the whole UI is gated on the wrong configuration flag~~.**
+~~All five entry points bail on `grok.ai.config.configured`, which means only that the *core admin
 AI Providers* setting has an endpoint and credential — a provider used for embeddings and entity
 indexing. Grokky's actual backend is the container. **A deployment with both containers running
 and valid Claude credentials shows no AI at all** unless an unrelated OpenAI/Azure key is also
-configured. **Fix:** gate on container availability (the discovery code already exists), or add
+configured.~~ **Fix:** gate on container availability (the discovery code already exists), or add
 a package setting.
+**(resolved 2026-08-18: all five entry points now gate on `ClaudeRuntimeClient.discover()` — a single
+cached discovery shared with `connect()`; the container entity being discoverable, stopped on-demand
+counts. Browser bundle only.)**
 
 <a id="f-40"></a>
 **F-40 · MEDIUM · ~~a legitimate answer mentioning `/login` is replaced by the auth widget~~.**

--- a/packages/Grokky/src/ai/ui.ts
+++ b/packages/Grokky/src/ai/ui.ts
@@ -165,8 +165,8 @@ export async function askWiki(question: string, sessionId?: string): Promise<DG.
 
 // sets up the ui button for the input
 export function setupSearchUI() {
-  if (!grok.ai.config.configured) {
-    console.warn('LLM API key is not set up. Search UI will not have AI assistance.');
+  if (!ClaudeRuntimeClient.getInstance().available) {
+    console.warn('Claude runtime container not found. Search UI will not have AI assistance.');
     return;
   }
 
@@ -234,7 +234,7 @@ export async function aiCombinedSearch(prompt: string) {
 // setQueryAndRun + the meta.viewType-registered SQL schema functions) are reached
 // by the singleton panel through the view-function meta-tools.
 export async function setupAIQueryEditorUI(_v: DG.ViewBase, _connectionID: string, _queryEditorRoot: HTMLElement, _setAndRunFunc: (query: string) => void): Promise<boolean> {
-  if (!grok.ai.config.configured)
+  if (!await ClaudeRuntimeClient.getInstance().discover())
     return false;
   initAIWindow();
   return true;
@@ -616,7 +616,7 @@ async function streamOnce(
 let _shellAIPanel: AIPanel | null = null;
 
 export function initAIWindow(): AIPanel | null {
-  if (!grok.ai.config.configured)
+  if (!ClaudeRuntimeClient.getInstance().available)
     return null;
   if (!_shellAIPanel) {
     _shellAIPanel = new AIPanel('shell-ai-panel', null as any);
@@ -641,7 +641,7 @@ export function setupShellAIPanelUI(): void {
 const AI_ICON_SELECTOR = 'i[data-name="ai"]';
 
 export async function setupTableViewAIPanelUI() {
-  if (!grok.ai.config.configured)
+  if (!ClaudeRuntimeClient.getInstance().available)
     return;
   const handleView = (tableView: DG.TableView) => {
     if (tableView.root?.parentElement?.querySelector(AI_ICON_SELECTOR) != null)

--- a/packages/Grokky/src/claude/runtime-client.ts
+++ b/packages/Grokky/src/claude/runtime-client.ts
@@ -34,6 +34,7 @@ export class ClaudeRuntimeClient {
   private containerId: string | null = null;
   private mcpServerUrl: string | null = null;
   private _connectPromise: Promise<void> | null = null;
+  private _discovery: Promise<boolean> | null = null;
 
 
   public onChunk = new rxjs.Subject<ChunkEvent>();
@@ -63,6 +64,31 @@ export class ClaudeRuntimeClient {
     return this.ws !== null && this.ws.readyState === WebSocket.OPEN;
   }
 
+  get available(): boolean {
+    return this.containerId !== null;
+  }
+
+  // "Available" means the container entity is discoverable — it may be stopped (on_demand starts on the first turn).
+  discover(): Promise<boolean> {
+    if (!this._discovery)
+      this._discovery = (async () => {
+        const [runtimeContainers, mcpContainers] = await Promise.all([
+          grok.dapi.docker.dockerContainers.filter('name = "grokky-claude-runtime"').list(),
+          grok.dapi.docker.dockerContainers.filter('name = "grokky-mcp-server"').list(),
+        ]);
+        this.containerId = runtimeContainers[0]?.id ?? null;
+        this.mcpServerUrl = mcpContainers[0] ?
+          `${grok.dapi.root}/docker/containers/proxy/${mcpContainers[0].id}/mcp` :
+          null;
+        return this.containerId !== null;
+      })().catch((e) => {
+        console.warn('Grokky: container discovery failed:', e);
+        this._discovery = null;
+        return false;
+      });
+    return this._discovery;
+  }
+
   async ensureConnected(): Promise<void> {
     if (this.connected)
       return;
@@ -77,23 +103,16 @@ export class ClaudeRuntimeClient {
     if (this.connected)
       return;
 
-    try {
-      if (!this.containerId || !this.mcpServerUrl) {
-        const [runtimeContainers, mcpContainers] = await Promise.all([
-          grok.dapi.docker.dockerContainers.filter('name = "grokky-claude-runtime"').list(),
-          grok.dapi.docker.dockerContainers.filter('name = "grokky-mcp-server"').list(),
-        ]);
-        this.containerId = runtimeContainers[0]?.id ?? null;
-        this.mcpServerUrl = mcpContainers[0] ?
-          `${grok.dapi.root}/docker/containers/proxy/${mcpContainers[0].id}/mcp` :
-          null;
+    if (await this.discover()) {
+      try {
+        this.ws = await grok.dapi.docker.dockerContainers.webSocketProxy(this.containerId!, '/ws', 180_000);
       }
-      if (this.containerId)
-        this.ws = await grok.dapi.docker.dockerContainers.webSocketProxy(this.containerId, '/ws', 180_000);
-    } catch (e) {
-      this.containerId = null;
-      this.mcpServerUrl = null;
-      console.error('Failed to connect to Claude runtime:', e);
+      catch (e) {
+        this._discovery = null;
+        this.containerId = null;
+        this.mcpServerUrl = null;
+        console.error('Failed to connect to Claude runtime:', e);
+      }
     }
 
     if (!this.ws)

--- a/packages/Grokky/src/package.ts
+++ b/packages/Grokky/src/package.ts
@@ -26,6 +26,7 @@ export class PackageFunctions {
   @grok.decorators.init({tags: ['init']})
   static async init() {
     await UsageLimiter.getInstance().init();
+    const aiAvailable = await ClaudeRuntimeClient.getInstance().discover();
     setupSearchUI();
     initAIWindow();
     setupTableViewAIPanelUI();
@@ -33,7 +34,8 @@ export class PackageFunctions {
     setupAgentScriptsUI();
     PackageFunctions.ensureAgentsFolder();
     // Warm the WebSocket to claude-runtime so the first user turn doesn't pay container-lookup + WS handshake cost.
-    ClaudeRuntimeClient.getInstance().ensureConnected().catch(() => {});
+    if (aiAvailable)
+      ClaudeRuntimeClient.getInstance().ensureConnected().catch(() => {});
     PackageFunctions.subscribeToSyncEvents();
   }
 
@@ -125,7 +127,7 @@ export class PackageFunctions {
     meta: {role: 'searchProvider'},
   })
   static combinedLLMSearchProvider(): DG.SearchProvider {
-    const isAiConfigured = grok.ai.config.configured;
+    const client = ClaudeRuntimeClient.getInstance();
     return {
       'home': {
         name: 'Ask AI Assistant',
@@ -134,10 +136,10 @@ export class PackageFunctions {
           return null;
         },
         getSuggestions: (_query: string) => [],
-        isApplicable: (query: string) => isAiConfigured ? query?.trim().length >= 2 : false,
+        isApplicable: (query: string) => client.available ? query?.trim().length >= 2 : false,
         description: 'Get answers form AI assistant',
         onValueEnter: async (query) => {
-          isAiConfigured && query?.trim().length >= 2 &&
+          client.available && query?.trim().length >= 2 &&
             await CombinedAISearchAssistant.instance.searchUI(query);
         }
       }


### PR DESCRIPTION
## What

All five AI-UI entry points (`setupSearchUI`, `initAIWindow`, `setupTableViewAIPanelUI`, `setupAIQueryEditorUI`, `combinedLLMSearchProvider`) gated on `grok.ai.config.configured` — the core **AI Providers** embeddings flag, unrelated to Grokky's backend. A deployment with working `grokky-claude-runtime`/`grokky-mcp-server` containers but no OpenAI/Azure key showed **no AI UI at all**; conversely an embeddings-only stand showed AI that failed on first use. Audit finding **F-39**.

## Design

`ClaudeRuntimeClient` owns a single cached `discover()` promise — one parallel lookup of both container entities, shared by everything:

- `connect()` consumes it instead of running its own duplicate discovery (2 dapi calls at startup instead of 3; `containerId` is the only source of truth).
- `init()` awaits `discover()` once before wiring UI; the sync gates read the derived `available` getter (`containerId !== null`), valid under the platform's init-before-first-function-call contract.
- `setupAIQueryEditorUI` — invoked by core Dart outside init's ordering — awaits `discover()` directly, making it order-independent.
- **Available = the container entity is discoverable.** A stopped `on_demand` container counts; it starts on the first turn.
- A transient discovery failure clears the cached promise, so the next gate re-checks instead of latching AI off for the whole session; a connect failure re-arms discovery as before.
- The WebSocket warm-up in `init()` is skipped when no container exists, removing a guaranteed failed-connect error on container-less stands.

Browser bundle only — no container rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)