### PR TITLE
JKG: point the last two references at the split images

### DIFF
--- a/docker/docker-enter-bash.cmd
+++ b/docker/docker-enter-bash.cmd
@@ -1,1 +1,3 @@
-docker exec -u root -it datagrok-jupyter_kernel_gateway-1 bash
+set SVC=%1
+if "%SVC%"=="" set SVC=jkg_python
+docker exec -u root -it datagrok-%SVC%-1 bash

--- a/packages/NodejsApiDemo/README.md
+++ b/packages/NodejsApiDemo/README.md
@@ -39,5 +39,5 @@ or from the browser console with the same two lines minus the bootstrap.
 ## Requirements
 
 The JKG image must ship `datagrok-api` (built from repo source since GROK-20443;
-`deploy/jupyter_kernel_gateway/Dockerfile`). Scripts run with `detached` js-api
+`deploy/jkg_nodejs/Dockerfile`). Scripts run with `detached` js-api
 init — nothing user-specific is cached across calls in the shared kernel.


### PR DESCRIPTION
The `public` half of retiring the all-languages kernel gateway image; the reddata side archives the Dockerfile and updates the service docs.

`docker/docker-enter-bash.cmd` still exec'd into `datagrok-jupyter_kernel_gateway-1`, a container none of the four local-install compose files start any more — they all name `jkg_python` and friends. It now takes a service name and defaults to `jkg_python`.

`packages/NodejsApiDemo/README.md` pointed at `deploy/jupyter_kernel_gateway/Dockerfile` for the `datagrok-api` build; that lives in `deploy/jkg_nodejs/Dockerfile` (verified — it builds js-api from repo source at lines 25-46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)