### PR TITLE
CI-CD core: playwright-public: fix the three specs the nightly reported red

### DIFF
--- a/playwright-public/Sharing/share-table-permissions.test.ts
+++ b/playwright-public/Sharing/share-table-permissions.test.ts
@@ -70,7 +70,7 @@ async function pollPermission(
 }
 
 async function openPermissionsView(page: Page, tableId: string) {
-  await page.evaluate((id) => grok.shell.route(`/permissions/${id}`), tableId);
+  await page.evaluate((id) => { grok.shell.route(`/permissions/${id}`); }, tableId);
   await page.waitForFunction(() => /\/permissions\/[0-9a-f-]+/.test(window.location.href),
     null, {timeout: 15_000});
 }

--- a/playwright-public/Sharing/sharing-smoke.test.ts
+++ b/playwright-public/Sharing/sharing-smoke.test.ts
@@ -210,7 +210,7 @@ test('Sharing — UI Smoke (Single-Actor): share dialog, context panel, permissi
     
     
     await softStep('Scenario 4: PermissionsView matrix opens at /permissions/<id>', async () => {
-      await evalJs(page, `window.grok.shell.route('/permissions/${projId}')`);
+      await evalJs(page, `void window.grok.shell.route('/permissions/${projId}')`);
       await page.waitForFunction(() => /\/permissions\/[0-9a-f-]+/.test(window.location.href),
         null, {timeout: 15_000});
       const loaded = page.locator(

--- a/playwright-public/user groups/groups.test.ts
+++ b/playwright-public/user groups/groups.test.ts
@@ -45,6 +45,7 @@ const GROUP = `qa_autotest_g_${STAMP}`;
 const GROUP_RENAMED = `${GROUP}_renamed`;
 const MEMBER_USER = 'opavlenko454';    // seeded user added as a member
 const CHILD_GROUP = 'UsersTest';        // seeded group nested into GROUP
+const SIBLING_GROUP = 'GroupsTest';     // second group so the Groups-06 search has something to narrow
 
 test.describe.configure({ mode: 'serial' });
 
@@ -55,6 +56,8 @@ test.describe('Groups View (Groups-*)', () => {
     try {
       await ensureUserSeeded(page, MEMBER_USER);
       await ensureGroupSeeded(page, CHILD_GROUP);
+      // Groups-06 asserts that searching narrows the list, which needs at least two groups to exist.
+      await ensureGroupSeeded(page, SIBLING_GROUP);
     } finally {
       await ctx.close();
     }

--- a/playwright-public/user groups/groups.test.ts
+++ b/playwright-public/user groups/groups.test.ts
@@ -130,7 +130,7 @@ test.describe('Groups View (Groups-*)', () => {
     expect(filtered.shown).toBeLessThan(before.total);
     expect(filtered.shown).toBeGreaterThan(0);
     await clearGallerySearch(page, 'groups');
-    expect((await readGalleryCount(page)).shown).toBe(before.total);
+    expect((await readGalleryCount(page)).total).toBe(before.total);
   });
 
   // Groups-08 + Groups-10: context menu items and context-panel info panes.

--- a/playwright-public/user groups/helpers.ts
+++ b/playwright-public/user groups/helpers.ts
@@ -53,12 +53,21 @@ export async function openPlatformView(page: Page, name: PlatformView): Promise<
 
 /** Parse the "shown / total" gallery counter into numbers, polling until it settles. */
 export async function readGalleryCount(page: Page): Promise<{ shown: number; total: number }> {
+  // The counter is parseable long before it is final — a gallery still loading reads "2 / 2" and
+  // only later "3 / 3" — so wait for the same text twice rather than taking the first match.
   const counter = page.locator(GALLERY_COUNTS).first();
   let m: RegExpMatchArray | null = null;
-  for (let i = 0; i < 20; i++) {
+  let last = '';
+  let repeats = 0;
+  for (let i = 0; i < 40; i++) {
     const text = (await counter.textContent().catch(() => ''))?.trim() ?? '';
-    m = text.match(/(\d+)\s*\/\s*(\d+)/);
-    if (m) break;
+    const parsed = text.match(/(\d+)\s*\/\s*(\d+)/);
+    if (parsed) {
+      m = parsed;
+      repeats = text === last ? repeats + 1 : 0;
+      if (repeats >= 2) break;
+    }
+    last = text;
     await page.waitForTimeout(250);
   }
   if (!m) return { shown: NaN, total: NaN };

--- a/playwright-public/user groups/roles.test.ts
+++ b/playwright-public/user groups/roles.test.ts
@@ -121,7 +121,7 @@ test.describe('Roles View (Roles-*)', () => {
     await expect(page).toHaveURL(new RegExp(`/roles\\?q=${BUILTIN_ROLE_SEARCH}`));
     expect((await readGalleryCount(page)).shown).toBeLessThan(before.total);
     await clearGallerySearch(page, 'roles');
-    expect((await readGalleryCount(page)).shown).toBe(before.total);
+    expect((await readGalleryCount(page)).total).toBe(before.total);
   });
 
   // Roles-08 + Roles-10: context menu items and context-panel info panes.

--- a/playwright-public/user groups/users.test.ts
+++ b/playwright-public/user groups/users.test.ts
@@ -182,7 +182,7 @@ test.describe('Users View (Users-*)', () => {
     expect(filtered.shown).toBeLessThan(before.total);
     expect(filtered.shown).toBeGreaterThan(0);
     await clearGallerySearch(page, 'users');
-    expect((await readGalleryCount(page)).shown).toBe(before.total);
+    expect((await readGalleryCount(page)).total).toBe(before.total);
   });
 
   test('Users-14 — user context menu items', async ({ page }) => {


### PR DESCRIPTION
Four Playwright specs the nightly has been reporting red. All four are test bugs — no product issues found.

## Sharing — Table, Sharing — UI Smoke

Both died at the "PermissionsView matrix opens at `/permissions/<id>`" step with
`page.evaluate: Cannot serialize result: object reference chain is too long`.

`page.evaluate` serialises whatever its callback returns, and `grok.shell.route()` hands back the
`PermissionsView`, whose object graph is far too deep to cross the boundary. The value was never
used — the calls now discard it.

Not caused by the u2 base-class change: both fail identically in Test-Playwright 364, which ran
`public` at `3f8a8c1a03`, before that commit. These specs were simply the first code to return a
routed view out of an `evaluate` callback.

## Groups-06

Two causes.

**The counter was read half-loaded.** `readGalleryCount` documented "polling until it settles" but
returned the *first parseable* value, and a still-loading gallery reads `2 / 2` before it reads
`3 / 3`. The CI trace for build 365 shows the reads in order — `"2 / 2"`, `"1 / ..."`, `"1 / 1"`,
`"3 / 3"` — so the baseline was captured mid-load and the final assertion compared 2 against 3. The
only reason a partial state was ever caught is accidental: the intermediate `"N / ..."` fails the
regex. It now waits for the same text twice in a row.

**It relied on its siblings.** The spec asserts that searching narrows the list, but nothing
guaranteed a second group existed — the group-lifecycle test happening to run first did. Run on its
own (build 367) the stand held one group and the assertion read `1 < 1`. `beforeAll` now seeds a
second group through the existing idempotent helper, so the assertion stays strict rather than
becoming conditional.

## Users-09 (and the same line in Roles-06, Groups-06)

All three asserted that clearing the search restores the list by comparing the **shown** count to
the total captured beforehand. That only holds while the entity count stays under the gallery's
lazy-load page size of 200 — dev has 205 users, so Users-09 read 200 against 205 and has been red
there ever since the stand crossed that line. The invariant the tests mean is that the *total* comes
back, so they now compare total to total.

### One side effect worth flagging

Users-09 is the first test in a serial `describe`, so its failure was also skipping the five tests
after it. **Users-14, Users-15/17, Users-18/19, Users-20 and Users-21 have never run**, on dev or on
CI. They run for the first time with this change.

On dev, Users-14 fails — but as a stale dev fixture, not a defect CI should hit. The specs match the
card by `userDisplay(login)` = `opavlenko45 QA`, while dev already holds that login with
`friendlyName` `opavlenko45`; `ensureUserSeeded` cannot find the expected label and cannot create
the login either, since it is taken. A fresh CI stand has no such user, so the helper creates it
with the QA last name and the label matches. The next nightly will settle it.

## Verification

| | |
|---|---|
| Sharing — Table, Sharing — UI Smoke | green on CI, Test-Playwright 367 |
| groups.test.ts | 5/5 on dev |
| roles.test.ts | 5/5 on dev |
| users.test.ts | green through Users-09 on dev |

The gallery-counter fix is not yet confirmed on CI: build 367 filtered Groups-06 down to a
single-test run and never reached that assertion.