### PR TITLE
GROK-20764: GrokConnect: stop dialing live Snowflake in CI; scrub secrets from test fixtures

### DIFF
--- a/connectors/grok_connect/src/test/java/grok_connect/providers/SnowflakeDataProviderTest.java
+++ b/connectors/grok_connect/src/test/java/grok_connect/providers/SnowflakeDataProviderTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.MethodSource;
 import serialization.DataFrame;
 
+@Disabled("Connects to a live Snowflake account - enable only against a dedicated test instance with credentials supplied out-of-band")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SnowflakeDataProviderTest {
     private static final Provider type = Provider.SNOWFLAKE;

--- a/connectors/grok_connect/src/test/resources/properties/athena.properties
+++ b/connectors/grok_connect/src/test/resources/properties/athena.properties
@@ -3,6 +3,6 @@ database=test_db
 accessKey=
 secretKey=
 region=eu-west-3
-S3OutputLocation:s3://datagrok-provider-test/queries
+S3OutputLocation:s3://<output-bucket>/queries
 VPCEndpoint:""
 S3OutputEncOption:""

--- a/connectors/grok_connect/src/test/resources/properties/redshift.properties
+++ b/connectors/grok_connect/src/test/resources/properties/redshift.properties
@@ -1,6 +1,6 @@
 providerName=Redshift
 user=
 password=
-server=grok.115780339528.eu-west-3.redshift-serverless.amazonaws.com
+server=<redshift-serverless-host>
 port=5439
 database=test

--- a/connectors/grok_connect/src/test/resources/properties/snowflake.properties
+++ b/connectors/grok_connect/src/test/resources/properties/snowflake.properties
@@ -1,8 +1,8 @@
 providerName=Snowflake
 database=test
 user=datagrok
-password=pBx7dyjp_Dgrok2001
-accountLocator=WM00888
+password=<snowflake-test-password>
+accountLocator=<account-locator>
 region=us-east-2
 cloud=aws
 warehouse=COMPUTE_WH

--- a/connectors/grok_connect/src/test/resources/properties/virtuoso.properties
+++ b/connectors/grok_connect/src/test/resources/properties/virtuoso.properties
@@ -1,6 +1,6 @@
 providerName=Virtuoso
 database=
 user=dba
-password=myDbaPassword
+password=<dba-password>
 server=localhost
 port=1111


### PR DESCRIPTION
## GROK-20764

`SnowflakeDataProviderTest` had **no class-level `@Disabled`** — unlike every other cloud-provider test (Athena/Redshift/Teradata/PI/Virtuoso/Impala) — so CI connected to a **live Snowflake account** with a committed password on every connectors PR. Combined with the CI suite ignoring test failures, the result was swallowed.

Also found: `redshift.properties` leaked an AWS account id in the hostname, `athena.properties` a private S3 bucket, `virtuoso.properties` a DBA password.

### Fix
- Added `@Disabled` to `SnowflakeDataProviderTest` so CI no longer dials the live account.
- Scrubbed the Snowflake password + account locator, the Redshift AWS-account host, the Athena bucket, and the Virtuoso password to placeholders. Container-provider fixtures (Postgres/MySQL/Oracle/…) were left intact — those are throwaway testcontainer credentials and scrubbing them would break the containerized tests that actually run.

### ⚠️ Requires out-of-band action (cannot be done in-repo)
- **Rotate/revoke the exposed Snowflake credential** — it is compromised and still present in git history; this change only removes it from HEAD.
- Consider purging the secret from history (BFG / filter-repo).
- Long-term, cloud-provider tests should read credentials from CI secrets, not committed fixtures.

Found during an audit of `public/connectors`.
