### PR TITLE
GrokConnect: Pin the Postgres interval rendering to six units

### DIFF
--- a/connectors/CHANGELOG.md
+++ b/connectors/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Streaming: chunks are gzipped in grok_connect when Datlas sends `compressChunks` (`gzipLevel`, default 1); announced as `DATAFRAME PART SIZE: <n> gzip=true` and passed through by Datlas
 * Streaming: two-stage pipeline - fetch(k+2) runs in parallel with serialize+gzip(k+1) while chunk k is sent; `-Dgrok.connect.pipelineFetch=false` restores the single-task path; closing mid-stream flags the query cancelled and waits (up to 5 s) for the in-flight fetch before releasing the connection
 * Debug: `COLUMN SIZES` line (per-column bytes/gz/encoder) after the serialize END marker; per-column encode `ms` only with the `columnTimings` query option
+* Fixed: Postgres `interval` columns lost their zero-valued units (`1 years 5 mons 5 days` instead of `1 years 5 mons 5 days 0 hours 0 mins 0.0 secs`) after the 2.8.0 driver refresh — pgjdbc 42.7.13 rewrote `PGInterval.toString()`; the six-unit rendering is now pinned in `PgIntervalTypeConverter` instead of coming from the driver
 * Fixed: the shaded jar failed every hostname lookup on JDK >= 18 (dnsjava's `java.net.spi.InetAddressResolverProvider` service entry pointed at a multi-release class the shade drops); the entry is now excluded
 * Fixed: `grok_connect.cmd` / `grok_connect.sh` put `lib/*` before the jar on the classpath, letting a driver's bundled SLF4J shadow the shaded one
 * `initConnectFetchSize` with a non-numeric value (e.g. `"10 MB"`, which only `connectFetchSize` accepts) now fails with a clear message instead of a bare `NumberFormatException`

--- a/connectors/grok_connect/src/main/java/grok_connect/managers/string_column/DefaultStringColumnManager.java
+++ b/connectors/grok_connect/src/main/java/grok_connect/managers/string_column/DefaultStringColumnManager.java
@@ -14,6 +14,7 @@ import oracle.sql.CLOB;
 import oracle.sql.NCLOB;
 import oracle.xdb.XMLType;
 import org.postgresql.jdbc.PgSQLXML;
+import org.postgresql.util.PGInterval;
 import org.w3c.dom.Document;
 import serialization.Column;
 import serialization.StringColumn;
@@ -52,6 +53,7 @@ public class DefaultStringColumnManager implements ColumnManager<String> {
         converterMap.put(DefaultTupleValue.class, gettableByIndexConverter);
         converterMap.put(DefaultUdtValue.class, gettableByIndexConverter);
         converterMap.put(Document.class, new DocumentTypeConverter());
+        converterMap.put(PGInterval.class, new PgIntervalTypeConverter());
     }
 
     @Override

--- a/connectors/grok_connect/src/main/java/grok_connect/managers/string_column/converters/PgIntervalTypeConverter.java
+++ b/connectors/grok_connect/src/main/java/grok_connect/managers/string_column/converters/PgIntervalTypeConverter.java
@@ -1,0 +1,24 @@
+package grok_connect.managers.string_column.converters;
+
+import grok_connect.managers.Converter;
+import org.postgresql.util.PGInterval;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+// pgjdbc 42.7.13 (upstream PR 3866) rewrote PGInterval.getValue() to skip zero-valued units, so
+// relying on toString() silently changed every interval on the wire — "1 years 5 mons 5 days
+// 0 hours 0 mins 0.0 secs" became "1 years 5 mons 5 days" on a driver bump alone. Render the six
+// units here so the value does not depend on the driver version.
+public class PgIntervalTypeConverter implements Converter<String> {
+    @Override
+    public String convert(Object value) {
+        PGInterval interval = (PGInterval) value;
+        DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+        df.applyPattern("0.0#####");
+        return String.format(Locale.ROOT, "%d years %d mons %d days %d hours %d mins %s secs",
+                interval.getYears(), interval.getMonths(), interval.getDays(),
+                interval.getHours(), interval.getMinutes(), df.format(interval.getSeconds()));
+    }
+}

--- a/connectors/grok_connect/src/test/java/grok_connect/managers/string_column/PgIntervalTypeConverterTest.java
+++ b/connectors/grok_connect/src/test/java/grok_connect/managers/string_column/PgIntervalTypeConverterTest.java
@@ -1,0 +1,42 @@
+package grok_connect.managers.string_column;
+
+import grok_connect.managers.ColumnManager;
+import grok_connect.resultset.ColumnMeta;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.postgresql.util.PGInterval;
+
+// Guards the six-unit interval rendering against a driver bump: pgjdbc 42.7.13 dropped the
+// zero-valued units from PGInterval.toString(), which changed every interval on the wire.
+class PgIntervalTypeConverterTest {
+    private static final ColumnMeta META = new ColumnMeta(java.sql.Types.OTHER, "interval", 0, 0, "interval", 1);
+
+    private String convert(PGInterval interval) {
+        ColumnManager<String> manager = new DefaultStringColumnManager();
+        return manager.convert(interval, META);
+    }
+
+    @Test
+    void keepsZeroValuedUnits() {
+        Assertions.assertEquals("1 years 5 mons 5 days 0 hours 0 mins 0.0 secs",
+                convert(new PGInterval(1, 5, 5, 0, 0, 0.0)));
+    }
+
+    @Test
+    void rendersEveryUnit() {
+        Assertions.assertEquals("2 years 3 mons 4 days 5 hours 6 mins 7.5 secs",
+                convert(new PGInterval(2, 3, 4, 5, 6, 7.5)));
+    }
+
+    @Test
+    void rendersZeroInterval() {
+        Assertions.assertEquals("0 years 0 mons 0 days 0 hours 0 mins 0.0 secs",
+                convert(new PGInterval(0, 0, 0, 0, 0, 0.0)));
+    }
+
+    @Test
+    void rendersNegativeInterval() {
+        Assertions.assertEquals("-1 years -2 mons -3 days -4 hours -5 mins -6.5 secs",
+                convert(new PGInterval(-1, -2, -3, -4, -5, -6.5)));
+    }
+}


### PR DESCRIPTION
## Summary

The 2.8.0 driver refresh moved pgjdbc 42.7.5 → 42.7.13. 42.7.13 rewrote `PGInterval.getValue()` ([pgjdbc#3866](https://github.com/pgjdbc/pgjdbc/pull/3866)) to skip zero-valued units. Because the value reaches the wire through the default converter's `toString()`, **every Postgres `interval` column silently changed shape on a driver bump alone**:

| interval | 42.7.5 (before) | 42.7.13 (now) |
|---|---|---|
| 1y 5mo 5d | `1 years 5 mons 5 days 0 hours 0 mins 0.0 secs` | `1 years 5 mons 5 days` |
| zero | `0 years 0 mons 0 days 0 hours 0 mins 0.0 secs` | `0 secs` |
| 1.234567s | `0 years 0 mons 0 days 0 hours 0 mins 1.234567 secs` | `1.234567 secs` |

It surfaced as `DBTests.Postgresql | PostgresqlDates`, which passed in Build-Deploy-Datagrok #1284 and failed in #1285 once the rebuilt connector image reached dev — but the change affected every interval column, not just that test.

## Fix

Render the six units in a `PgIntervalTypeConverter` registered on `DefaultStringColumnManager`, following the existing `converterMap` pattern, so the value no longer depends on the driver version.

Verified against the real 42.7.13 driver for the golden, full, zero, negative and microsecond cases; `PgIntervalTypeConverterTest` locks the rendering in.

Generated with [Claude Code](https://claude.com/claude-code)