### PR TITLE
EDA: Pass XGBoost hyperparameters explicitly in the playwright tests

### DIFF
--- a/packages/EDA/playwright/MLMethods/xgboost1.test.ts
+++ b/packages/EDA/playwright/MLMethods/xgboost1.test.ts
@@ -27,7 +27,9 @@ test.describe.serial('EDA / MLMethods / XGBoost (classification)', () => {
     await openTrainModelView(page);
     await setPredictColumn(page, 'Species');
 
-    const trained = await trainEdaModelViaApi(page, 'eda:trainXGBooster', 'Species');
+    const trained = await trainEdaModelViaApi(page, 'eda:trainXGBooster', 'Species', {
+      extraParams: { iterations: 20, eta: 0.3, maxDepth: 6, lambda: 1, alpha: 0 },
+    });
     expect(trained.ok, trained.error ?? 'xgboost training returned null').toBe(true);
   });
 });

--- a/packages/EDA/playwright/MLMethods/xgboost2.test.ts
+++ b/packages/EDA/playwright/MLMethods/xgboost2.test.ts
@@ -24,7 +24,10 @@ test.describe.serial('EDA / MLMethods / XGBoost (regression)', () => {
     await openTrainModelView(page);
     await setPredictColumn(page, 'price');
 
-    const trained = await trainEdaModelViaApi(page, 'eda:trainXGBooster', 'price', { numericOnly: true });
+    const trained = await trainEdaModelViaApi(page, 'eda:trainXGBooster', 'price', {
+      numericOnly: true,
+      extraParams: { iterations: 20, eta: 0.3, maxDepth: 6, lambda: 1, alpha: 0 },
+    });
     expect(trained.ok, trained.error ?? 'xgboost training returned null').toBe(true);
   });
 });


### PR DESCRIPTION
## The failure

Both EDA XGBoost scenarios fail in the nightly:

```
EDA.MLMethods | Train XGBoost classification on iris.csv predicting Species
EDA.MLMethods | Train XGBoost regression on cars.csv predicting price
  Error: XGBoost: iterations must be a positive integer
```

## Cause

`trainEdaModelViaApi` calls `grok.functions.call(fn, { df, predictColumn, ...params })`. Both XGBoost tests pass no `extraParams`, so `iterations`, `eta`, `maxDepth`, `lambda` and `alpha` are omitted — and they arrive as `undefined` rather than the defaults declared on the function (`//input: int iterations = 20 …`). `xgbooster.ts:311` then correctly rejects it.

The sibling tests show why only these two fail:

| test | passes hyperparameters | validates | result |
|---|---|---|---|
| softmax | **yes** — `{rate, iterations, penalty, tolerance}` | — | passes |
| linear regression | no | **no** `Number.isInteger` check | passes |
| **XGBoost ×2** | **no** | **yes** (`xgbooster.ts:311,315`) | **fails** |

Linear regression only survives because it does no equivalent validation. XGBoost's check is correct — it is catching a real omission.

## Fix

Pass the declared defaults explicitly, matching the softmax test's shape.

## Worth a separate look

`grok.functions.call` not applying a function's declared defaults for omitted inputs affects any caller, not just these tests. That looked out of scope for a test fix, but it is the underlying reason the omission is not harmless.

Generated with [Claude Code](https://claude.com/claude-code)