### PR TITLE
JS API: Viewer: break viewer/grid import cycle that broke app startup

### DIFF
--- a/js-api/src/viewer.ts
+++ b/js-api/src/viewer.ts
@@ -10,7 +10,9 @@ import {__obs, EventData, EventType, StreamSubscription} from "./events";
 import * as rxjs from "rxjs";
 import {Subscription} from 'rxjs';
 import {filter, map} from 'rxjs/operators';
-import {FormViewer, Grid, Point, Rect} from "./grid";
+// Must stay type-only: grid.ts has `FormViewer extends Viewer`, so a runtime import closes a
+// cycle and leaves Viewer in the TDZ whenever the bundler emits grid first. Use DG.* below.
+import type {FormViewer, Grid, Point, Rect} from "./grid";
 import {FormulaLinesHelper, AnnotationRegionsHelper} from "./helpers";
 import * as interfaces from "./interfaces/d4";
 import dayjs from "dayjs";
@@ -303,7 +305,7 @@ export class Viewer<TSettings = any> extends Widget<TSettings> {
   }
 
   static form(t: DataFrame, options?: Partial<interfaces.IFormSettings>): FormViewer {
-    return new FormViewer(api.grok_Viewer_Form(t.dart, _toJson(options)));
+    return new DG.FormViewer(api.grok_Viewer_Form(t.dart, _toJson(options)));
   }
 
   static markup(t: DataFrame, options?: Partial<interfaces.IMarkupViewerSettings>): Viewer<interfaces.IMarkupViewerSettings> {
@@ -637,10 +639,10 @@ export class LineChartViewer extends Viewer<interfaces.ILineChartSettings> {
   }
 
   worldToScreen(x: number, y: number, chartIdx: number): Point {
-    return Point.fromXY(api.grok_LineChartViewer_WorldToScreen(this.dart, x, y, chartIdx));
+    return DG.Point.fromXY(api.grok_LineChartViewer_WorldToScreen(this.dart, x, y, chartIdx));
   }
 
-  screenToWorld(x: number, y: number): Point { return Point.fromXY(api.grok_LineChartViewer_ScreenToWorld(this.dart, x, y));}
+  screenToWorld(x: number, y: number): Point { return DG.Point.fromXY(api.grok_LineChartViewer_ScreenToWorld(this.dart, x, y));}
 
   get onZoomed(): rxjs.Observable<null> { return this.onEvent('d4-linechart-zoomed'); }
   get onLineSelected(): rxjs.Observable<EventData<LineChartLineArgs>> { return this.onEvent('d4-linechart-line-selected'); }
@@ -692,11 +694,11 @@ export class ScatterPlotViewer extends Viewer<interfaces.IScatterPlotSettings> {
   get yAxisSlider(): RangeSlider { return toJs(api.grok_ScatterPlotViewer_Get_YAxisSlider(this.dart)); }
 
   /** Convert coords */
-  worldToScreen(x: number, y: number): Point { return Point.fromXY(api.grok_ScatterPlotViewer_WorldToScreen(this.dart, x, y)); }
-  screenToWorld(x: number, y: number): Point { return Point.fromXY(api.grok_ScatterPlotViewer_ScreenToWorld(this.dart, x, y)); }
+  worldToScreen(x: number, y: number): Point { return DG.Point.fromXY(api.grok_ScatterPlotViewer_WorldToScreen(this.dart, x, y)); }
+  screenToWorld(x: number, y: number): Point { return DG.Point.fromXY(api.grok_ScatterPlotViewer_ScreenToWorld(this.dart, x, y)); }
 
   /// 32-bit integer with X in the hi 16 bits, and Y in the lo 16 bits
-  pointToScreen(index: number): Point { return Point.fromXY(api.grok_ScatterPlotViewer_PointToScreen(this.dart, index)); }
+  pointToScreen(index: number): Point { return DG.Point.fromXY(api.grok_ScatterPlotViewer_PointToScreen(this.dart, index)); }
 
   render(g: CanvasRenderingContext2D): void { api.grok_ScatterPlotViewer_Render(this.dart, g); }
   getRowTooltip(rowIdx: number): HTMLDivElement { return api.grok_ScatterPlotViewer_GetRowTooltip(this.dart, rowIdx); }


### PR DESCRIPTION
## Problem

`dev.datagrok.ai` served HTTP 200 and every health check was green, but the app never opened — the page stopped at the login shell and `window.grok` was never defined.

The deployed `/js/api/js-api.js` threw at module-init:

```
ReferenceError: Cannot access 'wi' before initialization
    at js-api.js:1:346238
```

## Root cause

`viewer.ts` imported `{FormViewer, Grid, Point, Rect}` from `./grid` at runtime, while `grid.ts` imports `{Viewer}` from `./viewer` and declares `class FormViewer extends Viewer`. That is a genuine import cycle, and `extends` is evaluated at module-evaluation time.

With webpack scope hoisting (`mode: production`) the two modules get concatenated into one scope, and which side of the cycle is emitted first is not guaranteed. Measured in the built bundle by symbol offset:

| Build | `Viewer` | `FormViewer` | Result |
|---|---|---|---|
| deployed dev (master) | 365095 | 346319 | grid first → **TDZ crash** |
| an older commit | 346078 | 373190 | viewer first → works |

So this was latent for a long time and only became fatal when the graph traversal flipped. Nothing about `dg.ts` or `grid.ts` had to change for a working build to become a broken one.

## Fix

Make the `./grid` import in `viewer.ts` **type-only** and route the two runtime uses through the global `DG` — exactly the pattern `Viewer.grid()` already used (`new DG.Grid(...)`) to dodge this same cycle.

`Grid` and `Rect` were already used only in type positions; `Point.fromXY` and `new FormViewer` were the only runtime uses, both inside method bodies. Removing the runtime edge leaves a one-directional `grid → viewer` dependency, so `viewer` always finishes evaluating before grid's `extends` runs, regardless of emit order.

No public API change: `dg.ts` still re-exports both classes from `./src/grid`.

## Verification

Built the production bundle (`webpack.config.docker.js` recipe) from `master` and from `master` + this fix, and loaded each into the real `dev.datagrok.ai` page via Playwright request interception:

| Bundle | Page errors | `window.grok` | Verdict |
|---|---|---|---|
| master | `ReferenceError: Cannot access 'yi' before initialization` | ✗ | app did not bootstrap |
| master + fix | none | ✓ (plus `DG`, `ui`, `dayjs`, `wu`, `$`) | **app bootstrapped** |

`tsc --noEmit` passes.

Symbol order after the fix: `Viewer` @ 327807 before `FormViewer` @ 373809.

## Follow-up

This class of failure — server healthy, HTML 200, client bundle dead — is invisible to the current blackbox probes, which only check `/api/admin/health`. A boot check that asserts the app actually initializes is being added separately.