### PR TITLE
GrokConnect: Compare bigint columns by value, not by storage array

### DIFF
--- a/connectors/grok_connect/src/test/java/grok_connect/providers/utils/DataFrameComparator.java
+++ b/connectors/grok_connect/src/test/java/grok_connect/providers/utils/DataFrameComparator.java
@@ -46,12 +46,37 @@ public class DataFrameComparator {
             return false;
         if (!column.getName().equals(column1.getName()))
             return false;
-        return arraysEqual(column.toArray(), column1.toArray());
+        Object values = column.toArray();
+        Object values1 = column1.toArray();
+        // BigIntColumn keeps longs until a non-integral value forces it onto decimal strings, so a
+        // column built from a String[] fixture and one filled from the driver hold the same values
+        // in differently typed arrays. Fall back to the logical values rather than the storage.
+        if (values.getClass() != values1.getClass())
+            return valuesEqual(column, column1);
+        return arraysEqual(values, values1);
+    }
+
+    private boolean valuesEqual(Column<?> column, Column<?> column1) {
+        if (column.getLength() != column1.getLength())
+            return false;
+        for (int i = 0; i < column.getLength(); i++) {
+            Object value = column.get(i);
+            Object value1 = column1.get(i);
+            if (value == null || value1 == null) {
+                if (value != value1)
+                    return false;
+            }
+            else if (!String.valueOf(value).equals(String.valueOf(value1)))
+                return false;
+        }
+        return true;
     }
 
     private boolean arraysEqual(Object a, Object b) {
         if (a instanceof int[] && b instanceof int[])
             return Arrays.equals((int[]) a, (int[]) b);
+        if (a instanceof long[] && b instanceof long[])
+            return Arrays.equals((long[]) a, (long[]) b);
         if (a instanceof float[] && b instanceof float[])
             return Arrays.equals((float[]) a, (float[]) b);
         if (a instanceof double[] && b instanceof double[])


### PR DESCRIPTION
## Summary

`grok_connect`'s test suite has been failing since **2026-08-22**, and `Grok Connect` CI has been hard-red since **2026-08-25** when `GROK-20765` correctly made the build fail on test failures. That blocks the `docker` job (`needs: [build]`), so **no connector image has been published since 2026-08-24 21:02** — every `connectors/` change merged since then is unshipped.

## Root cause

`GROK-20752` moved `BigIntColumn` onto long storage until a non-integral value forces decimal strings. `toArray()` therefore returns either representation:

```java
return strings != null ? strings.toArray() : longs;
```

Fixtures build `new BigIntColumn("id", new String[]{"20"})` — `add(String)` isn't integral, so it switches to strings and yields `String[]`. The provider adds `Long`s and yields `long[]`. `arraysEqual` has branches for `int[]`, `float[]`, `double[]` and `Object[]`, so that pair matched none and fell to `return false`. `long[]` vs `long[]` had no branch either.

Reproduced against the compiled classes:

```
expected.getType() = bigint   toArray() = String[]   get(0) = 20 (String)
actual.getType()   = bigint   toArray() = long[]     get(0) = 20 (Long)
types equal      : true
arraysEqual(...) : false   <-- comparator verdict
```

Every fixture in `CommonObjectsMother` carries a `BigIntColumn("id", ...)`, which is why a single change failed the *same* test method across six unrelated providers plus the numeric/serial-type output tests.

This is confined to test code — nothing in `src/main` casts `BigIntColumn.toArray()`. The storage change itself is fine.

## Fix

Fall back to comparing logical values when the two columns' storage types differ, and add the missing `long[]` branch.

## Verification

Run locally (Maven + TestContainers), where these same cases fail in CI:

| test | result |
|---|---|
| `PostgresDataProviderTest#checkParameterSupport_ok` | 21 tests, **0 failures** |
| `MySqlDataProviderTest#checkParameterSupport_ok` | 21 tests, **0 failures** |

A standalone harness confirms every negative case still fails, so the assertion is not weakened.

## Expected residual

Hive2's `checkParameterSupport_ok` / `checkDatesParameterSupport_ok` were already failing on 08-18, *before* GROK-20752 — a separate cause. This PR should take the suite from 11 distinct failing methods to 2 (both Hive2). CI on this PR will confirm the exact residual.

Generated with [Claude Code](https://claude.com/claude-code)