### PR TITLE
CI: build and publish grok_connect_adbc images

### DIFF
--- a/.github/workflows/grok_connect_adbc.yaml
+++ b/.github/workflows/grok_connect_adbc.yaml
@@ -1,0 +1,181 @@
+name: Grok Connect ADBC
+on:
+  workflow_dispatch: { }
+  push:
+    branches:
+      - master
+      - 'release/**'
+    paths:
+      - 'connectors_adbc/**'
+      - '.github/workflows/grok_connect_adbc.yaml'
+  pull_request:
+    paths:
+      - 'connectors_adbc/**'
+      - '.github/workflows/grok_connect_adbc.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release/') }}
+
+jobs:
+  common-check:
+    name: Common checks
+    uses: ./.github/workflows/common_check.yaml
+    with:
+      run_trigger: ${{ github.event_name }}
+
+  docker:
+    name: Build Docker
+    needs: common-check
+    runs-on: ubuntu-22.04
+    # Unlike the Java connectors there is no separate compile job: the Dockerfile builds
+    # the ClickHouse ADBC driver (Rust/cmake) and the BigQuery and Snowflake drivers (Go)
+    # from source before the service itself, which is far past the default job budget on
+    # a cold cache.
+    timeout-minutes: 120
+    if: needs.common-check.outputs.continue == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            ./connectors_adbc
+            ./.github
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Get version
+        id: get_version
+        working-directory: ./connectors_adbc
+        run: |
+          version=$(awk '/^\[package\]/{p=1;next} /^\[/{p=0} p && /^version[[:space:]]*=/{gsub(/.*= *"|".*/,"");print;exit}' Cargo.toml)
+          if [[ -z "${version}" ]]; then
+            echo "::error title=Version::could not read version from connectors_adbc/Cargo.toml"
+            exit 1
+          fi
+          echo "version=${version}" >> $GITHUB_OUTPUT
+      - name: Check published image
+        id: check
+        run: |
+          version="${{ steps.get_version.outputs.version }}"
+          token=$(curl -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:datagrok/grok_connect_adbc:pull" | jq --raw-output .token)
+          image_status=$(curl -LIs -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${token}" "https://registry.hub.docker.com/v2/datagrok/grok_connect_adbc/manifests/${version}")
+          echo "${image_status}"
+          # 404 = tag missing; 401 = the repo itself does not exist yet (first release of a new repo)
+          if [[ "${image_status}" == "404" || "${image_status}" == "401" ]] ; then
+            echo "image_exists=false" >> $GITHUB_OUTPUT
+          else
+            echo "image_exists=true" >> $GITHUB_OUTPUT
+          fi
+          latest_pushed=$(curl --retry 5 -LsS "https://registry.hub.docker.com/v2/repositories/datagrok/grok_connect_adbc/tags?page_size=20" | jq -r '[.results[]? | select(.name | test("[0-9]+\\.[0-9]+\\.[0-9]+"))] | sort_by(.tag_last_pushed) | reverse[0].name // "0.0.0"')
+          newest_version=$(echo -e "$latest_pushed\n$version" | sort -V | tail -n1)
+          if [[ "${newest_version}" == "${version}" ]] ; then
+            echo "latest=true" >> $GITHUB_OUTPUT
+          else
+            echo "latest=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Set buildx parameters
+        id: param
+        run: |
+          commit_sha=$(echo ${{ github.sha }} | cut -c1-8)
+          branch=$(echo ${GITHUB_REF#refs/heads/})
+          echo "commit_sha=${commit_sha}" >> $GITHUB_OUTPUT
+          echo "branch=${branch}" >> $GITHUB_OUTPUT
+          if [[ ${{ steps.check.outputs.image_exists }} == 'true' ]]; then
+            platform='linux/amd64'
+            echo "platform=${platform}" >> $GITHUB_OUTPUT
+            tar="grok_connect_adbc_${{ steps.get_version.outputs.version }}-$(echo ${platform#linux/})-${commit_sha}-${{ github.run_id }}-${{ github.run_attempt }}.tar"
+            echo "tar=${tar}" >> $GITHUB_OUTPUT
+            echo "dest=type=docker,dest=/tmp/${tar}" >> $GITHUB_OUTPUT
+
+            echo "tags=datagrok/grok_connect_adbc:${{ steps.get_version.outputs.version }}-${commit_sha}" >> $GITHUB_OUTPUT
+          else
+            echo "platform=linux/amd64" >> $GITHUB_OUTPUT
+            if [[ ${{ steps.check.outputs.latest }} == 'true' ]]; then
+              echo "cache_to=type=registry,ref=datagrok/grok_connect_adbc:cache,mode=max" >> $GITHUB_OUTPUT
+              echo "tags=datagrok/grok_connect_adbc:latest,datagrok/grok_connect_adbc:${{ steps.get_version.outputs.version }}" >> $GITHUB_OUTPUT
+            else
+              echo "tags=datagrok/grok_connect_adbc:${{ steps.get_version.outputs.version }}" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - uses: hadolint/hadolint-action@v2.0.0
+        with:
+          dockerfile: ./connectors_adbc/Dockerfile
+          failure-threshold: error
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        id: build-push
+        with:
+          context: ./connectors_adbc
+          platforms: ${{ steps.param.outputs.platform }}
+          push: ${{ (steps.check.outputs.image_exists == 'false') && (github.ref == 'refs/heads/master' || startsWith(github.ref,'refs/heads/release/') == true) }}
+          tags: ${{ steps.param.outputs.tags }}
+          cache-from: type=registry,ref=datagrok/grok_connect_adbc:cache
+          cache-to: ${{ steps.param.outputs.cache_to }}
+          outputs: ${{ steps.param.outputs.dest }}
+          labels: |
+            BRANCH=${{ steps.param.outputs.branch }}
+            COMMIT_PUBLIC=${{ github.sha }}
+
+      - name: Build and push bleeding-edge
+        if: github.ref == 'refs/heads/master'
+        id: bleeding-edge
+        uses: docker/build-push-action@v3
+        with:
+          context: ./connectors_adbc
+          platforms: ${{ steps.param.outputs.platform }}
+          push: true
+          tags: "datagrok/grok_connect_adbc:bleeding-edge"
+          cache-from: type=registry,ref=datagrok/grok_connect_adbc:cache
+          cache-to: ${{ steps.param.outputs.cache_to }}
+          labels: |
+            BRANCH=${{ steps.param.outputs.branch }}
+            COMMIT_PUBLIC=${{ github.sha }}
+
+      - name: Upload Artifact
+        if: steps.param.outputs.tar != '' && github.ref != 'refs/heads/master' && startsWith(github.ref,'refs/heads/release/') != true
+        id: docker-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.param.outputs.tar }}
+          path: /tmp/${{ steps.param.outputs.tar }}
+          retention-days: 7
+
+      - name: Get actors slack
+        id: actor
+        uses: ./.github/actions/slack-user-action
+        with:
+          slack-token: ${{ secrets.SLACKBOT_TOKEN }}
+          email-mapping: ${{ secrets.EMAIL_SLACK_ID }}
+      - name: Get owners slack
+        id: owner
+        uses: ./.github/actions/slack-user-action
+        with:
+          slack-token: ${{ secrets.SLACKBOT_TOKEN }}
+          emails: "ppolovyi@datagrok.ai"
+      - name: Prepare Slack Message
+        id: slack-prepare
+        if: steps.docker-artifact.outcome == 'skipped' && (steps.build-push.outcome == 'success' || steps.bleeding-edge.outcome == 'success')
+        shell: bash
+        run: |
+          if [[ "${{ steps.bleeding-edge.outcome == 'success' }}" == "true" ]]; then
+            header="*grok_connect_adbc* Docker Image version *bleeding-edge* is published to Docker Hub"
+            echo SLACK_CHANNEL=${{ steps.actor.outputs.user-ids }} >> $GITHUB_ENV
+          else
+            mentions=$(echo -e "${{ steps.actor.outputs.user-ids }}\n${{ steps.owner.outputs.user-ids }}" | sort -u)
+            header="*grok_connect_adbc* Docker Image version *${{ steps.get_version.outputs.version }}* is published to Docker Hub.\n$(for value in $mentions; do echo -n "<@$value> "; done) FYI"
+            echo SLACK_CHANNEL='#build' >> $GITHUB_ENV
+          fi
+
+          echo "SLACK_MESSAGE_HEADER=$header" >> $GITHUB_ENV
+      - name: Send to Slack
+        id: slack
+        if: steps.slack-prepare.outcome == 'success'
+        uses: ./.github/actions/slack-post-action
+        with:
+          channel: ${{ env.SLACK_CHANNEL }}
+          slack-token: ${{ secrets.SLACKBOT_TOKEN }}
+          message: ${{ env.SLACK_MESSAGE_HEADER }}

--- a/.github/workflows/grok_connect_adbc.yaml
+++ b/.github/workflows/grok_connect_adbc.yaml
@@ -82,6 +82,14 @@ jobs:
           branch=$(echo ${GITHUB_REF#refs/heads/})
           echo "commit_sha=${commit_sha}" >> $GITHUB_OUTPUT
           echo "branch=${branch}" >> $GITHUB_OUTPUT
+          # Only master/release runs publish. Everything gated on this must stay off for
+          # pull_request runs: a PR that writes cache-to would push layers to the shared
+          # registry cache tag from an unmerged (and on a fork, untrusted) branch.
+          if [[ "${GITHUB_REF}" == "refs/heads/master" || "${GITHUB_REF}" == refs/heads/release/* ]]; then
+            echo "publishes=true" >> $GITHUB_OUTPUT
+          else
+            echo "publishes=false" >> $GITHUB_OUTPUT
+          fi
           if [[ ${{ steps.check.outputs.image_exists }} == 'true' ]]; then
             platform='linux/amd64'
             echo "platform=${platform}" >> $GITHUB_OUTPUT
@@ -93,7 +101,9 @@ jobs:
           else
             echo "platform=linux/amd64" >> $GITHUB_OUTPUT
             if [[ ${{ steps.check.outputs.latest }} == 'true' ]]; then
-              echo "cache_to=type=registry,ref=datagrok/grok_connect_adbc:cache,mode=max" >> $GITHUB_OUTPUT
+              if [[ "${GITHUB_REF}" == "refs/heads/master" || "${GITHUB_REF}" == refs/heads/release/* ]]; then
+                echo "cache_to=type=registry,ref=datagrok/grok_connect_adbc:cache,mode=max" >> $GITHUB_OUTPUT
+              fi
               echo "tags=datagrok/grok_connect_adbc:latest,datagrok/grok_connect_adbc:${{ steps.get_version.outputs.version }}" >> $GITHUB_OUTPUT
             else
               echo "tags=datagrok/grok_connect_adbc:${{ steps.get_version.outputs.version }}" >> $GITHUB_OUTPUT
@@ -158,7 +168,10 @@ jobs:
           emails: "ppolovyi@datagrok.ai"
       - name: Prepare Slack Message
         id: slack-prepare
-        if: steps.docker-artifact.outcome == 'skipped' && (steps.build-push.outcome == 'success' || steps.bleeding-edge.outcome == 'success')
+        # Gate on the ref, not on the artifact step: a pull_request run skips the artifact
+        # upload whenever the version tag is unpublished, which would otherwise announce a
+        # publish that never happened (push: false on PRs).
+        if: steps.param.outputs.publishes == 'true' && (steps.build-push.outcome == 'success' || steps.bleeding-edge.outcome == 'success')
         shell: bash
         run: |
           if [[ "${{ steps.bleeding-edge.outcome == 'success' }}" == "true" ]]; then


### PR DESCRIPTION
## Problem

`connectors_adbc/` has **no build pipeline**. It is absent from the `grok_connect.yaml` matrix (which covers only `grok_connect` and `grok_connect_extended`) and from every other workflow — the only references to `grok_connect_adbc` outside the crate are a compose profile name in `packages.yaml` and local test scripts that `docker build` a throwaway `:test` tag.

Consequence: `datagrok/grok_connect_adbc:bleeding-edge` was pushed by hand on **2026-08-18** and never refreshed, while `connectors_adbc/` moved on **2026-08-21** in `810a122930` *"Grok Connect ADBC: Rust ADBC connector service"*. CI has been running a connector build that predates that commit — `Build-Deploy-Datagrok` pulls this tag for its DB test stage.

## Change

Adds `.github/workflows/grok_connect_adbc.yaml`, mirroring `grok_connect.yaml`: published-version gate, hadolint, versioned + `latest` tags, `bleeding-edge` on master, PR artifact upload, Slack notification.

Two deliberate differences from the Java workflow:

- **No separate compile job.** The Dockerfile builds the ClickHouse ADBC driver (Rust/cmake) and the BigQuery and Snowflake drivers (Go) from source before the service itself, so compilation already happens inside the image build. Hence `timeout-minutes: 120`.
- **Version comes from `Cargo.toml`** (`[package].version`, currently `0.1.0`) instead of `mvn help:evaluate`.

The workflow's own path is in the trigger list, so edits to it are exercised by a real build on the PR rather than only after merge.

## Validation

- YAML parses; job/step graph matches `grok_connect.yaml`.
- Version extraction verified against the real `Cargo.toml` → `0.1.0`.
- `hadolint --failure-threshold error` run locally against `connectors_adbc/Dockerfile`: **exits 0** (5 warnings/info, no errors), so the lint gate will not block.
- The full image build has *not* been run end to end — the PR's own CI run is the first real exercise of it.

## After merge

Trigger once via `workflow_dispatch` on master to publish a current `bleeding-edge` and close the gap left by the 08-18 hand-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFyaKFNwhL1KW4MViVmnD1