### PR TITLE
DBTests: accept the lossless bigint to int narrowing in expectTable

### DIFF
--- a/libraries/test/src/test.ts
+++ b/libraries/test/src/test.ts
@@ -240,6 +240,14 @@ export function expectFloat(actual: number, expected: number, tolerance = 0.001,
     throw new Error(`Expected ${expected}, got ${actual} (tolerance = ${tolerance})`);
 }
 
+/** grok_connect ships a `bigint` column as `int` while every value in it fits int32, and upgrades
+ * it back on the first chunk that overflows (`int8AsInt32`, streaming queries only — see
+ * core/docs/features/connector-streaming-optimization/RESULTS_P1.md WO-1.5). The narrowing is
+ * lossless, so a test that declares `bigint` must accept `int` for small values. */
+function isLosslessNarrowing(expected: string, actual: string): boolean {
+  return expected === DG.TYPE.BIG_INT && actual === DG.TYPE.INT;
+}
+
 export function expectTable(actual: _DG.DataFrame, expected: _DG.DataFrame, error?: string): void {
   const expectedRowCount = expected.rowCount;
   const actualRowCount = actual.rowCount;
@@ -249,7 +257,8 @@ export function expectTable(actual: _DG.DataFrame, expected: _DG.DataFrame, erro
     const actualColumn = actual.columns.byName(column.name);
     if (actualColumn == null)
       throw new Error(`Column ${column.name} not found`);
-    if (actualColumn.type != column.type)
+    const narrowed = isLosslessNarrowing(column.type, actualColumn.type);
+    if (actualColumn.type != column.type && !narrowed)
       throw new Error(`Column ${column.name} type expected ${column.type} got ${actualColumn.type}`);
     for (let i = 0; i < expectedRowCount; i++) {
       const value = column.get(i);
@@ -258,6 +267,9 @@ export function expectTable(actual: _DG.DataFrame, expected: _DG.DataFrame, erro
         expectFloat(actualValue, value, 0.0001, error);
       else if (column.type == DG.TYPE.DATE_TIME)
         expect(actualValue.isSame(value), true, error);
+      else if (narrowed)
+        // bigint reads back as a string, int as a number — compare the value, not the encoding.
+        expect(String(actualValue), String(value), error);
       else
         expect(actualValue, value, error);
     }


### PR DESCRIPTION
127 provider tests across Snowflake, Postgresql, MariaDb, MySql, Neo4j and MSSQL have failed with `Column id type expected bigint got int` since GROK-20752 landed.

That behaviour is deliberate: the connector ships a `bigint` column as `int` while every value fits int32 and upgrades it back on the first chunk that overflows (`int8AsInt32`, streaming queries only). `core/docs/features/connector-streaming-optimization/RESULTS_P1.md` WO-1.5 records `row_id` arriving as `int` with an identical fingerprint. The expectations were never updated alongside it.

`expectTable` now accepts `int` where `bigint` is declared. It still compares every value — only the type equality is relaxed, and only in that direction — so a narrowing that actually lost data fails exactly as before.

**Verified in CI** on a full DBTests stand: 316 cases, **127 bigint failures → 0**, no new failures. The 6 remaining are unrelated: 5 docker-container tests that time out on the throwaway stand (they pass on the nightly) and `PostgresqlDates`, a separate producer-side change in how Postgres interval text is rendered — I confirmed the `string:tokens` codec round-trips that text byte-identically, so it is not a decoding bug and its expectation is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)