### PR TITLE
JS API: fail the build when the bundle is dead on arrival

### DIFF
--- a/js-api/package.json
+++ b/js-api/package.json
@@ -93,9 +93,10 @@
     "link": "npm link",
     "link-all": "npm link @datagrok-libraries/chem-meta",
     "build-ts": "tsc && eslint ./src/*.js ./dg.js ./ui.js ./grok.js --fix",
-    "build-js-api": "git clean -f -X -d ./src && tsc && webpack",
-    "build": "tsc && webpack",
-    "build-docker": "tsc && webpack --config webpack.config.docker.js",
+    "smoke": "node scripts/smoke-bundle.cjs",
+    "build-js-api": "git clean -f -X -d ./src && tsc && webpack && npm run smoke",
+    "build": "tsc && webpack && npm run smoke",
+    "build-docker": "tsc && webpack --config webpack.config.docker.js && npm run smoke",
     "build-node": "webpack --config webpack.config.node.js",
     "build-all": "npm --prefix ./../libraries/chem-meta run build && npm run build"
   }

--- a/js-api/scripts/smoke-bundle.cjs
+++ b/js-api/scripts/smoke-bundle.cjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Fails the build when the bundled js-api.js is dead on arrival.
+ *
+ * A bundle can download perfectly, be exactly the right size, and still throw the moment
+ * a browser evaluates it. An import cycle that leaves a base class in the temporal dead
+ * zone is enough: `class FormViewer extends Viewer` in a module emitted before viewer.ts
+ * throws "Cannot access 'wi' before initialization" at init, window.grok is never
+ * defined, and every user gets a stuck login screen. webpack does not warn about it,
+ * tsc cannot see it, and HTTP health checks stay green because the asset itself is fine.
+ *
+ * Which side of a cycle webpack emits first is not stable — it shifts when unrelated
+ * imports change — so this is not a one-off. The only reliable gate is to evaluate the
+ * real bundle and require that it finishes and exports its core classes.
+ *
+ * Usage: node scripts/smoke-bundle.cjs [path/to/js-api.js]
+ */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const DEFAULT_BUNDLE = path.resolve(__dirname, '../../../core/client/xamgle/web/js/api/js-api.js');
+const bundlePath = process.argv[2] ? path.resolve(process.argv[2]) : DEFAULT_BUNDLE;
+
+// Evaluating against stubs makes deferred work (timers, promises) fail in ways a real
+// browser never would. The synchronous module-init phase is the only part that matters
+// and try/catch already covers it, so async noise is dropped.
+process.on('uncaughtException', () => {});
+process.on('unhandledRejection', () => {});
+
+// Every property access yields another callable/constructible stub, so init code that
+// pokes at DOM or rxjs globals keeps going instead of failing for an unrelated reason.
+function stub(name) {
+  const fn = function () { return stub(name + '()'); };
+  return new Proxy(fn, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;
+      if (prop === 'prototype') return target.prototype;
+      if (prop === Symbol.toPrimitive) return () => name;
+      if (prop === Symbol.iterator) return function* () {};
+      return stub(name + '.' + String(prop));
+    },
+    set: () => true,
+    has: () => true,
+    apply: () => stub(name + '()'),
+    construct: () => stub('new ' + name),
+  });
+}
+
+const REQUIRED = ['Viewer', 'Grid', 'FormViewer', 'Point', 'DataFrame', 'Column'];
+
+function fail(message, detail) {
+  console.error('\njs-api bundle smoke test FAILED');
+  console.error('  bundle: ' + bundlePath);
+  console.error('  ' + message);
+  if (detail)
+    console.error('\n' + detail);
+  console.error('\nThis bundle is served to every browser as /js/api/js-api.js. In this state the');
+  console.error('app cannot start: window.grok is never defined and users get a stuck login page.');
+  console.error('A likely cause is a new import cycle whose base class is evaluated too early —');
+  console.error('make the offending import `import type`, or reach the class through DG.* at');
+  console.error('call time, so the runtime edge disappears.');
+  process.exit(1);
+}
+
+if (!fs.existsSync(bundlePath))
+  fail('bundle not found - run the webpack build first');
+
+const sandbox = {console, setTimeout, clearTimeout, setInterval, clearInterval};
+sandbox.globalThis = sandbox;
+sandbox.window = sandbox;
+sandbox.self = sandbox;
+for (const name of ['document', 'navigator', 'location', 'rxjs', 'OCL', 'fetch', 'localStorage'])
+  sandbox[name] = stub(name);
+vm.createContext(sandbox);
+
+try {
+  new vm.Script(fs.readFileSync(bundlePath, 'utf8'), {filename: 'js-api.js'})
+    .runInContext(sandbox, {timeout: 120000});
+} catch (e) {
+  // The bundle is one minified line, so V8 splices the whole source into the stack as
+  // context. Keep only the call frames — their offsets locate the throwing class.
+  const frames = (e.stack || '').split('\n')
+    .filter((line) => /^\s+at /.test(line))
+    .slice(0, 5)
+    .join('\n');
+  fail('the bundle threw while initializing: ' + e.name + ': ' + e.message, frames);
+}
+
+const DG = sandbox.DG;
+if (!DG || typeof DG !== 'object')
+  fail('the bundle evaluated but never defined the DG export');
+
+const missing = REQUIRED.filter((name) => typeof DG[name] !== 'function');
+if (missing.length)
+  fail('DG is missing expected classes: ' + missing.join(', '));
+
+console.log(`js-api bundle smoke test passed (${REQUIRED.length} core exports present)`);


### PR DESCRIPTION
## Why

The viewer/grid TDZ regression (#3984) took dev.datagrok.ai down and **nothing caught it**. The bundle compiled, minified, was the right size, and served HTTP 200 — it just threw the instant a browser evaluated it:

```
ReferenceError: Cannot access 'wi' before initialization
```

`webpack` doesn't warn, `tsc` can't see it, and every HTTP health check stayed green because the asset itself is perfectly fine. The first signal was a human opening the site.

Worse, it isn't a one-off. Which side of an import cycle webpack emits first is **not stable** — it shifts when unrelated imports change. The same latent cycle built fine for months and then didn't.

## What

`js-api/scripts/smoke-bundle.cjs` evaluates the built bundle in a stubbed global scope and requires that it (a) finishes without throwing and (b) exports its core classes (`Viewer`, `Grid`, `FormViewer`, `Point`, `DataFrame`, `Column`).

Wired into the three build entry points:

```json
"smoke":        "node scripts/smoke-bundle.cjs",
"build":        "tsc && webpack && npm run smoke",
"build-docker": "tsc && webpack --config webpack.config.docker.js && npm run smoke",
"build-js-api": "git clean -f -X -d ./src && tsc && webpack && npm run smoke",
```

`deploy/datagrok/Dockerfile` runs `npm run build-docker` under `set -ex`, so **the image build fails** — a bundle in this state can no longer reach any environment.

No new dependencies: stdlib `fs`/`path`/`vm` only. It's `.cjs` because `js-api/.gitignore` ignores `**/*.js` (tsc emits `.js` beside every `.ts`), so a `.js` helper here would be untracked and swept by `git clean -X`.

## Verification

Both directions, using the real `build-docker` recipe:

| Source | `npm run build-docker` | Output |
|---|---|---|
| current master | **exit 0** | `js-api bundle smoke test passed (6 core exports present)` |
| master with `viewer.ts` reverted to pre-fix | **exit 1** | `the bundle threw while initializing: ReferenceError: Cannot access 'wi' before initialization` |

The failure message points at the offending byte offsets in the bundle and tells the reader what to do (make the import `import type`, or reach the class via `DG.*` at call time).

## Note on false positives

Stubs make deferred work (timers, promises) fail in ways a real browser wouldn't, so async errors after evaluation are ignored — only the synchronous module-init phase, which is where this class of bug lives, can fail the build.