### PR TITLE
Chem: fix substructure filter not restoring empty state on Reset Filter

### DIFF
--- a/packages/Chem/src/widgets/chem-substructure-filter.ts
+++ b/packages/Chem/src/widgets/chem-substructure-filter.ts
@@ -280,8 +280,11 @@ export class SubstructureFilter extends DG.Filter {
       }));
 
     this.subs.push(grok.events.onResetFilterRequest.subscribe((_) => {
+      this.showOptions = false;
+      this.removeChildIfExists(this.root, this.searchOptionsDiv, 'chem-filter-search-options');
       this.sketcher.setMolFile(DG.WHITE_MOLBLOCK);
       this.searchTypeInput.value = SubstructureSearchType.CONTAINS;
+      this.updateFilterUiOnSketcherChanged(DG.WHITE_MOLBLOCK);
     }));
     this.subs.push(grok.events.onCustomEvent(FILTER_ENABLED_SYNC_EVENT).subscribe((state: any) => {
       if (state.colName === this.columnName && state.tableName === this.tableName && state.filterId !== this.filterId)


### PR DESCRIPTION
Drafted by Grokky from a Slack thread.

**Root cause:** **File:** `packages/Chem/src/widgets/chem-substructure-filter.ts`, lines 282–285.

The `onResetFilterRequest` handler only calls `sketcher.setMolFile(DG.WHITE_MOLBLOCK)` and `searchTypeInput.value = CONTAINS`. It relies entirely on the sketcher's async `onChanged` event to eventually reach `updateFilterUiOnSketcherChanged(WHITE_MOLBLOCK)`, which is the only method that moves `sketcherDiv` back inside `emptySketcherDiv` (restoring the "Sketch" placeholder UI). This path is unreliable in two ways:

1. **Plugin-dependent async event** (`js-api/src/chem.ts`, `setMolFile`, line 260–269): `setMolFile` sets `this._molfile` and, if the underlying plugin is initialized, assigns `plugin.molFile = x`. Whether the plugin fires its own `onChanged` on a programmatic assignment is sketcher-plugin-specific. When it does not (e.g. because the plugin already holds an `explicitMol` reference that survives the reset, or because the plugin's programmatic setter is silent), the DG.chem.Sketcher wrapper's `this.onChanged.next(null)` never fires, `_onSketchChanged` in the filter is never called, and `updateFilterUiOnSketcherChanged` is never called. The canvas (`sketcherDiv`) stays as a direct child of `root` instead of being wrapped inside `emptySketcherDiv`, which is the reported symptom.

2. **No-op when search type is already CONTAINS**: If the user applied a plain CONTAINS filter, `searchTypeInput.value = CONTAINS` is a no-op (value unchanged → `onValueChanged` may not fire → `searchTypeChanged.next()` not called → no synchronous `_onSketchChanged`). Both fallback paths are then absent.

3. **Secondary: `showOptions` never reset**: If the user had opened the ⚙ settings gear (`showOptions = true`), `searchOptionsDiv` is prepended to `root`. Neither the reset handler nor the empty-branch of `updateFilterUiOnSketcherChanged` (lines 726–733) removes it, so the settings panel persists after reset.

**Fix**: call `updateFilterUiOnSketcherChanged(DG.WHITE_MOLBLOCK)` synchronously in the handler to immediately correct the DOM state. Reset `showOptions = false` and explicitly remove `searchOptionsDiv` from `root`. Filter-data clearing (bitset → null, `requestFilter`) continues to flow via the existing async path through `_onSketchChanged` (triggered by `searchTypeChanged.next()` when the type changes, or by the plugin `onChanged` when it does fire).

**Reproduced on dev:** The bug is a UI interaction that requires opening a filter panel, sketching a substructure, then clicking Reset — not exercisable through the REST/JS API. The root cause was traced statically: `setMolFile` in `js-api/src/chem.ts` does not fire `DG.chem.Sketcher.onChanged` itself (it only assigns `plugin.molFile`; the plugin is responsible for bubbling its own event), and the empty branch of `updateFilterUiOnSketcherChanged` in the filter widget is never called synchronously during reset.

**Thread:** https://datagrok.slack.com/archives/C04BF3YM6CF/p1787068612018069?thread_ts=1787068612.018069&cid=C04BF3YM6CF

> Auto-drafted fix — review and test before merging.