### PR TITLE
Viewers: Override the inherited name accessor instead of redeclaring it

### DIFF
--- a/libraries/ml/src/viewers/search-base-viewer.ts
+++ b/libraries/ml/src/viewers/search-base-viewer.ts
@@ -3,7 +3,9 @@ import * as DG from 'datagrok-api/dg';
 import * as grok from 'datagrok-api/grok';
 
 export class SearchBaseViewer extends DG.JsViewer {
-  name: string = '';
+  private _name: string = '';
+  get name(): string { return this._name; }
+  set name(x: string | undefined) { this._name = x ?? ''; }
   semType: string = '';
   limit: number;
   targetColumn?: DG.Column<string>;

--- a/packages/Charts/CHANGELOG.md
+++ b/packages/Charts/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* Fixed the package build failing on `TS2610` — `name` is an accessor on the u2 `Component` base, so the viewer overrides it with its own accessor instead of redeclaring it as a property
 * GROK-18695: Forced d3-color >= 3.1.0 (ReDoS fix under circos); kept echarts 5 — the 6.1.0 upgrade (XSS fix GHSA-fgmj-fm8m-jvvx) deterministically breaks the Tree and Surface plot viewers (CI EXECUTION TIMEOUT on two independent runs) and needs a proper migration
 * Moved the Charts Playwright E2E suite into the package (`playwright/`); helpers sourced from `@datagrok-libraries/test/src/playwright`
 * GROK-19683: Charts | Tree viewer: Option to customize molecule label size

--- a/packages/Charts/src/viewers/group-analysis/group-analysis-viewer.ts
+++ b/packages/Charts/src/viewers/group-analysis/group-analysis-viewer.ts
@@ -96,7 +96,9 @@ interface IAnalyzedColumn {
 })
 export class GroupAnalysisViewer extends DG.JsViewer {
   initialized: boolean = false;
-  name = 'group';
+  private _name: string = 'group';
+  get name(): string { return this._name; }
+  set name(x: string | undefined) { this._name = x ?? ''; }
   groupByColumnNames: string[];
   analyzedColumns: IAnalyzedColumn[];
   analyzedColumnsEncoded: string;

--- a/packages/Chem/CHANGELOG.md
+++ b/packages/Chem/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* Fixed the package build failing on `TS2610` — `name` is an accessor on the u2 `Component` base, so the viewer overrides it with its own accessor instead of redeclaring it as a property
 * Fixed Gasteiger Partial Charges panel on current RDKit — `GetSimilarityMapFromWeights` now requires an explicit `MolDraw2DCairo` drawer (passed by keyword, so pre-2023.09 RDKit still works)
 
 ## 1.17.14 (2026-08-13)

--- a/packages/Chem/src/analysis/chem-search-base-viewer.ts
+++ b/packages/Chem/src/analysis/chem-search-base-viewer.ts
@@ -18,7 +18,9 @@ export enum RowSourceTypes {
 export class ChemSearchBaseViewer extends DG.JsViewer {
   isEditedFromSketcher: boolean = false;
   gridSelect: boolean = false;
-  name: string = '';
+  private _name: string = '';
+  get name(): string { return this._name; }
+  set name(x: string | undefined) { this._name = x ?? ''; }
   distanceMetric: string;
   limit: number;
   fingerprint: string;


### PR DESCRIPTION
## What breaks

The u2 refactor gave the `Component` base a `name` accessor pair, inherited by `JsViewer` through `Viewer` and `Widget`:

```ts
// js-api/src/u2core/component.ts
get name(): string | undefined { return this._u2.name; }
set name(x: string | undefined) { this._u2.name = x; }
```

Three viewers declare `name` as an instance property, which TypeScript rejects over an inherited accessor:

```
TS2610: 'name' is defined as an accessor in class 'JsViewer',
        but is overridden here as an instance property.
```

Their webpack builds die, so the packages are never published — and everything needing them at runtime fails too.

## Blast radius

Eight package builds fail in the nightly. Four die on this error directly (**Bio**, **Chem**, **Charts**, **NLP** — Bio and NLP both via `libraries/ml`), and it cascades:

| suite | failures | error |
|---|---|---|
| UsageAnalysis | 270/341 | its Bio/Chem/Charts tests — 56 errors name Bio, 24 Chem, 10 Charts |
| SequenceTranslator | 122/248 | `Package 'Bio' must be installed for MonomerLibHelper` |
| Helm | 74/75 | `Package Helm .helmHelper is not initialized` |
| Peptides | 70/70 | `Package 'Bio' must be installed for SeqHelper` |
| Bio / Chem / Charts | 44 / 19 / 10 | own packages never published |

That is **~609 of the 764 failures** in Build-Deploy-Datagrok #1290, with identical counts in #1285 — deterministic, not flaky.

(The other four build failures — Compute, DevTools, Tutorials on `TS2416` `run`, PlatesFixture on `TS2304` `global` — are separate causes, out of scope.)

## Why not just delete the declarations

Because two build contexts disagree, and a fix has to satisfy both:

- the **nightly package build** links the repo's js-api, which has the u2 accessor;
- the **standalone library/package builds** (including this PR's own `ml: Build` / `Chem: Build` checks) resolve `datagrok-api` from **npm**, which is still **1.27.9** — the u2 accessor is unpublished, and there `JsViewer` has no `name` at all.

Measured, compiling each variant against both:

| variant | repo js-api (u2) | published 1.27.x |
|---|---|---|
| `name: string = '';` (current) | **TS2610** | clean |
| declaration removed | clean | **TS2339** |
| `declare name: string;` | **TS2610** | — |
| **accessor override** | **clean** | **clean** |

An earlier revision of this PR simply deleted the declarations; its `ml: Build` check failed with TS2339, which is what surfaced the second context.

## The fix

Override the accessor rather than redeclaring the member. u2 touches `_u2.name` only through its own accessor pair and otherwise reads `this.name`, so the override is transparent to it. `GroupAnalysisViewer` keeps its `'group'` default, which a plain deletion would have silently dropped.

These overrides become redundant once a js-api containing u2 is published and these packages move onto it — worth removing then.

Generated with [Claude Code](https://claude.com/claude-code)