### PR TITLE
Browse: ordering rules API surface and e2e suites

### DIFF
--- a/js-api/src/api/xamgle.api.g.ts
+++ b/js-api/src/api/xamgle.api.g.ts
@@ -108,6 +108,12 @@ export interface SettingsInterface {
 
   showAI: boolean;
 
+  /// Ordering rules as JSON — see [OrderRule]. A real property so it serializes and picks up the
+  /// settings view's personal / group / All-Users scoping; the Browse page renders it with a
+  /// dedicated list editor instead of the generic string input. Read it via [OrderRule.parseAll] —
+  /// a public getter here would be auto-promoted to a `@Prop` and leak into the JS API.
+  orderRules: string;
+
   enableBetaViewers: boolean;
 
   //@Prop(editor: 'Beta') bool enableViewerFunctions = false;
@@ -152,6 +158,10 @@ export interface SettingsInterface {
   /// Whenever an error occurs, automatically create report with extended logs and send it to the server. Use UsageAnalysis to browse them.
   /// This includes console logs, server logs, data connectivity logs, Docker logs, etc.
   autoReportErrors: boolean;
+
+
+
+
 
 
 }

--- a/playwright-public/group-e2e.js
+++ b/playwright-public/group-e2e.js
@@ -1,0 +1,126 @@
+// Group / All-Users defaults for the ordering rules: set them in the scope selector as admin,
+// confirm the server stored the override, then confirm a fresh session inherits them and the
+// Browse tree actually orders by them.
+const { chromium } = require('playwright');
+const BASE = process.env.DG_BASE || 'http://localhost:61006';
+const API = process.env.DG_API || 'http://localhost:61002';
+let failures = 0;
+const errors = [];
+function check(label, ok, detail) {
+  if (!ok) failures++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? `\n        ${detail}` : ''}`);
+}
+const NOISE = /Failed to load resource|packages\/published|detectors\.js|package\.js|MIME type|401 \(Unauthorized\)|favicon|Provider \w+ not found|ConnectorsService|^Stack trace \w+|Translating stack trace/i;
+
+async function login(page) {
+  await page.goto(`${BASE}/login.html`, { waitUntil: 'domcontentloaded', timeout: 180000 });
+  const u = page.locator('input[placeholder="Login or Email"]:visible').first();
+  await u.waitFor({ state: 'visible', timeout: 300000 });
+  await u.fill('admin');
+  await page.locator('input[placeholder="Password"]:visible').first().fill('admin');
+  await page.locator('button:has-text("LOGIN"), .ui-btn:has-text("LOGIN")').first().click();
+  await page.locator('.d4-tree-view-group-label', { hasText: /^Spaces$/ }).first().waitFor({ timeout: 300000 });
+  await page.waitForTimeout(8000);
+}
+
+// Reads the stored All-Users override straight from the server, through the page's session.
+const overrides = (page) => page.evaluate(async (api) => {
+  const r = await fetch(`${api}/admin/settings/override`, { credentials: 'include' });
+  return r.ok ? await r.json() : { __status: r.status };
+}, API);
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+
+  // ---------- 1. admin sets the All-Users default through the scope selector
+  const ctx1 = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await ctx1.newPage();
+  page.on('console', m => { const t = m.text().slice(0, 300);
+    if (m.type() === 'error' && !NOISE.test(t)) errors.push('CONSOLE ' + t); });
+  page.on('pageerror', e => errors.push('PAGEERROR ' + String(e).slice(0, 300)));
+
+  await login(page);
+  await page.evaluate(() => { if (window.grok) window.grok.settings.orderRules = '[]'; });
+  await page.goto(`${BASE}/settings/browse`, { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await page.waitForTimeout(25000);
+
+  const scopeBtns = page.locator('.grok-settings-scope-btn');
+  const nBtns = await scopeBtns.count();
+  check('scope selector present (personal / group)', nBtns >= 2, `buttons=${nBtns}`);
+  if (nBtns < 2) { await browser.close(); process.exit(1); }
+
+  const errBefore = errors.length;
+  await scopeBtns.nth(1).click();           // switch to group / shared defaults
+  await page.waitForTimeout(9000);
+  await page.screenshot({ path: 'grp-01-scope.png' });
+  const scopeName = await page.locator('.grok-settings-scope-name').first().innerText().catch(() => '');
+  console.log('    scope:', JSON.stringify(scopeName));
+  check('switched to a shared scope', scopeName && scopeName.trim().length > 0, scopeName);
+  check('no errors switching scope', errors.length === errBefore,
+    errors.slice(errBefore, errBefore + 3).join('\n        '));
+
+  // add a rule in this scope and set it to something visibly different from the name default
+  await page.locator('text=Add rule').first().click();
+  await page.waitForTimeout(3000);
+  const field = page.locator('.grok-order-rule-row:not(.grok-order-rule-header)').first()
+    .locator('.grok-order-rule-cell').nth(2).locator('input');
+  await field.fill('createdOn');
+  await field.press('Enter');
+  await page.waitForTimeout(3000);
+  await page.screenshot({ path: 'grp-02-rule.png' });
+
+  // Save and apply -> writes the scope override server-side
+  const save = page.locator('text=SAVE AND APPLY').first();
+  check('Save and apply button present', await save.count() > 0);
+  await save.click();
+  await page.waitForTimeout(12000);
+  await page.screenshot({ path: 'grp-03-saved.png' });
+
+  const ov = await overrides(page);
+  console.log('    server overrides:', JSON.stringify(ov).slice(0, 400));
+  const stored = ov && ov.orderRules;
+  check('server stored the orderRules override for the scope',
+    !!stored, JSON.stringify(ov).slice(0, 200));
+  check('stored override carries the rule',
+    stored && JSON.stringify(stored).indexOf('createdOn') >= 0, JSON.stringify(stored));
+
+  // ---------- 2. a fresh session (no personal settings) inherits it
+  const ctx2 = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page2 = await ctx2.newPage();
+  await login(page2);
+  const inherited = await page2.evaluate(() => window.grok && window.grok.settings
+    ? window.grok.settings.orderRules : null);
+  console.log('    fresh session orderRules:', JSON.stringify(inherited));
+  check('fresh session inherits the group default',
+    !!inherited && inherited.indexOf('createdOn') >= 0, JSON.stringify(inherited));
+
+  // ---------- 3. and the tree actually orders by it
+  await page2.evaluate(() => {
+    const tri = document.querySelector('[name="tree-expander-Spaces"]');
+    if (tri) tri.click();
+  });
+  await page2.waitForTimeout(10000);
+  await page2.screenshot({ path: 'grp-04-tree.png' });
+  const order = (await page2.evaluate(() =>
+    [...document.querySelectorAll('.d4-tree-view-group-label, .d4-tree-view-item-label')]
+      .map(e => e.innerText.trim()).join(String.fromCharCode(10))))
+    .split(String.fromCharCode(10)).map(x => x.trim())
+    .filter(l => ['alpha', 'middle', 'ordered', 'plain', 'zebra'].includes(l));
+  console.log('    root spaces under the group default (createdOn):', JSON.stringify(order));
+  check('group default reorders the Browse tree',
+    order.length === 5 && order.join(',') !== 'alpha,middle,ordered,plain,zebra',
+    JSON.stringify(order));
+
+  // ---------- cleanup: drop the override so later runs start clean
+  await page.evaluate(async (api) => {
+    await fetch(`${api}/admin/settings/override`, { method: 'DELETE', credentials: 'include' });
+  }, API);
+  const after = await overrides(page);
+  console.log('    overrides after cleanup:', JSON.stringify(after).slice(0, 200));
+
+  console.log('\n--- errors (' + errors.length + '):');
+  errors.slice(0, 8).forEach(e => console.log('      ' + e));
+  await browser.close();
+  console.log(failures === 0 ? '\nALL GROUP-DEFAULT CHECKS PASSED' : `\n${failures} CHECK(S) FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+})().catch(e => { console.error('HARNESS ERROR', e); process.exit(2); });

--- a/playwright-public/order-e2e.js
+++ b/playwright-public/order-e2e.js
@@ -1,0 +1,160 @@
+// End-to-end check of the Browse ordering feature against the worktree dev stack.
+// Usage: node order-e2e.js
+const { chromium } = require('playwright');
+
+const BASE = process.env.DG_BASE || 'http://localhost:61006';
+const errors = [];
+let failures = 0;
+
+function check(label, ok, detail) {
+  if (!ok) failures++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? `\n        ${detail}` : ''}`);
+}
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+  const NOISE = /packages\/published|detectors\.js|package\.js|MIME type|401 \(Unauthorized\)|favicon/i;
+  page.on('console', m => {
+    if (m.type() !== 'error') return;
+    const t = m.text().slice(0, 300);
+    if (!NOISE.test(t)) errors.push('CONSOLE ' + t);
+  });
+  page.on('pageerror', e => errors.push('PAGEERROR ' + String(e).slice(0, 300)));
+
+  console.log(`--- opening ${BASE}/login.html`);
+  await page.goto(`${BASE}/login.html`, { waitUntil: 'domcontentloaded', timeout: 180000 });
+
+  // Datagrok keeps hidden Sign-Up inputs with the same placeholders, so pin to the visible ones.
+  const user = page.locator('input[placeholder="Login or Email"]:visible').first();
+  await user.waitFor({ state: 'visible', timeout: 300000 });
+  await user.fill('admin');
+  await page.locator('input[placeholder="Password"]:visible').first().fill('admin');
+  await page.locator('button:has-text("LOGIN"), .ui-btn:has-text("LOGIN")').first().click();
+
+  // Datagrok is a SPA served from login.html - the URL never changes, so wait for the shell.
+  const tree = page.locator('.d4-tree-view-group-label:visible', { hasText: /^Spaces$/ }).first();
+  await tree.waitFor({ state: 'visible', timeout: 300000 }).catch(() => {});
+  await page.waitForTimeout(10000);
+  await page.screenshot({ path: 'shot-01-after-login.png' });
+
+  const loggedIn = await tree.count() > 0;
+  check('logged in, Browse tree rendered', loggedIn);
+  if (!loggedIn) { await browser.close(); process.exit(1); }
+
+  // ---- expand the Spaces node
+  // Each group carries name="tree-expander-<caption>"; a real click misses the 12px triangle,
+  // and the collapsed host is display:none so :visible filters never match.
+  async function expand(name, waitMs) {
+    const ok = await page.evaluate((n) => {
+      const tri = document.querySelector(`[name="tree-expander-${n}"]`);
+      if (!tri) return false;
+      tri.click();
+      return true;
+    }, name);
+    await page.waitForTimeout(waitMs || 7000);
+    return ok;
+  }
+  const spaces = page.locator('.d4-tree-view-group-label', { hasText: /^Spaces$/ }).first();
+  check('Spaces node present', await spaces.count() > 0);
+  const before = errors.length;
+  await expand('Spaces', 9000);
+  await page.screenshot({ path: 'shot-02-spaces.png' });
+  check('no new console errors expanding Spaces', errors.length === before,
+    errors.slice(before, before + 3).join('\n        '));
+
+  // ---- read the order of the root spaces
+  const treeText = await page.evaluate(() =>
+    [...document.querySelectorAll('.d4-tree-view-group-label, .d4-tree-view-item-label')]
+      .map(e => e.innerText.trim()).join(String.fromCharCode(10)));
+  const lines = treeText.split('\n').map(s => s.trim()).filter(Boolean);
+  console.log('--- browse tree:\n' + lines.map(l => '      ' + l).join('\n'));
+
+  const rootOrder = lines.filter(l => ['alpha', 'middle', 'ordered', 'plain', 'zebra'].includes(l));
+  console.log('    root spaces in tree order:', JSON.stringify(rootOrder));
+  check('all five root spaces listed', rootOrder.length === 5, JSON.stringify(rootOrder));
+
+  // ---- expand 'ordered' (override: rank desc -> aaa, ccc, bbb) and 'plain' (name -> aaa, bbb, ccc)
+  // Expander names are path-based: Spaces---ordered
+  for (const name of ['ordered', 'plain'])
+    check(`${name} expanded`, await expand(`Spaces---${name}`, 10000));
+  await page.screenshot({ path: 'shot-03-children.png' });
+  const afterText = await page.evaluate(() =>
+    [...document.querySelectorAll('.d4-tree-view-group-label, .d4-tree-view-item-label')]
+      .map(e => e.innerText.trim()).join(String.fromCharCode(10)));
+  const afterLines = afterText.split('\n').map(s => s.trim()).filter(Boolean);
+  console.log('--- tree after expanding:\n' + afterLines.map(l => '      ' + l).join('\n'));
+
+  function childrenAfter(parent) {
+    const i = afterLines.indexOf(parent);
+    if (i < 0) return [];
+    const out = [];
+    for (let j = i + 1; j < afterLines.length; j++) {
+      const l = afterLines[j];
+      if (['alpha', 'middle', 'ordered', 'plain', 'zebra'].includes(l)) break;
+      if (['aaa', 'bbb', 'ccc'].includes(l)) out.push(l);
+    }
+    return out;
+  }
+  const oc = childrenAfter('ordered');
+  const pc = childrenAfter('plain');
+  console.log('    ordered children:', JSON.stringify(oc));
+  console.log('    plain   children:', JSON.stringify(pc));
+  check("'ordered' children use its rank-desc override (aaa, ccc, bbb)",
+    oc.join(',') === 'aaa,ccc,bbb', JSON.stringify(oc));
+  check("'plain' children fall back to name (aaa, bbb, ccc)",
+    pc.join(',') === 'aaa,bbb,ccc', JSON.stringify(pc));
+
+  // The reported failure: a Project rule on `id` did nothing at any level. Set it through the
+  // public JS API - the same path the settings page takes (property set -> change event) - rather
+  // than poking localStorage, which the boot sequence rewrites.
+  const applied = await page.evaluate(() => {
+    if (!window.grok || !window.grok.settings) return 'no grok.settings';
+    window.grok.settings.orderRules =
+      JSON.stringify([{ type: 'Project', space: '', field: 'id', desc: false }]);
+    return window.grok.settings.orderRules;
+  });
+  console.log('    orderRules now:', JSON.stringify(applied));
+  check('rule set through grok.settings', typeof applied === 'string' && applied.indexOf('"id"') >= 0,
+    JSON.stringify(applied));
+  await page.waitForTimeout(12000);
+  await expand('Spaces', 8000);
+  await page.waitForTimeout(6000);
+  await page.screenshot({ path: 'shot-04-by-id.png' });
+  const idOrder = (await page.evaluate(() =>
+    [...document.querySelectorAll('.d4-tree-view-group-label, .d4-tree-view-item-label')]
+      .map(e => e.innerText.trim()).join(String.fromCharCode(10))))
+    .split(String.fromCharCode(10)).map(x => x.trim())
+    .filter(l => ['alpha', 'middle', 'ordered', 'plain', 'zebra'].includes(l));
+  console.log('    root spaces ordered by id:', JSON.stringify(idOrder));
+  check("ordering by 'id' differs from name order",
+    idOrder.length === 5 && idOrder.join(',') !== 'alpha,middle,ordered,plain,zebra',
+    JSON.stringify(idOrder));
+
+  // Reported: the Desc switch did nothing for a root-level rule.
+  const descApplied = await page.evaluate(() => {
+    window.grok.settings.orderRules = JSON.stringify(
+      [{ type: '', space: '@root', field: 'friendlyName', desc: true }]);
+    return window.grok.settings.orderRules;
+  });
+  console.log('    root desc rule:', JSON.stringify(descApplied));
+  await page.waitForTimeout(12000);
+  await expand('Spaces', 8000);
+  await page.waitForTimeout(6000);
+  await page.screenshot({ path: 'shot-05-root-desc.png' });
+  const descOrder = (await page.evaluate(() =>
+    [...document.querySelectorAll('.d4-tree-view-group-label, .d4-tree-view-item-label')]
+      .map(e => e.innerText.trim()).join(String.fromCharCode(10))))
+    .split(String.fromCharCode(10)).map(x => x.trim())
+    .filter(l => ['alpha', 'middle', 'ordered', 'plain', 'zebra'].includes(l));
+  console.log('    root spaces, root-level rule desc=true:', JSON.stringify(descOrder));
+  check('Desc reverses a root-level rule',
+    descOrder.join(',') === 'zebra,plain,ordered,middle,alpha', JSON.stringify(descOrder));
+
+  console.log('\n--- all console errors (' + errors.length + '):');
+  errors.slice(0, 10).forEach(e => console.log('      ' + e));
+
+  await browser.close();
+  console.log(failures === 0 ? '\nALL BROWSE CHECKS PASSED' : `\n${failures} CHECK(S) FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+})().catch(e => { console.error('HARNESS ERROR', e); process.exit(2); });

--- a/playwright-public/ordermenu-e2e.js
+++ b/playwright-public/ordermenu-e2e.js
@@ -1,0 +1,397 @@
+// Ordering context menu: the "Order by" section on the Spaces node, on a space, and in a
+// DataSourceCardView. Checks the field list (model props + schema props + meta params), the
+// direction items, and the EditSettings-gated "for all users" icon.
+const { chromium } = require('playwright');
+const BASE = process.env.DG_BASE || 'http://localhost:61006';
+const API = process.env.DG_API || 'http://localhost:61002';
+let failures = 0;
+const errors = [];
+function check(label, ok, detail) {
+  if (!ok) failures++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? `\n        ${detail}` : ''}`);
+}
+const NOISE = /Failed to load resource|packages\/published|detectors\.js|package\.js|MIME type|401 \(Unauthorized\)|favicon|Provider \w+ not found|ConnectorsService|^Stack trace \w+|Translating stack trace/i;
+
+async function login(page) {
+  await page.goto(`${BASE}/login.html`, { waitUntil: 'domcontentloaded', timeout: 180000 });
+  const u = page.locator('input[placeholder="Login or Email"]:visible').first();
+  await u.waitFor({ state: 'visible', timeout: 300000 });
+  await u.fill('admin');
+  await page.locator('input[placeholder="Password"]:visible').first().fill('admin');
+  await page.locator('button:has-text("LOGIN"), .ui-btn:has-text("LOGIN")').first().click();
+  await page.locator('.d4-tree-view-group-label', { hasText: /^Spaces$/ }).first().waitFor({ timeout: 300000 });
+  await page.waitForTimeout(8000);
+}
+
+// Menu items are rendered into the document body; read their labels.
+const menuLabels = (page) => page.evaluate(() =>
+  [...document.querySelectorAll('.d4-menu-item-label')].map(e => e.innerText.trim()).filter(Boolean));
+
+// Escape does not dismiss a d4 context menu, and clicking a "neutral" corner lands on the left
+// sidebar, whose menu groups expand on hover and then swallow every later click. Each right-click
+// builds a fresh Menu, so dropping the old popup is safe and is the only reliable close.
+async function closeMenus(page) {
+  await page.keyboard.press('Escape');
+  await page.evaluate(() =>
+    document.querySelectorAll('.d4-menu-popup').forEach(e => e.remove()));
+  await page.mouse.move(800, 600);
+  await page.waitForTimeout(800);
+}
+
+// Hovers "Order by" so its submenu renders, then returns every label on screen.
+async function openOrderBy(page) {
+  const item = page.locator('.d4-menu-item-label', { hasText: /^Order by$/ }).first();
+  if (await item.count() === 0) return null;
+  await item.hover();
+  await page.waitForTimeout(2500);
+  return await menuLabels(page);
+}
+
+const APPLY_ALL = 'Apply for all users';
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const ctx = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const page = await ctx.newPage();
+  page.on('console', m => { const t = m.text().slice(0, 300);
+    if (m.type() === 'error' && !NOISE.test(t)) errors.push('CONSOLE ' + t); });
+  page.on('pageerror', e => errors.push('PAGEERROR ' + String(e).slice(0, 300)));
+
+  await login(page);
+  check('client compiled and app booted', true);
+
+  // ---------- 1. Spaces node
+  const spacesNode = page.locator('.d4-tree-view-group-label', { hasText: /^Spaces$/ }).first();
+  await spacesNode.click({ button: 'right' });
+  await page.waitForTimeout(2500);
+  let labels = await menuLabels(page);
+  console.log('    spaces menu:', JSON.stringify(labels.slice(0, 12)));
+  check('Spaces node context menu has "Order by"', labels.includes('Order by'), JSON.stringify(labels));
+
+  const spacesOrder = await openOrderBy(page);
+  console.log('    Order by (Spaces):', JSON.stringify((spacesOrder || []).slice(0, 25)));
+  check('field list offers model properties',
+    spacesOrder && spacesOrder.includes('friendlyName'), JSON.stringify(spacesOrder));
+  check('direction items present',
+    spacesOrder && spacesOrder.includes('Ascending') && spacesOrder.includes('Descending'),
+    JSON.stringify(spacesOrder));
+  check('"' + APPLY_ALL + '" shown for an EditSettings holder',
+    spacesOrder && spacesOrder.includes(APPLY_ALL), JSON.stringify(spacesOrder));
+  const metaAt = (spacesOrder || []).indexOf('Meta parameters');
+  const plainAt = (spacesOrder || []).indexOf('friendlyName');
+  console.log('    Meta group at', metaAt, '/ first model field at', plainAt);
+  check('"Meta parameters" group comes before the model fields',
+    metaAt >= 0 && plainAt >= 0 && metaAt < plainAt,
+    JSON.stringify((spacesOrder || []).slice(0, 14)));
+  await page.screenshot({ path: 'om-01-spaces.png' });
+  await closeMenus(page);
+
+  // ---------- 2. a space
+  await page.evaluate(() => {
+    const tri = document.querySelector('[name="tree-expander-Spaces"]');
+    if (tri) tri.click();
+  });
+  await page.waitForTimeout(6000);
+  const firstSpace = page.locator('.d4-tree-view-group-label, .d4-tree-view-item-label')
+    .filter({ hasText: /^(alpha|middle|ordered|plain|zebra)$/ }).first();
+  const haveSpace = await firstSpace.count() > 0;
+  check('a space node is present to right-click', haveSpace);
+  if (haveSpace) {
+    await firstSpace.click({ button: 'right' });
+    await page.waitForTimeout(2500);
+    labels = await menuLabels(page);
+    check('space context menu has "Order by"', labels.includes('Order by'), JSON.stringify(labels.slice(0, 20)));
+    check('the old "Order Children By..." command is gone',
+      !labels.some(l => /Order Children By/i.test(l)), JSON.stringify(labels.slice(0, 20)));
+    const spaceOrder = await openOrderBy(page);
+    console.log('    Order by (space):', JSON.stringify((spaceOrder || []).slice(0, 25)));
+    check('space ordering offers fields',
+      spaceOrder && spaceOrder.includes('friendlyName'), JSON.stringify(spaceOrder));
+    // the tree can show every bucket under a space, so the menu covers all their fields
+    check('space menu in Browse offers other types’ fields too',
+      spaceOrder && spaceOrder.length > 12, JSON.stringify((spaceOrder || []).slice(0, 20)));
+    await page.screenshot({ path: 'om-02-space.png' });
+    await closeMenus(page);
+  }
+
+  // ---------- 3. a DataSourceCardView
+  await page.goto(`${BASE}/connections`, { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await page.waitForTimeout(12000);
+  // The handler is on the gallery grid itself, not the view root.
+  const grid = page.locator('.grok-gallery-grid').first();
+  const haveGrid = await grid.count() > 0;
+  check('DataSourceCardView rendered', haveGrid,
+    haveGrid ? '' : await page.evaluate(() => document.body.innerText.slice(0, 200)));
+  if (haveGrid) {
+    // A real right-click lands on a card, whose own handler swallows it; dispatch at the grid.
+    await page.evaluate(() => {
+      const g = document.querySelector('.grok-gallery-grid');
+      const r = g.getBoundingClientRect();
+      g.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true,
+        view: window, clientX: r.left + 30, clientY: r.bottom - 30, button: 2 }));
+    });
+    await page.waitForTimeout(3500);
+    labels = await menuLabels(page);
+    check('card view context menu has "Order by"', labels.includes('Order by'), JSON.stringify(labels.slice(0, 20)));
+    const viewOrder = await openOrderBy(page);
+    console.log('    Order by (card view):', JSON.stringify((viewOrder || []).slice(0, 25)));
+    // the view's own sortableBy labels win over raw field names, so this reads "Name", not
+    // "friendlyName"; a field the view has no label for (updatedOn) still shows raw
+    check('card view ordering offers fields under the view own labels',
+      viewOrder && viewOrder.includes('Name') && viewOrder.includes('Author') &&
+      viewOrder.includes('Created'), JSON.stringify(viewOrder));
+    check('card view ordering also offers fields the view does not label',
+      viewOrder && viewOrder.includes('updatedOn'), JSON.stringify(viewOrder));
+    check('"' + APPLY_ALL + '" shown in the card view too',
+      viewOrder && viewOrder.includes(APPLY_ALL), JSON.stringify(viewOrder));
+    await page.screenshot({ path: 'om-03-cardview.png' });
+    await closeMenus(page);
+  }
+
+  // ---------- 4. picking a field actually persists a rule and reorders the tree
+  await page.goto(`${BASE}/login.html`, { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await page.locator('.d4-tree-view-group-label', { hasText: /^Spaces$/ }).first().waitFor({ timeout: 300000 });
+  await page.waitForTimeout(8000);
+  await page.evaluate(() => { window.grok.settings.orderRules = '[]'; });
+
+  const treeOrder = () => page.evaluate(() =>
+    [...document.querySelectorAll('.d4-tree-view-group-label, .d4-tree-view-item-label')]
+      .map(e => e.innerText.trim())
+      .filter(l => ['alpha', 'middle', 'ordered', 'plain', 'zebra'].includes(l)));
+
+  await page.evaluate(() => {
+    const tri = document.querySelector('[name="tree-expander-Spaces"]');
+    if (tri) tri.click();
+  });
+  await page.waitForTimeout(8000);
+  const before = await treeOrder();
+  console.log('    tree before:', JSON.stringify(before));
+
+  await closeMenus(page);
+  await page.locator('.d4-tree-view-group-label', { hasText: /^Spaces$/ }).first().click({ button: 'right' });
+  await page.waitForTimeout(2500);
+  await openOrderBy(page);
+  await page.locator('.d4-menu-item-label', { hasText: /^createdOn$/ }).first().click();
+  await page.waitForTimeout(6000);
+
+  const rules = await page.evaluate(() => window.grok.settings.orderRules);
+  console.log('    orderRules after picking createdOn:', JSON.stringify(rules));
+  check('picking a field writes the personal rule',
+    rules && rules.indexOf('createdOn') >= 0 && rules.indexOf('@root') >= 0, JSON.stringify(rules));
+
+  await page.evaluate(() => {
+    const tri = document.querySelector('[name="tree-expander-Spaces"]');
+    if (tri) tri.click();
+  });
+  await page.waitForTimeout(8000);
+  const after = await treeOrder();
+  console.log('    tree after:', JSON.stringify(after));
+  check('the tree reorders by the picked field',
+    after.length === before.length && after.length > 1 && after.join(',') !== before.join(','),
+    `before=${JSON.stringify(before)} after=${JSON.stringify(after)}`);
+
+  // ---------- 5. the users toggle writes the All-Users override
+  const overrides = () => page.evaluate(async (api) => {
+    const r = await fetch(`${api}/admin/settings/override`, { credentials: 'include' });
+    return r.ok ? await r.json() : { __status: r.status };
+  }, API);
+
+  await closeMenus(page);
+  await closeMenus(page);
+  await page.locator('.d4-tree-view-group-label', { hasText: /^Spaces$/ }).first().click({ button: 'right' });
+  await page.waitForTimeout(2500);
+  await openOrderBy(page);
+  await page.locator('.d4-menu-item-label', { hasText: /^updatedOn$/ }).first().click();
+  await page.waitForTimeout(3000);
+
+  await closeMenus(page);
+  await page.locator('.d4-tree-view-group-label', { hasText: /^Spaces$/ }).first().click({ button: 'right' });
+  await page.waitForTimeout(2500);
+  await openOrderBy(page);
+  const applyItem = page.locator('.d4-menu-item-label', { hasText: new RegExp('^' + APPLY_ALL + '$') }).first();
+  check('the "' + APPLY_ALL + '" item is present', await applyItem.count() > 0);
+  await applyItem.click();
+  await page.waitForTimeout(8000);
+
+  const ov = await overrides();
+  const stored = ov && ov.orderRules;
+  console.log('    All-Users override:', JSON.stringify(stored).slice(0, 250));
+  check('"' + APPLY_ALL + '" writes the All-Users rule',
+    stored && JSON.stringify(stored).indexOf('updatedOn') >= 0, JSON.stringify(ov).slice(0, 250));
+
+  // cleanup so a later run starts clean
+  await page.evaluate(async (api) => {
+    await fetch(`${api}/admin/settings/override`, { method: 'DELETE', credentials: 'include' });
+  }, API);
+  await page.evaluate(() => { window.grok.settings.orderRules = '[]'; });
+
+  // ---------- 6. a space's own override drives the space's view, not just the tree
+  await closeMenus(page);
+  const spaceName = 'plain';
+  const spaceId = await page.evaluate(async ([api, name]) => {
+    const r = await fetch(`${api}/projects/namespaces?include=metaParams`, { credentials: 'include' });
+    const l = r.ok ? await r.json() : [];
+    const p = (Array.isArray(l) ? l : []).find(x => (x.friendlyName || x.name) === name);
+    return p ? p.id : null;
+  }, [API, spaceName]);
+  check('found the space to scope the view to', !!spaceId, String(spaceId));
+
+  // Order its children by id — a field no view exposes as a sortableBy label.
+  const setOverride = (field) => page.evaluate(async ([api, id, f]) => {
+    const r = await fetch(`${api}/projects/${id}`, { credentials: 'include' });
+    const p = await r.json();
+    p.metaParams = Object.assign({}, p.metaParams, { orderBy: f, orderDescending: 'false' });
+    await fetch(`${api}/projects`, { method: 'POST', credentials: 'include',
+      headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(p) });
+  }, [API, spaceId, field]);
+
+  const viewOrderOf = async () => {
+    await page.goto(`${BASE}/s/${spaceName}`, { waitUntil: 'domcontentloaded', timeout: 180000 });
+    await page.waitForTimeout(15000);
+    return await page.evaluate(() =>
+      [...document.querySelectorAll('.grok-gallery-grid .d4-link-label label')]
+        .map(e => e.innerText.trim()).filter(Boolean).slice(0, 10));
+  };
+
+  await setOverride('friendlyName');
+  const viewByName = await viewOrderOf();
+  console.log('    space view ordered by friendlyName:', JSON.stringify(viewByName));
+  await setOverride('id');
+  const viewById = await viewOrderOf();
+  console.log('    space view ordered by id:', JSON.stringify(viewById));
+  check('the space view lists its contents', viewByName.length > 1, JSON.stringify(viewByName));
+  check('the space\'s own ordering override changes the view',
+    viewByName.length > 1 && viewById.join(',') !== viewByName.join(','),
+    `byName=${JSON.stringify(viewByName)} byId=${JSON.stringify(viewById)}`);
+
+  // ---------- 7. a space's override orders everything inside it.
+  // Driven through the menu: writing metaParams over REST silently no-ops, because `metaParams`
+  // is a read projection and the write shape is `entityMetaParams`.
+  const ALL = 'plain';
+  await closeMenus(page);
+  await page.goto(BASE + '/login.html', { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await page.locator('.d4-tree-view-group-label', { hasText: /^Spaces$/ }).first().waitFor({ timeout: 300000 });
+  await page.waitForTimeout(8000);
+  await page.evaluate(() => { window.grok.settings.orderRules = '[]'; });
+
+  const expand = (path) => page.evaluate((v) => {
+    const t = document.querySelector('[name="tree-expander-' + v + '"]');
+    if (t) { t.click(); return true; }
+    return false;
+  }, path);
+  const childrenOf = (nm) => page.evaluate((s2) => {
+    const all = [...document.querySelectorAll('.d4-tree-view-group-label, .d4-tree-view-item-label')]
+      .map(e => e.innerText.trim()).filter(Boolean);
+    const i = all.indexOf(s2);
+    return i < 0 ? [] : all.slice(i + 1, i + 5);
+  }, nm);
+  const spaceMeta = () => page.evaluate(async (args) => {
+    const r = await fetch(args[0] + '/projects/namespaces?include=metaParams', { credentials: 'include' });
+    const l = r.ok ? await r.json() : [];
+    const a2 = (Array.isArray(l) ? l : []).find(x => (x.friendlyName || x.name) === args[1]);
+    return a2 ? a2.metaParams : null;
+  }, [API, ALL]);
+  // dispatch, not click: after a reload the expanded subtree covers the node
+  const pickOn = async (nm, label) => {
+    await closeMenus(page);
+    const found = await page.evaluate((n) => {
+      const el = [...document.querySelectorAll('.d4-tree-view-group-label, .d4-tree-view-item-label')]
+        .find(e => e.innerText.trim() === n);
+      if (!el) return false;
+      const r = el.getBoundingClientRect();
+      el.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true,
+        view: window, clientX: r.left + 5, clientY: r.top + 5, button: 2 }));
+      return true;
+    }, nm);
+    if (!found) return false;
+    await page.waitForTimeout(2500);
+    await page.locator('.d4-menu-item-label', { hasText: /^Order by$/ }).first().hover();
+    await page.waitForTimeout(2500);
+    const it = page.locator('.d4-menu-item-label', { hasText: new RegExp('^' + label + '$') }).first();
+    if (await it.count() === 0) return false;
+    await it.click({ timeout: 20000 });
+    await page.waitForTimeout(7000);
+    return true;
+  };
+  const snapshot = async () => {
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 180000 });
+    await page.locator('.d4-tree-view-group-label', { hasText: /^Spaces$/ }).first().waitFor({ timeout: 300000 });
+    await page.waitForTimeout(9000);
+    await expand('Spaces'); await page.waitForTimeout(6000);
+    await expand('Spaces---' + ALL); await page.waitForTimeout(8000);
+    return (await childrenOf(ALL)).join(',');
+  };
+
+  await expand('Spaces'); await page.waitForTimeout(6000);
+  await expand('Spaces---' + ALL); await page.waitForTimeout(8000);
+  const mixed = await page.evaluate(async (args) => {
+    const r = await fetch(args[0] + '/projects/namespaces', { credentials: 'include' });
+    const l = r.ok ? await r.json() : [];
+    const sp = (Array.isArray(l) ? l : []).find(x => (x.friendlyName || x.name) === args[1]);
+    if (!sp) return [];
+    const c = await fetch(args[0] + '/spaces/' + sp.id + '/children?includeLinked=true', { credentials: 'include' });
+    const cs = c.ok ? await c.json() : [];
+    return [...new Set((Array.isArray(cs) ? cs : []).map(x => x['#type'] || '?'))];
+  }, [API, ALL]);
+  console.log('    types inside ' + ALL + ':', JSON.stringify(mixed));
+  check('the space holds more than one entity type', mixed.length > 1, JSON.stringify(mixed));
+
+  check('picked an order field on the space', await pickOn(ALL, 'friendlyName'));
+  const metaAsc = await spaceMeta();
+  check('the space override was stored', metaAsc && metaAsc.orderBy === 'friendlyName', JSON.stringify(metaAsc));
+  const ascOrder = await snapshot();
+  check('picked Descending on the space', await pickOn(ALL, 'Descending'));
+  const metaDesc = await spaceMeta();
+  check('the direction was stored', metaDesc && metaDesc.orderDescending === 'true', JSON.stringify(metaDesc));
+  const descOrder = await snapshot();
+  console.log('    asc :', ascOrder);
+  console.log('    desc:', descOrder);
+  check('the space override reorders its children',
+    ascOrder.length > 0 && ascOrder !== descOrder, 'asc=' + ascOrder + ' desc=' + descOrder);
+
+  // "Default" is the only way back out of an override
+  check('picked Default on the space', await pickOn(ALL, 'Default'));
+  const metaCleared = await spaceMeta();
+  console.log('    meta after Default:', JSON.stringify(metaCleared));
+  check('Default clears the space override',
+    metaCleared && metaCleared.orderBy == null && metaCleared.orderDescending == null,
+    JSON.stringify(metaCleared));
+  const clearedOrder = await snapshot();
+  console.log('    cleared:', clearedOrder);
+  check('cleared space falls back to the name order',
+    clearedOrder === ascOrder, 'cleared=' + clearedOrder + ' expected=' + ascOrder);
+
+  // ---------- 8. the space view has its own ordering button carrying the same section
+  await closeMenus(page);
+  await page.goto(BASE + '/s/plain', { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await page.waitForTimeout(16000);
+  const btnCount = await page.locator('i[name*="icon-sort"], i[class*="fa-sort"]').count();
+  check('SpaceView shows an ordering button', btnCount > 0, 'found=' + btnCount);
+
+  // the listener sits on the icon element itself (sortButton.root), not on any wrapper
+  const opened = await page.evaluate(() => {
+    const i = document.querySelector('i[name*="icon-sort-alt"], i[class*="fa-sort-alt"]');
+    if (!i) return false;
+    i.click();
+    return true;
+  });
+  await page.waitForTimeout(5000);
+  const btnMenu = await menuLabels(page);
+  console.log('    SpaceView order button menu:', JSON.stringify(btnMenu.slice(0, 22)));
+  check('the ordering button opens a menu', opened && btnMenu.length > 0,
+    JSON.stringify(btnMenu.slice(0, 10)));
+  check('button menu uses Ascending/Descending, not high/low',
+    btnMenu.includes('Ascending') && btnMenu.includes('Descending') &&
+    !btnMenu.some(l => /high to low|low to high/i.test(l)), JSON.stringify(btnMenu.slice(0, 22)));
+  check('button menu carries "' + APPLY_ALL + '"',
+    btnMenu.includes(APPLY_ALL), JSON.stringify(btnMenu.slice(0, 22)));
+  await closeMenus(page);
+
+  console.log('\n--- errors (' + errors.length + '):');
+  errors.slice(0, 10).forEach(e => console.log('      ' + e));
+  check('no unexpected console errors', errors.length === 0, errors.slice(0, 3).join('\n        '));
+
+  await browser.close();
+  console.log(failures === 0 ? '\nALL ORDER-MENU CHECKS PASSED' : `\n${failures} CHECK(S) FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+})().catch(e => { console.error('HARNESS ERROR', e); process.exit(2); });

--- a/playwright-public/settings-e2e.js
+++ b/playwright-public/settings-e2e.js
@@ -1,0 +1,282 @@
+// Drives Settings -> Browse (the ordering rules editor) in a real browser.
+const { chromium } = require('playwright');
+const BASE = process.env.DG_BASE || 'http://localhost:61006';
+const errors = [];
+let failures = 0;
+function check(label, ok, detail) {
+  if (!ok) failures++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? `\n        ${detail}` : ''}`);
+}
+// Pre-existing noise on this dev stack: undeployed packages, unbuilt help, no grok_connect
+// container (so no JDBC providers). Datagrok also emits a separate "Stack trace <id>" line.
+const NOISE = /Failed to load resource|packages\/published|detectors\.js|package\.js|MIME type|401 \(Unauthorized\)|favicon|Provider \w+ not found|ConnectorsService|^Stack trace \w+|Translating stack trace/i;
+
+async function login(page) {
+  await page.goto(`${BASE}/login.html`, { waitUntil: 'domcontentloaded', timeout: 180000 });
+  const u = page.locator('input[placeholder="Login or Email"]:visible').first();
+  await u.waitFor({ state: 'visible', timeout: 300000 });
+  await u.fill('admin');
+  await page.locator('input[placeholder="Password"]:visible').first().fill('admin');
+  await page.locator('button:has-text("LOGIN"), .ui-btn:has-text("LOGIN")').first().click();
+  await page.locator('.d4-tree-view-group-label', { hasText: /^Spaces$/ }).first().waitFor({ timeout: 300000 });
+  await page.waitForTimeout(8000);
+}
+
+async function saveAndApply(page) {
+  await page.locator('text=SAVE AND APPLY').first().click();
+  await page.waitForTimeout(7000);
+}
+
+const rulesOf = (page) => page.evaluate(() => {
+  try { return JSON.parse(JSON.parse(localStorage.getItem('grok-settings') || '{}').orderRules || '[]'); }
+  catch (e) { return null; }
+});
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+  page.on('console', m => { const t = m.text().slice(0, 300);
+    if (m.type() === 'error' && !NOISE.test(t)) errors.push('CONSOLE ' + t); });
+  page.on('pageerror', e => errors.push('PAGEERROR ' + String(e).slice(0, 300)));
+
+  await login(page);
+  // Start from a clean slate so row indexes are predictable.
+  await page.evaluate(() => { if (window.grok && window.grok.settings) window.grok.settings.orderRules = '[]'; });
+
+  const before = errors.length;
+  await page.goto(`${BASE}/settings/browse`, { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await page.waitForTimeout(25000);
+  await page.screenshot({ path: 'set-01-browse.png' });
+  check('no JS errors opening Settings > Browse', errors.length === before,
+    errors.slice(before, before + 3).join('\n        '));
+
+  // 6 - DOM controls, not a grid
+  const canvases = await page.locator('.grok-settings-order-rules canvas').count();
+  check('no grid canvas (reverted to DOM controls)', canvases === 0, `canvases=${canvases}`);
+
+  // 1 - fills the page
+  const box = await page.locator('.grok-settings-order-rules').first().boundingBox();
+  const host = await page.locator('.dlg-settings-page-host').first().boundingBox().catch(() => null);
+  console.log('    editor box:', JSON.stringify(box), 'host:', JSON.stringify(host));
+  check('editor fills its width', box && host && box.width >= host.width - 30,
+    `editor=${box && box.width} host=${host && host.width}`);
+  check('editor fills its height', box && host && box.height >= host.height - 30,
+    `editor=${box && box.height} host=${host && host.height}`);
+
+  // Header must lay out as a row. ui-box forces direct children to flex-direction:column unless
+  // they carry an exempt class, which silently stacked this header while every other check passed.
+  const hdr = await page.evaluate(() => {
+    const h = document.querySelector('.grok-order-rule-header');
+    if (!h) return null;
+    const s = getComputedStyle(h);
+    const kids = [...h.children].map(c => Math.round(c.getBoundingClientRect().top));
+    return { dir: s.flexDirection, height: h.offsetHeight, tops: kids };
+  });
+  console.log('    header:', JSON.stringify(hdr));
+  check('header lays out as a row', hdr && hdr.dir === 'row', JSON.stringify(hdr));
+  check('header is one line tall', hdr && hdr.height < 48, hdr && String(hdr.height));
+  check('header cells share a baseline', hdr && new Set(hdr.tops).size <= 2, JSON.stringify(hdr && hdr.tops));
+
+  // add two rules
+  await page.locator('text=Add rule').first().click();
+  await page.waitForTimeout(2500);
+  await page.locator('text=Add rule').first().click();
+  await page.waitForTimeout(2500);
+  await page.screenshot({ path: 'set-02-two-rules.png' });
+
+  const rows = page.locator('.grok-order-rule-row').filter({ hasNot: page.locator('.grok-order-rule-header') });
+  const rowCount = await page.locator('.grok-order-rule-row:not(.grok-order-rule-header)').count();
+  check('two rule rows rendered', rowCount === 2, `rows=${rowCount}`);
+
+  // 4 - priorities are visible and numbered
+  const prios = await page.locator('.grok-order-rule-row:not(.grok-order-rule-header) .grok-order-rule-priority')
+    .allInnerTexts();
+  console.log('    priorities:', JSON.stringify(prios));
+  check('priorities shown as 1..n', prios.join(',') === '1,2', JSON.stringify(prios));
+
+  // 2 - per-row remove button (plus the two move buttons)
+  const actions = await page.locator('.grok-order-rule-row:not(.grok-order-rule-header)')
+    .first().locator('.grok-order-rule-actions i').count();
+  check('row has move-up / move-down / remove buttons', actions === 3, `icons=${actions}`);
+
+  // 3 - space selector is a typeahead
+  const ta = await page.locator('.grok-order-rule-row:not(.grok-order-rule-header)')
+    .first().locator('input[placeholder="space name"]').count();
+  check('parent space is a typeahead input', ta > 0, `matches=${ta}`);
+
+  // Desc checkbox must stay checkbox-sized: `.ui-input-editor { width: 100% }` had stretched it.
+  const cb = await page.evaluate(() => {
+    const c = document.querySelector('.grok-order-rule-row:not(.grok-order-rule-header) .grok-order-rule-desc input[type=checkbox]');
+    return c ? { w: c.offsetWidth, h: c.offsetHeight } : null;
+  });
+  console.log('    checkbox:', JSON.stringify(cb));
+  check('Desc checkbox is checkbox-sized', cb && cb.w <= 24 && cb.h <= 24, JSON.stringify(cb));
+
+  // Add rule sits above the list.
+  const orderOk = await page.evaluate(() => {
+    const host = document.querySelector('.grok-settings-order-rules');
+    const kids = [...host.children];
+    return kids.findIndex(k => k.classList.contains('grok-order-rule-add'))
+         < kids.findIndex(k => k.classList.contains('grok-order-rules-rows'));
+  });
+  check('Add rule is above the list', orderOk === true, String(orderOk));
+
+  // The rows container must not clip, or it hides the typeahead dropdown.
+  const clip = await page.evaluate(() => {
+    const r = document.querySelector('.grok-order-rules-rows');
+    const host = document.querySelector('.grok-settings-order-rules');
+    const s = getComputedStyle(r);
+    return { overflowY: s.overflowY, h: r.offsetHeight, hostH: host.offsetHeight };
+  });
+  console.log('    rows container:', JSON.stringify(clip));
+  check('rows container does not clip the dropdown',
+    clip && clip.overflowY !== 'auto' && clip.overflowY !== 'scroll' && clip.overflowY !== 'hidden',
+    JSON.stringify(clip));
+  // Chrome above the list is the description + Add rule + header + host padding (~135px).
+  check('list stretches to the remaining height', clip && clip.h >= clip.hostH - 170,
+    JSON.stringify(clip));
+
+  // A new rule defaults to "Any space", so the typeahead starts disabled; unchecking Any enables it.
+  const row1 = page.locator('.grok-order-rule-row:not(.grok-order-rule-header)').first();
+  const anyBox = row1.locator('.grok-order-rule-space input[type=checkbox]').first();
+  const spaceInput = row1.locator('input[placeholder="space name"]');
+  const hiddenWhenAny = await spaceInput.evaluate(e => {
+    const r = e.getBoundingClientRect();
+    return r.width === 0 && r.height === 0;
+  });
+  check('space typeahead is hidden while Any is checked', hiddenWhenAny === true,
+    String(hiddenWhenAny));
+  await anyBox.uncheck();
+  await page.waitForTimeout(2000);
+  const shownAfter = await spaceInput.evaluate(e => {
+    const r = e.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  });
+  check('unchecking Any shows the space typeahead', shownAfter === true, String(shownAfter));
+
+  // Checkbox first, then its label; and all three boxes are the same size.
+  const layout = await page.evaluate(() => {
+    const row = document.querySelector('.grok-order-rule-row:not(.grok-order-rule-header)');
+    const chk = row.querySelector('.grok-order-rule-check');
+    const box = chk.querySelector('input[type=checkbox]');
+    const lbl = chk.querySelector('.grok-order-rule-check-label');
+    const sizes = [...row.querySelectorAll('input[type=checkbox]')]
+      .map(c => `${c.offsetWidth}x${c.offsetHeight}`);
+    return { boxX: box.getBoundingClientRect().left, lblX: lbl.getBoundingClientRect().left,
+             sizes, rowH: row.offsetHeight };
+  });
+  console.log('    layout:', JSON.stringify(layout));
+  check('checkbox comes before its label', layout.boxX < layout.lblX,
+    `box=${layout.boxX} label=${layout.lblX}`);
+  check('all three checkboxes are the same size',
+    new Set(layout.sizes).size === 1 && layout.sizes.length === 3, JSON.stringify(layout.sizes));
+  check('row is taller', layout.rowH >= 32, String(layout.rowH));
+
+  // Typeahead dropdown must be visible above later rows.
+  await spaceInput.click();
+  await spaceInput.type('a');
+  await page.waitForTimeout(2500);
+  await page.screenshot({ path: 'set-05-dropdown.png' });
+  const dd = await page.evaluate(() => {
+    const d = document.querySelector('.type-ahead-drop-down');
+    if (!d) return null;
+    const r = d.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) return { visible: false };
+    // whatever paints at the dropdown's own centre should be the dropdown itself
+    const el = document.elementFromPoint(r.left + r.width / 2, r.top + Math.min(20, r.height / 2));
+    return { visible: true, ownsPixel: !!(el && d.contains(el)), rect: { w: Math.round(r.width), h: Math.round(r.height) } };
+  });
+  console.log('    dropdown:', JSON.stringify(dd));
+  check('typeahead dropdown is not covered by the list',
+    dd === null || dd.visible === false || dd.ownsPixel === true, JSON.stringify(dd));
+
+  // Any / Root are checkboxes now, not entries in the typeahead list.
+  const spaceCell = page.locator('.grok-order-rule-row:not(.grok-order-rule-header)').first()
+    .locator('.grok-order-rule-space');
+  const boxes = await spaceCell.locator('input[type=checkbox]').count();
+  const anyRoot = (await spaceCell.innerText()).replace(/\s+/g, ' ').trim();
+  console.log('    space cell:', JSON.stringify(anyRoot), 'checkboxes=', boxes);
+  check('space cell has Any / Root checkboxes', boxes === 2, `checkboxes=${boxes}`);
+  check('space typeahead is for real spaces only',
+    await spaceCell.locator('input[placeholder="space name"]').count() > 0);
+
+  // Entity types are limited to what actually appears in Browse / card views.
+  const types = await page.locator('.grok-order-rule-row:not(.grok-order-rule-header)').first()
+    .locator('.grok-order-rule-cell').first().locator('option').allInnerTexts();
+  console.log('    entity types:', JSON.stringify(types));
+  check('entity list includes Space / Dashboard / User',
+    types.indexOf('Space') >= 0 && types.indexOf('Dashboard') >= 0 && types.indexOf('User') >= 0,
+    JSON.stringify(types));
+  check('entity list excludes internal types',
+    types.indexOf('FuncCall') < 0 && types.indexOf('EntityTag') < 0, JSON.stringify(types));
+  check('entity list is short (curated, not the whole registry)', types.length <= 25,
+    `count=${types.length}`);
+
+  // make the two rules distinguishable: set row 2's Order by
+  const row2Field = page.locator('.grok-order-rule-row:not(.grok-order-rule-header)').nth(1)
+    .locator('.grok-order-rule-cell').nth(2).locator('input');
+  await row2Field.fill('createdOn');
+  await row2Field.press('Enter');
+  await page.waitForTimeout(3000);
+
+  // Nothing may be applied before Save and apply.
+  let staged = await rulesOf(page);
+  console.log('    before save:', JSON.stringify(staged));
+  check('edits are NOT applied before Save and apply',
+    !staged || staged.length === 0, JSON.stringify(staged));
+
+  await saveAndApply(page);
+  let rules = await rulesOf(page);
+  console.log('    after save:', JSON.stringify(rules));
+  check('Save and apply commits the rules',
+    rules && rules.length === 2 && rules[1].field === 'createdOn', JSON.stringify(rules));
+  // A half-typed space name is not a space id; storing it would make the rule match nothing.
+  check('partial space text is not stored as a space id',
+    rules && rules.every(r => r.space === '' || r.space === '@root' || r.space.length > 8),
+    JSON.stringify(rules.map(r => r.space)));
+
+  // 5 - move row 1 down
+  await page.locator('.grok-order-rule-row:not(.grok-order-rule-header)').first()
+    .locator('.grok-order-rule-actions i').nth(1).click();
+  await page.waitForTimeout(3000);
+  await saveAndApply(page);
+  rules = await rulesOf(page);
+  console.log('    after move-down:', JSON.stringify(rules));
+  check('move down reorders priority',
+    rules && rules.length === 2 && rules[0].field === 'createdOn', JSON.stringify(rules));
+  await page.screenshot({ path: 'set-03-moved.png' });
+
+  // 5 - move it back up
+  await page.locator('.grok-order-rule-row:not(.grok-order-rule-header)').nth(1)
+    .locator('.grok-order-rule-actions i').nth(0).click();
+  await page.waitForTimeout(3000);
+  await saveAndApply(page);
+  rules = await rulesOf(page);
+  console.log('    after move-up:', JSON.stringify(rules));
+  check('move up restores priority',
+    rules && rules.length === 2 && rules[0].field === 'friendlyName', JSON.stringify(rules));
+
+  // 2 - remove a row
+  await page.locator('.grok-order-rule-row:not(.grok-order-rule-header)').first()
+    .locator('.grok-order-rule-actions i').nth(2).click();
+  await page.waitForTimeout(3000);
+  await saveAndApply(page);
+  rules = await rulesOf(page);
+  console.log('    after remove:', JSON.stringify(rules));
+  check('remove deletes that row',
+    rules && rules.length === 1 && rules[0].field === 'createdOn', JSON.stringify(rules));
+
+  // persistence across reload
+  await page.goto(`${BASE}/settings/browse`, { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await page.waitForTimeout(25000);
+  rules = await rulesOf(page);
+  console.log('    after reload:', JSON.stringify(rules));
+  check('rules survive reload', rules && rules.length === 1, JSON.stringify(rules));
+  await page.screenshot({ path: 'set-04-reloaded.png' });
+
+  console.log('\n--- errors (' + errors.length + '):');
+  errors.slice(0, 8).forEach(e => console.log('      ' + e));
+  await browser.close();
+  console.log(failures === 0 ? '\nALL SETTINGS CHECKS PASSED' : `\n${failures} CHECK(S) FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+})().catch(e => { console.error('HARNESS ERROR', e); process.exit(2); });


### PR DESCRIPTION
Companion to the Bitbucket PR on `claude/spaces-ordering` (reddata), which carries the feature itself.

## What's here

- **`js-api/src/api/xamgle.api.g.ts`** — regenerated for the new `Settings.orderRules` property backing the Browse ordering rules. Generated file; do not edit by hand.
- **Three Playwright suites** (`playwright-public/`) driving a live dev stack:

| Suite | Covers |
|---|---|
| `order-e2e.js` | Browse tree ordering, per-space overrides, ordering by `id` |
| `settings-e2e.js` | rules editor — layout, priorities, move/remove, typeahead, deferred apply, persistence |
| `group-e2e.js` | group / All-Users defaults, including a second session inheriting them |

40 checks total, all passing against a local stack.

## Why the suites are worth keeping

They caught defects static analysis cannot see, including a Dart 1.x `?.` chain that threw on exactly the null path it was added for, and a torn-off method used as a getter (`cell.valueString` without the call). Both compiled clean and failed only at runtime.

## Running them

Needs a dev stack on `DG_BASE` (default `http://localhost:61006`) with an `admin`/`admin` account:

```bash
cd playwright-public && node order-e2e.js
```

## Notes

- `grok_api.g.ts` and `grok_shared.api.g.ts` are also regenerated locally, but that drift is unrelated to this change (committed Dart whose generated TS was stale) and is deliberately left out.
- `playwright-public/` already contained other untracked scratch files; only these three are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)