### PR TITLE
CI: make package Playwright suites actually run and actually report

### DIFF
--- a/packages/UsageAnalysis/CHANGELOG.md
+++ b/packages/UsageAnalysis/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* TestTrack: Fixed the relative imports in 28 specs nested two levels deep (`../spec-login`, `../helpers/viewers`) — Playwright aborts collection when any spec fails to import, so the whole 284-spec suite had been producing zero results in CI
 * GROK-20624: Context panes: Show 0 instead of the empty-stats sentinel when a summary query returns no rows
 * GROK-6166: Query viewers: Surface query-load failures in the UI — missing/failing queries now clear the loader spinner and show an inline error message instead of silently swallowing the rejection
 * GROK-20479: Set the Reports DataFrame name so it is not listed as "null" in the Table selector

--- a/packages/UsageAnalysis/files/TestTrack/StickyMeta/primary/add-and-edit-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/StickyMeta/primary/add-and-edit-spec.ts
@@ -1,5 +1,5 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '../spec-login';
+import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '../../spec-login';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/StickyMeta/primary/copy-clone-delete-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/StickyMeta/primary/copy-clone-delete-spec.ts
@@ -1,5 +1,5 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep, stepErrors, login, password} from '../spec-login';
+import {loginToDatagrok, specTestOptions, softStep, stepErrors, login, password} from '../../spec-login';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/StickyMeta/primary/create-schema-and-type-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/StickyMeta/primary/create-schema-and-type-spec.ts
@@ -1,5 +1,5 @@
 import {test, expect} from '@playwright/test';
-import {baseUrl, loginToDatagrok, specTestOptions, softStep, stepErrors} from '../spec-login';
+import {baseUrl, loginToDatagrok, specTestOptions, softStep, stepErrors} from '../../spec-login';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/StickyMeta/primary/database-meta-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/StickyMeta/primary/database-meta-spec.ts
@@ -1,5 +1,5 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep, stepErrors, baseUrl} from '../spec-login';
+import {loginToDatagrok, specTestOptions, softStep, stepErrors, baseUrl} from '../../spec-login';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/3DScatterPlot/3d-scatter-plot-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/3DScatterPlot/3d-scatter-plot-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/BarChart/bar-chart-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/BarChart/bar-chart-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/BoxPlot/box-plot-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/BoxPlot/box-plot-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep, login} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep, login} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/Calendar/calendar-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/Calendar/calendar-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/CorrelationPlot/correlation-plot-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/CorrelationPlot/correlation-plot-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/DensityPlot/density-plot-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/DensityPlot/density-plot-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect, Page} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/Form/form-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/Form/form-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect, Page} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/FormsViewer/forms-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/FormsViewer/forms-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect, Page} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/Grid/grid-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/Grid/grid-spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/Heatmap/heatmap-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/Heatmap/heatmap-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect, Page} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/Histogram/histogram-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/Histogram/histogram-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/LineChart/line-chart-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/LineChart/line-chart-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect, type Page} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/Map/map-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/Map/map-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/MatrixPlot/matrix-plot-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/MatrixPlot/matrix-plot-spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/NetworkDiagram/network-diagram-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/NetworkDiagram/network-diagram-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/PcPlot/pc-plot-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/PcPlot/pc-plot-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/PieChart/pie-chart-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/PieChart/pie-chart-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/PivotTable/pivot-table-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/PivotTable/pivot-table-spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/ScatterPlot/scatter-plot-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/ScatterPlot/scatter-plot-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect, type Page} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep, stepErrors} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/Statistics/statistics-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/Statistics/statistics-spec.ts
@@ -1,6 +1,6 @@
 import {test} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/TileViewer/tile-viewer-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/TileViewer/tile-viewer-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/TreeMapViewer/tree-map-viewer-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/TreeMapViewer/tree-map-viewer-spec.ts
@@ -1,6 +1,6 @@
 import {test} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/TrellisPlot/trellis-plot-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/TrellisPlot/trellis-plot-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/WordCloud/word-cloud-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/WordCloud/word-cloud-spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {loginToDatagrok, specTestOptions, softStep} from '../spec-login';
-import * as v from '../helpers/viewers';
+import {loginToDatagrok, specTestOptions, softStep} from '../../spec-login';
+import * as v from '../../helpers/viewers';
 
 test.use(specTestOptions);
 

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 6.5.6 (WIP)
 
+* `grok test` — a Playwright pass that fails before running specs now reports a failing test instead of nothing. It returned an empty CSV, and the caller drops an empty Playwright result whenever the Puppeteer pass produced rows, so a suite whose config would not load (or that collected zero specs) was indistinguishable from a clean run — Build-Deploy #1277 printed "Playwright: no JSON report produced" and then "Tests passed", exit 0, for six packages. Every early exit now writes one failing row to `test-report-playwright.csv` and the merged report, and a report containing no specs is treated as a failure rather than a pass.
 * `grok report` (`ticket`, `comment`, `label`, `attach`) — support Atlassian **service-account** tokens alongside user API tokens, chosen by the token itself. A user token (`ATATT...`) keeps HTTP Basic with `JIRA_USER` + `JIRA_TOKEN` against the site. A service-account token (`ATSTT...`, minted at admin.atlassian.com) is a scoped token that the site host will not accept — Basic returns 401 and Bearer returns 403 `"Failed to parse Connect Session Auth Token"` — so it is sent as Bearer to the API gateway at `api.atlassian.com/ex/jira/<cloudId>`, with the cloud id read once from the site's public `/_edge/tenant_info` (override with `$JIRA_CLOUD_ID`). `$JIRA_URL` and `--jira-url` still mean the SITE; the gateway address is derived from it, never substituted for it. A service token needs no `JIRA_USER`, so the credential checks no longer demand one.
 
 ## 6.5.5 (WIP)

--- a/tools/bin/utils/playwright-runner.ts
+++ b/tools/bin/utils/playwright-runner.ts
@@ -144,6 +144,44 @@ function rowsToCsv(rows: FlatRow[]): string {
   return Papa.unparse({fields: header, data: rows.map((r) => header.map((h) => (r as any)[h]))});
 }
 
+function writePlaywrightCsv(pkgDir: string, csv: string): void {
+  // Persist a Playwright-only CSV so the pipeline can ship it to the Datlas
+  // 'playwright' bucket, separate from the merged Puppeteer+Playwright
+  // test-report.csv that feeds the legacy 'package' bucket and JUnit.
+  try {
+    fs.writeFileSync(path.join(pkgDir, 'test-report-playwright.csv'), csv, 'utf-8');
+  } catch (e: any) {
+    color.warn(`Playwright: failed to write test-report-playwright.csv: ${e.message || e}`);
+  }
+}
+
+// A pass that dies before running specs still has to report a failure. Returning an empty CSV
+// let the caller drop it whenever the Puppeteer pass had rows, so a suite that never launched
+// (a config that fails to load, an unreachable host) was reported as a clean run.
+function runnerFailure(pkgDir: string, args: PlaywrightArgs, message: string): ResultObject {
+  const rows: FlatRow[] = [{
+    date: new Date().toISOString(),
+    category: 'playwright',
+    name: 'Playwright suite',
+    success: false,
+    result: message,
+    ms: 0,
+    skipped: false,
+    logs: '',
+    owner: '',
+    package: process.env.TARGET_PACKAGE || args.package || '',
+    widgetsDifference: '',
+    flaking: false,
+  }];
+  const csv = rowsToCsv(rows);
+  writePlaywrightCsv(pkgDir, csv);
+  color.error(`Playwright: ${message}`);
+  return {
+    failed: true, passedAmount: 0, failedAmount: 1, skippedAmount: 0,
+    verbosePassed: '', verboseSkipped: '', verboseFailed: `Playwright: ${message}\n`, csv: csv,
+  };
+}
+
 export async function runPlaywrightTests(
   pkgDir: string,
   testDir: string,
@@ -159,16 +197,14 @@ export async function runPlaywrightTests(
   try {
     ({url, key} = testUtils.getDevKey(hostKey));
   } catch (e: any) {
-    color.error(`Playwright: cannot resolve host '${hostKey}': ${e.message || e}`);
-    return {...empty, failed: true, failedAmount: 1, verboseFailed: `Playwright: ${e.message || e}\n`};
+    return runnerFailure(pkgDir, args, `cannot resolve host '${hostKey}': ${e.message || e}`);
   }
 
   let token: string;
   try {
     token = await testUtils.getToken(url, key);
   } catch (e: any) {
-    color.error(`Playwright: cannot exchange dev key for token: ${e.message || e}`);
-    return {...empty, failed: true, failedAmount: 1, verboseFailed: `Playwright: ${e.message || e}\n`};
+    return runnerFailure(pkgDir, args, `cannot exchange dev key for token: ${e.message || e}`);
   }
 
   let webUrl: string;
@@ -190,10 +226,8 @@ export async function runPlaywrightTests(
   }
 
   const configPath = path.join(testDir, 'playwright.config.ts');
-  if (!fs.existsSync(configPath)) {
-    color.error(`Playwright: ${configPath} not found.`);
-    return {...empty, failed: true, failedAmount: 1, verboseFailed: 'Playwright: missing playwright.config.ts\n'};
-  }
+  if (!fs.existsSync(configPath))
+    return runnerFailure(pkgDir, args, `${configPath} not found`);
 
   const reportFile = path.join(pkgDir, 'test-playwright-report.json');
   if (fs.existsSync(reportFile))
@@ -277,12 +311,8 @@ export async function runPlaywrightTests(
   }
 
   if (!report) {
-    color.error('Playwright: no JSON report produced.');
     const tail = Buffer.concat(stderrChunks).toString('utf-8').slice(-2000);
-    return {
-      ...empty, failed: true, failedAmount: 1,
-      verboseFailed: `Playwright: no JSON report. stderr tail:\n${tail}\n`,
-    };
+    return runnerFailure(pkgDir, args, `no JSON report produced — the suite never ran. stderr tail:\n${tail}`);
   }
 
   const pkgJson = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf-8'));
@@ -291,6 +321,11 @@ export async function runPlaywrightTests(
 
   const rows: FlatRow[] = [];
   flattenSuites(report.suites, testDir, pkgName, typeof owner === 'string' ? owner : '', args.verbose === true, rows);
+
+  // A report with no specs is the same non-event as no report at all: the config loaded but
+  // collection found nothing, or died on a spec that cannot be imported.
+  if (rows.length === 0)
+    return runnerFailure(pkgDir, args, 'the run produced a report with no specs — check the spec imports and testMatch');
 
   let passedAmount = 0;
   let failedAmount = 0;
@@ -306,14 +341,7 @@ export async function runPlaywrightTests(
   }
 
   const csv = rowsToCsv(rows);
-  // Persist a Playwright-only CSV so the pipeline can ship it to the Datlas
-  // 'playwright' bucket, separate from the merged Puppeteer+Playwright
-  // test-report.csv that feeds the legacy 'package' bucket and JUnit.
-  try {
-    fs.writeFileSync(path.join(pkgDir, 'test-report-playwright.csv'), csv, 'utf-8');
-  } catch (e: any) {
-    color.warn(`Playwright: failed to write test-report-playwright.csv: ${e.message || e}`);
-  }
+  writePlaywrightCsv(pkgDir, csv);
 
   return {
     failed: failedAmount > 0,


### PR DESCRIPTION
Every package-owned Playwright suite has been producing zero results since it was wired up. The pipeline half of the fix is in the reddata repo; this is the `public` half.

**`grok test`** — a Playwright pass that dies before running specs returned an empty CSV, and the caller drops an empty Playwright result whenever the Puppeteer pass produced rows. Build-Deploy #1277 printed `Playwright: no JSON report produced` and then `Tests passed`, exit 0, for six packages. Every early exit now writes one failing row to `test-report-playwright.csv` and the merged report, and a report containing no specs is a failure rather than a pass.

**UsageAnalysis TestTrack** — 28 specs nested two levels deep imported `../spec-login` and `../helpers/viewers` one level short. Playwright aborts collection when any spec fails to import, so all 284 specs produced nothing. All 284 now resolve (verified by a resolver sweep over every relative import).

Note the `grok test` change cannot reach CI until `datagrok-tools` is published and the `grok_tester` image rebuilt — the stages run the published CLI baked into `grok_tester:6.5.3`. The pipeline-side guard in reddata covers CI in the meantime.

Verified in `Test-Package-Playwright-TEMP` #1 (reddata branch): Charts' Playwright pass produced 10 specs / 9 passed / 1 real failure where it previously produced none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)