### PR TITLE
GROK-20763: GrokConnect: don't destroy the connection pool on a transient checkout timeout

### DIFF
--- a/connectors/grok_connect/src/main/java/grok_connect/utils/ConnectionPool.java
+++ b/connectors/grok_connect/src/main/java/grok_connect/utils/ConnectionPool.java
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.SQLTransientConnectionException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
@@ -34,7 +33,7 @@ public class ConnectionPool {
         try {
             HikariDataSource ds = getOrCreateDataSource(key, url, properties, driverClassName);
             return ds.getConnection();
-        } catch (HikariPool.PoolInitializationException | SQLTransientConnectionException e) {
+        } catch (HikariPool.PoolInitializationException e) {
             HikariDataSource pool = connectionPool.remove(key);
             if (pool != null)
                 pool.close();
@@ -53,7 +52,7 @@ public class ConnectionPool {
         try {
             HikariDataSource ds = getOrCreateDataSource(key, dataSource);
             return ds.getConnection();
-        } catch (HikariPool.PoolInitializationException | SQLTransientConnectionException e) {
+        } catch (HikariPool.PoolInitializationException e) {
             HikariDataSource pool = connectionPool.remove(key);
             if (pool != null)
                 pool.close();


### PR DESCRIPTION
## GROK-20763

`ConnectionPool.getConnection()` caught `SQLTransientConnectionException` together with `HikariPool.PoolInitializationException` and, in that handler, removed the datasource from the pool map and called `pool.close()`.

But `SQLTransientConnectionException` is HikariCP's **normal pool-saturation signal** — thrown when `connectionTimeout` elapses waiting for a free connection under load — not a pool-initialization failure. So a single saturation timeout destroyed the shared pool for every in-flight query using that connection, and the next query paid a full pool re-initialization. Under sustained load this thrashes continuously.

### Fix
Removed `SQLTransientConnectionException` from the fatal catch clause in both `getConnection` overloads. As a subclass of `SQLException`, it now falls through to the existing `catch (SQLException …)` handler, which wraps and rethrows it **without touching the pool** — the timeout surfaces to the caller and the shared pool is preserved.

Verified by code analysis (the only path that removed/closed the pool no longer matches this exception) and by compilation. Found during an audit of `public/connectors`.
