### PR TITLE
CI-CD core: playwright-public: fix the specs the nightly has been failing/flaking on

### DIFF
--- a/playwright-public/Sharing/share-connection-permissions.test.ts
+++ b/playwright-public/Sharing/share-connection-permissions.test.ts
@@ -113,7 +113,6 @@ test('Sharing & Permissions — Connection', async ({page}) => {
     await expect(dlg.locator('.d4-dialog-title')).toContainText('Share');
     await expect(page.locator('input[placeholder="User, group, or email"]')).toBeVisible();
     await expect(page.locator('[name="div-share-selector"]')).toBeVisible();
-    await expect(page.locator('[name="label-Advanced-editor..."]')).toBeVisible();
     await expect(page.locator('[name="button-OK"]')).toBeVisible();
     await expect(page.locator('[name="button-CANCEL"]')).toBeVisible();
     
@@ -164,6 +163,11 @@ test('Sharing & Permissions — Connection', async ({page}) => {
   });
 
   await softStep('Block B.3: CANCEL closes dialog; no grant changed (owner-only)', async () => {
+    // The suggestion dropdown left open by B.1 renders over the dialog footer and swallows the
+    // click on CANCEL; clearing the input collapses it.
+    await page.locator('input[placeholder="User, group, or email"]').fill('');
+    await expect(page.locator('.d4-tags-selector-drop-down.d4-user-selector-drop-down'))
+      .toBeHidden({timeout: 10_000});
     await page.locator('[name="button-CANCEL"]').click();
     await expect(page.locator('.d4-dialog')).toHaveCount(0, {timeout: 10_000});
     

--- a/playwright-public/Sharing/share-layout-permissions.test.ts
+++ b/playwright-public/Sharing/share-layout-permissions.test.ts
@@ -156,7 +156,6 @@ test('Sharing & Permissions — Layout', async ({page}) => {
     await expect(dlg.locator('.d4-dialog-title')).toContainText('Share');
     await expect(page.locator('input[placeholder="User, group, or email"]')).toBeVisible();
     await expect(page.locator('[name="div-share-selector"]')).toBeVisible();
-    await expect(page.locator('[name="label-Advanced-editor..."]')).toBeVisible();
     await expect(page.locator('[name="button-OK"]')).toBeVisible();
     await expect(page.locator('[name="button-CANCEL"]')).toBeVisible();
     

--- a/playwright-public/Sharing/share-query-permissions.test.ts
+++ b/playwright-public/Sharing/share-query-permissions.test.ts
@@ -97,7 +97,6 @@ test('Sharing & Permissions — Query', async ({page}) => {
     await expect(dlg.locator('.d4-dialog-title')).toContainText('Share');
     await expect(page.locator('input[placeholder="User, group, or email"]')).toBeVisible();
     await expect(page.locator('[name="div-share-selector"]')).toBeVisible();
-    await expect(page.locator('[name="label-Advanced-editor..."]')).toBeVisible();
     await expect(page.locator('[name="button-OK"]')).toBeVisible();
     await expect(page.locator('[name="button-CANCEL"]')).toBeVisible();
     

--- a/playwright-public/Sharing/share-script-permissions.test.ts
+++ b/playwright-public/Sharing/share-script-permissions.test.ts
@@ -148,7 +148,6 @@ test('Sharing & Permissions — Script', async ({page}) => {
     await expect(dlg.locator('.d4-dialog-title')).toContainText('Share');
     await expect(page.locator('input[placeholder="User, group, or email"]')).toBeVisible();
     await expect(page.locator('[name="div-share-selector"]')).toBeVisible();
-    await expect(page.locator('[name="label-Advanced-editor..."]')).toBeVisible();
     await expect(page.locator('[name="button-OK"]')).toBeVisible();
     await expect(page.locator('[name="button-CANCEL"]')).toBeVisible();
     
@@ -197,6 +196,11 @@ test('Sharing & Permissions — Script', async ({page}) => {
   });
 
   await softStep('Block B.3: CANCEL closes dialog; no grant changed (owner-only)', async () => {
+    // The suggestion dropdown left open by B.1 renders over the dialog footer and swallows the
+    // click on CANCEL; clearing the input collapses it.
+    await page.locator('input[placeholder="User, group, or email"]').fill('');
+    await expect(page.locator('.d4-tags-selector-drop-down.d4-user-selector-drop-down'))
+      .toBeHidden({timeout: 10_000});
     await page.locator('[name="button-CANCEL"]').click();
     await expect(page.locator('.d4-dialog')).toHaveCount(0, {timeout: 10_000});
     

--- a/playwright-public/Sharing/share-table-permissions.test.ts
+++ b/playwright-public/Sharing/share-table-permissions.test.ts
@@ -69,36 +69,8 @@ async function pollPermission(
   return last;
 }
 
-async function openAdvancedEditorToPermissionsRoute(page: Page, tableId: string) {
-  const label = page.locator('[name="label-Advanced-editor..."]');
-  await label.waitFor({state: 'visible', timeout: 15_000});
-  
-  await expect.poll(async () => page.evaluate(() => {
-    const e = document.querySelector('[name="label-Advanced-editor..."]') as HTMLElement | null;
-    if (!e) return false;
-    const r = e.getBoundingClientRect();
-    return e.offsetParent !== null && r.width > 0 && r.height > 0;
-  }), {timeout: 15_000, intervals: [200, 400, 800]}).toBe(true);
-
-  
-  
-  const uiDeadline = Date.now() + 8_000;
-  while (Date.now() < uiDeadline) {
-    const onPermRoute = await page.evaluate(() => /\/permissions\/[0-9a-f-]+/.test(window.location.href));
-    if (onPermRoute) return;
-    const advStillThere = await page.locator('[name="label-Advanced-editor..."]').count();
-    if (advStillThere > 0)
-      await page.locator('[name="label-Advanced-editor..."]').dispatchEvent('click').catch(() => {});
-    try {
-      await page.waitForFunction(() => /\/permissions\/[0-9a-f-]+/.test(window.location.href),
-        null, {timeout: 2_000});
-      return; 
-    } catch (_) {  }
-  }
-
-  
-  
-  await page.evaluate((id) => { try { grok.shell.route(`/permissions/${id}`); } catch (_) {  } }, tableId);
+async function openPermissionsView(page: Page, tableId: string) {
+  await page.evaluate((id) => grok.shell.route(`/permissions/${id}`), tableId);
   await page.waitForFunction(() => /\/permissions\/[0-9a-f-]+/.test(window.location.href),
     null, {timeout: 15_000});
 }
@@ -198,7 +170,6 @@ test('Sharing & Permissions — Table', async ({page}) => {
     await expect(dlg.locator('.d4-dialog-title')).toContainText('Share');
     await expect(page.locator('input[placeholder="User, group, or email"]')).toBeVisible();
     await expect(page.locator('[name="div-share-selector"]')).toBeVisible();
-    await expect(page.locator('[name="label-Advanced-editor..."]')).toBeVisible();
     await expect(page.locator('[name="button-OK"]')).toBeVisible();
     await expect(page.locator('[name="button-CANCEL"]')).toBeVisible();
     
@@ -281,7 +252,7 @@ test('Sharing & Permissions — Table', async ({page}) => {
     
     
     
-    await openAdvancedEditorToPermissionsRoute(page, tableId);
+    await openPermissionsView(page, tableId);
     await page.waitForTimeout(2500);
     await expect(page.locator('.grok-permissions-self, [class*="grok-permissions"]').first())
       .toBeVisible({timeout: 15_000});

--- a/playwright-public/Sharing/sharing-smoke.test.ts
+++ b/playwright-public/Sharing/sharing-smoke.test.ts
@@ -39,7 +39,7 @@ async function openShareDialogViaPane(page: Page, projId: string) {
   await page.locator('.d4-dialog').waitFor({state: 'visible', timeout: 15_000});
 }
 
-test('Sharing — UI Smoke (Single-Actor): share dialog, context panel, advanced editor', async ({page}) => {
+test('Sharing — UI Smoke (Single-Actor): share dialog, context panel, permissions view', async ({page}) => {
   // Single-actor UI lifecycle: project save + share dialog / context panel / advanced
   // editor render checks. No login switches; 180s is ample.
   test.setTimeout(180_000);
@@ -145,12 +145,6 @@ test('Sharing — UI Smoke (Single-Actor): share dialog, context panel, advanced
       await expect(dlg.locator('[name="div-share-selector"]'),
         'access-level dropdown (View and use / Full access) must be present').toBeAttached({timeout: 10_000});
       
-      await expect(dlg.locator('[name="label-Advanced-editor..."]'),
-        'Advanced editor... link must be present').toBeAttached({timeout: 10_000});
-      
-      
-      
-      
       await expect(dlg.locator('textarea[placeholder="Type in message here"]'),
         'notification message textarea must be present').toBeAttached({timeout: 10_000});
       await expect(dlg.locator('[name="input-Send-notifications"]'),
@@ -158,7 +152,7 @@ test('Sharing — UI Smoke (Single-Actor): share dialog, context panel, advanced
       
       await expect(dlg.locator('[name="button-OK"]'), 'OK button must be present').toBeAttached({timeout: 10_000});
       await expect(dlg.locator('[name="button-CANCEL"]'), 'CANCEL button must be present').toBeAttached({timeout: 10_000});
-      console.log('[sharing-smoke] Scenario 1: PermissionsEditor widget fully rendered (input, dropdown, advanced link, notify, OK/CANCEL)');
+      console.log('[sharing-smoke] Scenario 1: PermissionsEditor widget fully rendered (input, dropdown, notify, OK/CANCEL)');
       
     });
 
@@ -191,10 +185,14 @@ test('Sharing — UI Smoke (Single-Actor): share dialog, context panel, advanced
       console.log(`[sharing-smoke] Scenario 2: autocomplete popup visible with ${suggestionCount} suggestion(s)`);
 
       
+      // The suggestion dropdown renders over the dialog footer and swallows the click on
+      // CANCEL; clearing the input collapses it.
+      await input.fill('');
+      await expect(popup, 'suggestion popup must collapse when the input is cleared').toBeHidden({timeout: 10_000});
       await dlg.locator('[name="button-CANCEL"]').click();
       await expect(dlg, 'dialog must close on CANCEL').toBeHidden({timeout: 10_000});
 
-      
+
       const after = await evalJs(page, `(async () => {
         const g = window.grok;
         const p = await g.dapi.projects.find('${projId}');
@@ -211,22 +209,17 @@ test('Sharing — UI Smoke (Single-Actor): share dialog, context panel, advanced
     
     
     
-    await softStep('Scenario 4: Advanced editor... opens the PermissionsView matrix', async () => {
-      await openShareDialogViaPane(page, projId!);
-      const dlg = page.locator('.d4-dialog');
-      const advLabel = dlg.locator('[name="label-Advanced-editor..."]');
-      await expect(advLabel, 'Advanced editor... link must be present').toBeAttached({timeout: 10_000});
-      await advLabel.click();
-      
-      
-      
+    await softStep('Scenario 4: PermissionsView matrix opens at /permissions/<id>', async () => {
+      await evalJs(page, `window.grok.shell.route('/permissions/${projId}')`);
+      await page.waitForFunction(() => /\/permissions\/[0-9a-f-]+/.test(window.location.href),
+        null, {timeout: 15_000});
       const loaded = page.locator(
         '[name="button-Calculate-resulting-permissions-for-this-entity"], ' +
         'input[placeholder="Type in user, role or group to add..."], ' +
         '[name="button-Save"], .d4-grid',
       ).first();
-      await expect(loaded, 'PermissionsView (Advanced editor) must load with its matrix surface').toBeVisible({timeout: 25_000});
-      console.log('[sharing-smoke] Scenario 4: Advanced editor PermissionsView loaded (DOM signal, class-1)');
+      await expect(loaded, 'PermissionsView must load with its matrix surface').toBeVisible({timeout: 25_000});
+      console.log('[sharing-smoke] Scenario 4: PermissionsView loaded (DOM signal, class-1)');
 
       
       await evalJs(page, `(async () => { try { window.grok.shell.closeAll(); } catch(_){} })()`).catch(() => {});
@@ -238,8 +231,8 @@ test('Sharing — UI Smoke (Single-Actor): share dialog, context panel, advanced
         const perms = await g.dapi.permissions.get(p);
         return {groupCount: [...(perms.view||[]), ...(perms.edit||[])].length};
       })()`);
-      expect(after.groupCount, 'navigating away from Advanced editor without SAVE must alter no permissions').toBe(0);
-      console.log('[sharing-smoke] Scenario 4: left Advanced editor without SAVE; permissions unchanged');
+      expect(after.groupCount, 'navigating away from the PermissionsView without SAVE must alter no permissions').toBe(0);
+      console.log('[sharing-smoke] Scenario 4: left the PermissionsView without SAVE; permissions unchanged');
     });
   } finally {
     

--- a/playwright-public/browse/demo_apps.test.ts
+++ b/playwright-public/browse/demo_apps.test.ts
@@ -126,14 +126,19 @@ function treeName(path: string[]): string {
 /** Expand a tree group identified by its stable `name="tree-..."` attribute (unambiguous, by name). */
 async function expandByTreeName(page: Page, name: string): Promise<void> {
   const node = page.locator(`[name="${name}"]`).first();
-  await node.waitFor({ state: 'visible', timeout: 20_000 });
+  // A node below the fold is attached but not visible, and scrolling is what makes it visible —
+  // waiting for visible before scrolling can never succeed.
+  await node.waitFor({ state: 'attached', timeout: 20_000 });
   await node.scrollIntoViewIfNeeded();
+  await node.waitFor({ state: 'visible', timeout: 20_000 });
   const tri = node.locator(TREE_EXPAND_ARROW).first();
-  const expanded = await tri.evaluate((el) => el.classList.contains('d4-tree-view-tri-expanded')).catch(() => false);
-  if (expanded) return;
+  const isExpanded = () => tri.evaluate((el) => el.classList.contains('d4-tree-view-tri-expanded')).catch(() => false);
+  if (await isExpanded()) return;
   if (await tri.isVisible().catch(() => false)) await tri.click();
   else await node.click();
-  await page.waitForTimeout(900);
+  // Children of a group that has not finished expanding are display:none, so the next step
+  // would look for them too early. Wait for the group to report itself expanded.
+  await expect.poll(isExpanded, { timeout: 20_000, intervals: [100, 200, 400, 800] }).toBe(true);
 }
 
 /**
@@ -148,8 +153,9 @@ async function openDemo(page: Page, demo: Demo): Promise<void> {
     await expandByTreeName(page, treeName(demo.path.slice(0, i)));
   // Wait until the parent group's children are actually rendered, then click the leaf.
   const leaf = page.locator(`[name="${treeName(demo.path)}"]`).first();
-  await leaf.waitFor({ state: 'visible', timeout: 20_000 });
+  await leaf.waitFor({ state: 'attached', timeout: 20_000 });
   await leaf.scrollIntoViewIfNeeded();
+  await leaf.waitFor({ state: 'visible', timeout: 20_000 });
   await leaf.click();
 }
 

--- a/playwright-public/browse/helpers.ts
+++ b/playwright-public/browse/helpers.ts
@@ -145,8 +145,11 @@ export async function openTreeItem(
   await expandTreeGroup(page, parent);
   const { treeItemByName } = await import('./selectors');
   const item = treeItemByName(page, itemName);
-  await item.waitFor({ state: 'visible', timeout: 10_000 });
+  // An item below the fold is attached but not visible, and scrolling is what makes it
+  // visible — waiting for visible before scrolling can never succeed.
+  await item.waitFor({ state: 'attached', timeout: 10_000 });
   await item.scrollIntoViewIfNeeded();
+  await item.waitFor({ state: 'visible', timeout: 10_000 });
   if (options?.dblclick) await item.dblclick();
   else await item.click();
   await page.waitForTimeout(1000);

--- a/playwright-public/browse/tree.test.ts
+++ b/playwright-public/browse/tree.test.ts
@@ -114,7 +114,12 @@ test.describe('Browse tree (Browse-Tree-*)', () => {
 
     // Switch view: open Tutorials. Sidebar switches to Toolbox after a table-like view opens.
     await expandTreeGroup(page, 'Apps');
-    await treeItemByName(page, 'Tutorials').click();
+    // Files and Databases are expanded above, so Tutorials sits below the fold — scroll it in
+    // before clicking, or the click waits on an element that will never become visible.
+    const tutorials = treeItemByName(page, 'Tutorials');
+    await tutorials.waitFor({ state: 'attached', timeout: 20_000 });
+    await tutorials.scrollIntoViewIfNeeded();
+    await tutorials.click();
     await page.waitForTimeout(2000);
 
     // Return to the Browse panel from the Sidebar.

--- a/playwright-public/connections/04-browser.test.ts
+++ b/playwright-public/connections/04-browser.test.ts
@@ -220,8 +220,10 @@ test.describe.serial('Connections / Browser (Postgres / browser_new_test_postgre
     await showContextPanel(page);
 
     const { paneTextContent } = await clickContextPanelSection(page, 'Activity');
-    const text = await paneTextContent();
-    expect(text).toMatch(/created|edited|shared|test/i);
+    // The pane paints its header and entry count first and fills the rows in afterwards, so a
+    // single read can catch it at "Activity3" — the count without the entries.
+    await expect.poll(paneTextContent, { timeout: 20_000, intervals: [500, 1000, 2000] })
+      .toMatch(/created|edited|shared|test/i);
   });
 
   test('5. Chats — send a message via the chat box', async ({ page }) => {

--- a/playwright-public/connections/helpers.ts
+++ b/playwright-public/connections/helpers.ts
@@ -407,7 +407,19 @@ export async function clickConnectionTest(page: Page, timeout = 60_000): Promise
 /** Click the OK button in the connection dialog and wait for the dialog to detach. */
 export async function clickConnectionOk(page: Page): Promise<void> {
   await page.locator('.d4-dialog [name="button-OK"]').click();
-  await page.locator('.d4-dialog').waitFor({ state: 'detached', timeout: 15_000 });
+  try {
+    // Saving a connection is a server round trip and 15s is not always enough on a loaded agent.
+    await page.locator('.d4-dialog').waitFor({ state: 'detached', timeout: 60_000 });
+  } catch (e) {
+    // A dialog that never closes is either a slow save or a rejected one; the balloon says which,
+    // and without it the failure is an anonymous locator timeout.
+    const why = await page.evaluate(() => ({
+      dialogs: Array.from(document.querySelectorAll('.d4-dialog')).map((d) => d.getAttribute('name')),
+      balloons: Array.from(document.querySelectorAll('.grok-balloon, .d4-balloon'))
+        .map((b) => (b.textContent || '').trim()).filter(Boolean),
+    })).catch(() => null);
+    throw new Error(`the connection dialog did not close after OK: ${JSON.stringify(why)}`);
+  }
 }
 
 /** Click the SAVE button inside the connection dialog (used by Edit... in some versions). */

--- a/playwright-public/projects/complex-derived-tables.test.ts
+++ b/playwright-public/projects/complex-derived-tables.test.ts
@@ -10,6 +10,16 @@ import {deleteProjectWithCleanup} from '@datagrok-libraries/test/src/playwright/
 
 test.use(projectsTestOptions);
 
+/**
+ * Projects created by THIS run, found by the stamp every entity it creates carries — including a
+ * stray project named after the joined table, which is what the invariant is looking for.
+ * Counting all projects instead cannot work: dev holds 5000+ of them, and anyone saving one
+ * concurrently moves the number.
+ */
+function readRunProjectCount(page: Page, stamp: number): Promise<number> {
+  return evalJs(page, `(async () => (await grok.dapi.projects.filter('${stamp}').list({pageSize: 100})).length)()`);
+}
+
 async function closeAll(page: Page) {
   await evalJs(page, 'grok.shell.closeAll()');
 }
@@ -84,10 +94,8 @@ test('Projects / Complex derived-tables: Join lands in active project (GROK-1910
     });
 
     await softStep('Step 2: capture project-count baseline before Save (GROK-19103 invariant prep)', async () => {
-      baselineCount = await evalJs(page,
-        `(async () => (await grok.dapi.projects.list({limit: 1000})).length)()`,
-      );
-      expect(baselineCount).toBeGreaterThanOrEqual(0);
+      baselineCount = await readRunProjectCount(page, stamp);
+      expect(baselineCount, 'nothing carrying this run\'s stamp should exist before Save').toBe(0);
     });
 
     await softStep('Step 2: Save current project with Data Sync ON', async () => {
@@ -127,9 +135,11 @@ test('Projects / Complex derived-tables: Join lands in active project (GROK-1910
     });
 
     await softStep('GROK-19103 INVARIANT: exactly ONE new project created (no stray join-only project)', async () => {
-      const afterCount = await evalJs(page,
-        `(async () => (await grok.dapi.projects.list({limit: 1000})).length)()`,
-      );
+      // The project list is eventually consistent after save: read it too soon and the project
+      // the previous step just confirmed exists is still absent, which reads as "none created".
+      await expect.poll(() => readRunProjectCount(page, stamp), {timeout: 60_000, intervals: [1000, 2000, 3000]})
+        .toBeGreaterThan(baselineCount);
+      const afterCount = await readRunProjectCount(page, stamp);
       // GROK-19103: a stray join-only project would push delta to 2+.
       expect(afterCount - baselineCount).toBe(1);
     });

--- a/playwright-public/queries/helpers.ts
+++ b/playwright-public/queries/helpers.ts
@@ -583,13 +583,33 @@ export async function saveQuery(page: Page, friendlyName: string): Promise<void>
   // landed — a lingering dialog or the preloader swallows it, and the spec then waits out
   // the whole timeout with nothing saved. Re-click until the query is actually on the
   // server. Save is idempotent on an existing query, so a repeat is an update, not a copy.
-  await expect(async () => {
-    if (await findQueryByFriendlyName(page, friendlyName)) return;
-    await page.locator('[name="button-Save"]').first().click({ timeout: 5_000 });
-    await expect.poll(async () =>
-      (await findQueryByFriendlyName(page, friendlyName)) !== null,
-    { timeout: 20_000 }).toBe(true);
-  }).toPass({ timeout: 90_000 });
+  try {
+    await expect(async () => {
+      if (await findQueryByFriendlyName(page, friendlyName)) return;
+      await page.locator('[name="button-Save"]').first().click({ timeout: 5_000 });
+      await expect.poll(async () =>
+        (await findQueryByFriendlyName(page, friendlyName)) !== null,
+      { timeout: 20_000 }).toBe(true);
+    }).toPass({ timeout: 90_000 });
+  } catch (e) {
+    // A bare timeout cannot tell "Save never committed" from "committed under a different
+    // name", and those have different owners. Report what the server and the editor actually
+    // hold so the next occurrence is diagnosable from the CI log alone.
+    const state = await page.evaluate(async (fn) => {
+      const g = (window as unknown as { grok: any }).grok;
+      const byName = await g.dapi.queries.filter(`name = "${fn}"`).list().catch(() => []);
+      const nameInput = document.querySelector('[name="input-Name"]') as HTMLInputElement | null;
+      const save = document.querySelector('[name="button-Save"]') as HTMLElement | null;
+      return {
+        foundByName: byName.map((q: any) => ({name: q.name, friendlyName: q.friendlyName})),
+        nameInputValue: nameInput?.value ?? '(no name input)',
+        saveButton: save ? save.className : '(absent)',
+        dialogsOpen: document.querySelectorAll('.d4-dialog').length,
+      };
+    }, friendlyName).catch((err) => ({probeFailed: String(err).slice(0, 200)}));
+    throw new Error(`saveQuery("${friendlyName}") never appeared with that friendlyName.\n` +
+      `Editor/server state at give-up: ${JSON.stringify(state)}\n${String(e).slice(0, 400)}`);
+  }
 }
 
 /** Find a saved query by the user-facing name (stored server-side as `friendlyName`). */

--- a/playwright-public/spaces/spaces-general-v2.test.ts
+++ b/playwright-public/spaces/spaces-general-v2.test.ts
@@ -684,14 +684,23 @@ test('7. Share dialog: UI structure, share with permission, verify, delete remov
     await rightClickSpace(page, SPACE);
     await clickMenuItem(page, 'Share...');
     await expect(page.locator('input[placeholder*="User"]').first()).toBeVisible({ timeout: 8_000 });
-    const permSelect = page.locator('select').first();
-    await expect(permSelect).toBeVisible({ timeout: 5_000 });
-    await expect(permSelect.locator('option', { hasText: /Full access/i })).toHaveCount(1);
-    await expect(permSelect.locator('option', { hasText: /View and use/i })).toHaveCount(1);
+    const permSelector = page.locator('[name="div-share-selector"]');
+    const permLabel = permSelector.locator('.grok-privilege-selector-label');
+    await expect(permSelector).toBeVisible({ timeout: 5_000 });
+    await permSelector.locator('.grok-privilege-selector').click();
+    const permTree = page.locator('.grok-privilege-selector-tree');
+    await expect(permTree).toBeVisible({ timeout: 5_000 });
+    await expect(permTree.locator('[name="tree-Full-access"]')).toHaveCount(1);
+    await expect(permTree.locator('[name="tree-View-and-use"]')).toHaveCount(1);
 
     // Part B: select "View and use" permission explicitly, share with second user
-    await permSelect.selectOption({ label: 'View and use' });
-    const selectedValue = await permSelect.inputValue();
+    // "View and use" is the default, and the tree items are checkboxes — clicking one that is
+    // already selected would clear it.
+    if (!/View and use/.test(await permLabel.textContent() ?? ''))
+      await permTree.locator('[name="tree-View-and-use"] input[type="checkbox"]').check();
+    await page.keyboard.press('Escape');
+    await expect(permTree).toBeHidden({ timeout: 5_000 });
+    await expect(permLabel).toHaveText(/View and use/);
     const userInput = page.locator('input[placeholder*="User"]').first();
     await userInput.fill(SHARING_LOGIN);
     await page.waitForTimeout(1000);

--- a/playwright-public/spaces/spaces-general-v2.test.ts
+++ b/playwright-public/spaces/spaces-general-v2.test.ts
@@ -698,10 +698,12 @@ test('7. Share dialog: UI structure, share with permission, verify, delete remov
     // already selected would clear it.
     if (!/View and use/.test(await permLabel.textContent() ?? ''))
       await permTree.locator('[name="tree-View-and-use"] input[type="checkbox"]').check();
-    await page.keyboard.press('Escape');
+    // Escape closes the whole Share dialog and leaves the popup orphaned, so dismiss it the
+    // way a user would — by clicking on into the recipient field.
+    const userInput = page.locator('input[placeholder*="User"]').first();
+    await userInput.click();
     await expect(permTree).toBeHidden({ timeout: 5_000 });
     await expect(permLabel).toHaveText(/View and use/);
-    const userInput = page.locator('input[placeholder*="User"]').first();
     await userInput.fill(SHARING_LOGIN);
     await page.waitForTimeout(1000);
     // Select the user from autocomplete dropdown

--- a/playwright-public/stickymeta/01-schema-and-type.md
+++ b/playwright-public/stickymeta/01-schema-and-type.md
@@ -11,7 +11,7 @@ Covers the admin configuration surface of Sticky Meta: defining a metadata **ent
 
 **Test data**
 
-- Entity type name: `PW_SM1_Type_<suffix>`, matching expression `semtype=molecule`.
+- Entity type name: `PW_SM1_Type_<suffix>`, matching expression `source=PW_SM1_<suffix>` (run-unique, so this schema never joins spec 02's Sticky meta dialog).
 - Schema name: `PW_SM1_Schema_<suffix>`, associated with the entity type above, properties:
   `rating` (int), `notes` (string), `verified` (bool), `review_date` (datetime).
 
@@ -30,7 +30,7 @@ Covers the admin configuration surface of Sticky Meta: defining a metadata **ent
    **Name** and **Matching expression**.
 3. With both fields empty, observe the **OK** button.
 4. Type the name only, observe **OK**.
-5. Enter the matching expression `semtype=molecule`. Click **OK**.
+5. Enter the matching expression `source=PW_SM1_<suffix>`. Click **OK**.
 
 **Expected**
 

--- a/playwright-public/stickymeta/01-schema-and-type.test.ts
+++ b/playwright-public/stickymeta/01-schema-and-type.test.ts
@@ -38,7 +38,9 @@ test('Sticky Meta: entity type & schema lifecycle (create, edit, delete)', async
 
     await typeDialog.locator('[name="input-Matching-expression"]').click();
     await page.keyboard.press('Control+A');
-    await page.keyboard.type('semtype=molecule', { delay: 10 });
+    // Nothing here depends on what the expression matches, and a molecule matcher would put this
+    // schema into spec 02's Sticky meta dialog while both run — a run-unique source tag cannot.
+    await page.keyboard.type(`source=${PREFIX}${suffix}`, { delay: 10 });
     await expect(typeDialog.locator('[name="button-OK"]')).not.toHaveClass(/disabled/);
 
     await H.clickDialogButton(page, 'dialog-Create-a-new-entity-type', 'button-OK');

--- a/playwright-public/stickymeta/02-add-and-edit.test.ts
+++ b/playwright-public/stickymeta/02-add-and-edit.test.ts
@@ -54,17 +54,31 @@ test('Sticky Meta: add & edit metadata (cell, sticky column, batch)', async ({ p
         .find((l) => l.textContent?.trim() === 'Edit for current cell...');
       (edit?.closest('.d4-menu-item') as HTMLElement)?.click();
       await new Promise((r) => setTimeout(r, 1500));
+      // The dialog stacks a flat section per matching schema — header, property hosts, Save — with
+      // no per-schema container. Mark ours (it owns the only Rating host, asserted below) so the
+      // reads and clicks cannot drift into a neighbour's: dev carries a second molecule schema, and
+      // an unscoped query there clicks its Save, leaving everything typed here unsaved.
+      const kids = Array.from(document.querySelectorAll('.d4-dialog .d4-build-root.ui-form > *'));
+      for (let i = kids.findIndex((el) => el.getAttribute('name') === 'input-host-Rating'); i >= 0 && i < kids.length; i++) {
+        kids[i].setAttribute('data-pw-mine', '');
+        if (kids[i].querySelector('[name="button-Save"]')) break;
+      }
       return document.querySelector('.d4-dialog .d4-dialog-header, .d4-dialog .d4-dialog-title')?.textContent?.trim();
     });
 
     expect(await openCellEditor()).toBe('Sticky meta');
 
+    // What the marking above anchors on: a second schema carrying a `rating` would take it over.
+    // Spec 01 used to, and that is what broke this test in builds #357 and #360.
+    expect(await page.evaluate(() =>
+      document.querySelectorAll('.d4-dialog [name="input-host-Rating"]').length)).toBe(1);
+
     const readCellDialog = () => page.evaluate(() => {
       const d = document.querySelector('.d4-dialog') as HTMLElement;
       return {
-        rating: (d.querySelector('[name="input-host-Rating"] input') as HTMLInputElement).value,
-        notes: (d.querySelector('[name="input-host-Notes"] input') as HTMLInputElement).value,
-        verified: (d.querySelector('[name="input-host-Verified"] input[type="checkbox"]') as HTMLInputElement).checked,
+        rating: (d.querySelector('[data-pw-mine][name="input-host-Rating"] input') as HTMLInputElement).value,
+        notes: (d.querySelector('[data-pw-mine][name="input-host-Notes"] input') as HTMLInputElement).value,
+        verified: (d.querySelector('[data-pw-mine][name="input-host-Verified"] input[type="checkbox"]') as HTMLInputElement).checked,
       };
     });
     const closeDialog = async () => {
@@ -74,24 +88,24 @@ test('Sticky Meta: add & edit metadata (cell, sticky column, batch)', async ({ p
     const expected = { rating: '5', notes: 'test note', verified: true };
 
     // Fill rating, notes, verified.
-    await page.locator('.d4-dialog [name="input-host-Rating"] input').click();
+    await page.locator('.d4-dialog [data-pw-mine][name="input-host-Rating"] input').click();
     await page.keyboard.press('Control+a');
     await page.keyboard.type('5');
     await page.keyboard.press('Tab');
-    await page.locator('.d4-dialog [name="input-host-Notes"]').first().locator('input').click();
+    await page.locator('.d4-dialog [data-pw-mine][name="input-host-Notes"] input').click();
     await page.keyboard.press('Control+a');
     await page.keyboard.type('test note');
     await page.keyboard.press('Tab');
     await page.evaluate(() => {
-      const cb = document.querySelector('.d4-dialog [name="input-host-Verified"] input[type="checkbox"]') as HTMLInputElement;
+      const cb = document.querySelector('.d4-dialog [data-pw-mine][name="input-host-Verified"] input[type="checkbox"]') as HTMLInputElement;
       if (!cb.checked) cb.click();
     });
     await page.waitForTimeout(400);
     // Confirm the dialog holds the values before saving (catches fill failures distinctly).
     expect(await readCellDialog()).toEqual(expected);
 
-    // Click the schema section's Save and give the server round-trip time to commit.
-    await page.evaluate(() => (document.querySelector('.d4-dialog [name="button-Save"]') as HTMLElement | null)?.click());
+    // Click our schema section's Save and give the server round-trip time to commit.
+    await page.evaluate(() => (document.querySelector('.d4-dialog [data-pw-mine] [name="button-Save"]') as HTMLElement | null)?.click());
     await page.waitForTimeout(2500);
     await closeDialog();
 

--- a/playwright-public/user groups/helpers.ts
+++ b/playwright-public/user groups/helpers.ts
@@ -95,7 +95,11 @@ export async function clearGallerySearch(page: Page, kind: 'users' | 'groups' | 
 export async function searchAndWaitCard(
   page: Page, kind: 'users' | 'groups' | 'roles', search: string, matchName: string = search,
 ): Promise<void> {
-  for (let i = 0; i < 8; i++) {
+  // A fixed attempt count spends about half a minute and then gives up; on a loaded CI agent the
+  // search index sometimes takes longer than that, which is the only way this has ever failed.
+  // Bound the wait by time instead, so a slow indexer costs patience rather than a red run.
+  const deadline = Date.now() + 120_000;
+  for (let i = 0; i === 0 || Date.now() < deadline; i++) {
     await searchGallery(page, kind, search);
     const card = galleryCardByName(page, matchName);
     if (await card.isVisible().catch(() => false)) {


### PR DESCRIPTION
Sixteen playwright-public specs that the nightly reported red, fixed in the tests only - no product code is touched. Four root causes:

- The share dialog lost its `Advanced editor...` link and its privilege dropdown became a checkbox tree (GROK-20322). Six Sharing specs and the spaces spec now follow the new UI.
- The Browse tree helper waited for an item to be visible before scrolling it into view, which can never succeed below the fold. Five specs.
- Two specs asserted against server-wide counts that only hold on a small stand: the projects join invariant counted all 5000+ projects on dev.
- Sticky Meta specs 01 and 02 registered schemas matching the same molecules and collided inside one dialog; 02 also clicked the neighbouring schema's Save.

Two failures that never reproduced outside CI are not fixed — they now report their own state instead, so the next red run explains itself.

The spaces "delete removes access" spec stays red on purpose: GROK-20759.

Verified on dev — Sticky Meta three parallel runs 9/9, connections/04-browser 6/6, user groups 20/21, projects join green.