### PR TITLE
Tutorials: Rename Tutorial.run to start

### DIFF
--- a/libraries/tutorials/src/tutorial.ts
+++ b/libraries/tutorials/src/tutorial.ts
@@ -124,7 +124,7 @@ export abstract class Tutorial extends DG.Widget {
     grok.shell.windows.showBrowse = true;
   }
 
-  async run(): Promise<void> {
+  async start(): Promise<void> {
     this._addHeader();
 
     const tutorials = this.track?.tutorials;
@@ -232,7 +232,7 @@ export abstract class Tutorial extends DG.Widget {
             this.clearRoot();
             tutorialNode.html('');
             tutorialNode.append(nextTutorial.root);
-            nextTutorial.run();
+            nextTutorial.start();
           }),
           ui.button('Cancel', () => {
             this.updateProgress(this.track);

--- a/packages/Tutorials/CHANGELOG.md
+++ b/packages/Tutorials/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* Fixed the package build failing on `TS2416` — the u2 `Component` base introduced `run(fn)`, which every widget now inherits, so `Tutorial`'s own `run()` no longer matched; it is now `start()`
 * GROK-20602: BREAKING regen — `grok api` codegen v2 for the Northwind demo schema: datetime fields are dayjs, typed expand/transaction surface, lazy db.ts clients
 * Demo app: Added a Domain Databases demo (Data Access | Domain Databases) — ships the classic Northwind schema and data as a plugin-declared domain database (databases/northwind) and walks through browsing, security, audit history, and the JS API
 

--- a/packages/Tutorials/src/tests/tutorial-test.ts
+++ b/packages/Tutorials/src/tests/tutorial-test.ts
@@ -29,7 +29,7 @@ category('Tutorials', () => {
 
   test('Run a tutorial', async () => {
     try {
-      await tutorial.run();
+      await tutorial.start();
     } catch (e) {
       expect(e instanceof Error ? e.message : e, 'Method "_run" not implemented.');
     }

--- a/packages/Tutorials/src/tutorial-runner.ts
+++ b/packages/Tutorials/src/tutorial-runner.ts
@@ -19,7 +19,7 @@ export class TutorialRunner {
     $('#tutorial-child-node').html('');
     $('#tutorial-child-node').append(t.root);
     t.clearRoot();
-    await t.run();
+    await t.start();
   }
 
   async getCompleted(tutorials: Tutorial[]) {


### PR DESCRIPTION
## The failure

`Tutorials` is one of four packages still failing to build in the nightly:

```
libraries/tutorials/src/tutorial.ts(127,9)
TS2416: Property 'run' in type 'Tutorial' is not assignable to the
        same property in base type 'Widget<any>'
```

The u2 refactor added a scope helper to the `Component` base:

```ts
// js-api/src/u2core/component.ts
run<T>(fn: () => T): T { return Scope.runWith(this.scope, fn); }
```

`Tutorial extends DG.Widget`, and `Widget → Control → Component`, so it now inherits `run(fn)` — which its own `async run(): Promise<void>` no longer matches.

## Why renaming is the only option here

No signature satisfies both. A subclass may drop parameters, but it cannot return `Promise<void>` where the base returns `T`. Unlike the `name` accessor case (#4005), there is no override shape that works — the member has to be called something else.

## Why this side, and why `start`

Renaming the **u2 helper** would be the alternative, but it has ~38 call sites across `libraries/u2`, not all of which are `Component.run`, in a library under active development. Renaming `Tutorial.run` is far smaller and contained:

- `start` is free on `Component`, `Control` and `Widget` — checked, so this does not trade one collision for another
- subclasses are untouched: they implement the protected `_run()` hook, which does not collide; only the base declares the public entry point
- 3 call sites, and one of them sits directly under the `'Start'` button that launches the next tutorial, so the name reads correctly

## Verification

Compiled `tutorial.ts` against the current js-api sources:

| | TS2416 |
|---|---|
| before (origin/master) | 1 — `tutorial.ts(127,9)` |
| after | **0** |

No new errors introduced.

`Compute` and `DevTools` fail on the same collision via `FunctionView.run` in `libraries/compute-utils`; that is a separate change and not included here.

Generated with [Claude Code](https://claude.com/claude-code)