### PR TITLE
JS API: Rename the u2 Component.run scope helper to runInScope

### DIFF
--- a/js-api/CHANGELOG.md
+++ b/js-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* Renamed the u2 `Component.run(fn)` scope helper to `runInScope(fn)` — `run` is inherited by every view and widget and collided with the long-standing `run()` on `FunctionView` and `Tutorial`, breaking those package builds with `TS2416`
 * GROK-20753: Added `DG.SEMTYPE.FUNCTION_NAME` (`'FunctionName'`) — the standard semantic type for a namespace-qualified function name.
 * GROK-20753: Added `FuncCall.evalParamValidators(name)` — runs the parameter's named `validators:` against its current value in the call (resolution and evaluation stay Dart-side; passing validators are omitted from the returned `{message, isError, isHelper}` list).
 * GROK-20753: Added `DG.StringUtils.levenshteinDistance(a, b)` / `jaroWinklerDistance(a, b)` — normalized string distances in [0, 1] (moved from `@datagrok-libraries/u2`)

--- a/js-api/src/u2core/component.ts
+++ b/js-api/src/u2core/component.ts
@@ -127,7 +127,7 @@ export class Component implements BindSource {
     return proto === Object.prototype || proto === null;
   }
 
-  run<T>(fn: () => T): T {
+  runInScope<T>(fn: () => T): T {
     return Scope.runWith(this.scope, fn);
   }
 

--- a/libraries/u2/src/components/actions/buttons.ts
+++ b/libraries/u2/src/components/actions/buttons.ts
@@ -17,7 +17,7 @@ export interface IconButtonOptions {
 }
 
 const NO_OWNER = 'u2: signal binding needs an owner — ' +
-  'wrap the code in Control.build(...) or component.run(...)';
+  'wrap the code in Control.build(...) or component.runInScope(...)';
 
 /** Hover text in the icon.ts convention: the tooltip service when there is a scope to own it,
  * the native `title` otherwise. The tooltip doubles as the accessible name — the u2 tooltip

--- a/libraries/u2/src/components/collections/functions-browser.ts
+++ b/libraries/u2/src/components/collections/functions-browser.ts
@@ -181,10 +181,10 @@ export class FunctionsBrowser extends Control {
     this._shown = computed(() => filterFuncItems(this._source.value.value, this.query.value,
       this.checkedTags.value, this.checkedRoles.value));
 
-    const searchInput = this.run(() => new TextInput(
+    const searchInput = this.runInScope(() => new TextInput(
       {search: true, inline: true, placeholder: 'Search by name, #tag, or @role', bind: this.query}));
     // the toggle option mirrors showTags into aria-pressed and the pressed skin, however it flips
-    const filterIcon = this.run(() => iconButton('filter', () => {},
+    const filterIcon = this.runInScope(() => iconButton('filter', () => {},
       {tooltip: 'Toggle filter panel', toggle: this.showTags}));
     const searchRow = divH([searchInput, filterIcon], 'u2-fb-search');
     searchRow.dataset.u2 = 'fb-search';
@@ -214,7 +214,7 @@ export class FunctionsBrowser extends Control {
     panes.dataset.u2 = 'fb-panes';
 
     const contextActions = options.contextActions;
-    this._list = this.run(() => new VirtualList<FuncItem>({
+    this._list = this.runInScope(() => new VirtualList<FuncItem>({
       itemHeight: options.itemHeight ?? 28,
       keyOf: (item) => item.name,
       render: (item, _index, row) => this._renderRow(item, row),
@@ -224,7 +224,7 @@ export class FunctionsBrowser extends Control {
     this._list.setItems(this._shown);
 
     const emptyMessage = span('', 'u2-fb-empty-message');
-    const clearSearch = this.run(() => button('Clear search', () => this.query.value = ''));
+    const clearSearch = this.runInScope(() => button('Clear search', () => this.query.value = ''));
     clearSearch.classList.add('u2-fb-clear');
     clearSearch.dataset.u2 = 'fb-clear';
     const empty = divV([emptyMessage, clearSearch], 'u2-async-empty u2-fb-empty');

--- a/libraries/u2/src/components/containers/card.ts
+++ b/libraries/u2/src/components/containers/card.ts
@@ -36,7 +36,7 @@ export class Card extends Control {
     this.selected = options.selected instanceof Signal ? options.selected : signal(!!options.selected);
     this.root.classList.add('u2-card');
     this.root.dataset.u2 = 'card';
-    this.body = this.run(() => this._build(options));
+    this.body = this.runInScope(() => this._build(options));
     this._wire(options);
   }
 

--- a/libraries/u2/src/components/containers/dialog.ts
+++ b/libraries/u2/src/components/containers/dialog.ts
@@ -171,7 +171,7 @@ export class Dialog extends Control {
   }
 
   private _button(text: string, onClick: () => void, primary?: boolean): HTMLButtonElement {
-    return this.run(() => button(text, onClick, {primary}));
+    return this.runInScope(() => button(text, onClick, {primary}));
   }
 
   private _finish(fn: (() => unknown) | undefined): void {

--- a/libraries/u2/src/components/containers/section.ts
+++ b/libraries/u2/src/components/containers/section.ts
@@ -30,7 +30,7 @@ export class Section extends Control {
     this.expanded = options.expanded instanceof Signal ? options.expanded :
       signal(options.expanded !== false);
     const collapsible = options.collapsible !== false;
-    const title = this.run(() => span(options.title, 'u2-section-title'));
+    const title = this.runInScope(() => span(options.title, 'u2-section-title'));
     this.header = div([title], 'u2-section-header');
     this.header.id = `${id}-header`;
     this.body = div([], 'u2-section-body');

--- a/libraries/u2/src/components/containers/wizard.ts
+++ b/libraries/u2/src/components/containers/wizard.ts
@@ -120,7 +120,7 @@ export class Wizard extends Control {
   /** Shows the wizard as a modal dialog; repeated calls reopen the same one. */
   openInDialog(title: string, options: {width?: number, height?: number} = {}): Dialog {
     if (!this._dialog) {
-      const dialog = this.run(() => Dialog.create(title).add(this));
+      const dialog = this.runInScope(() => Dialog.create(title).add(this));
       this._dialog = dialog;
       this._footer.insertBefore(this._button('CANCEL', () => dialog.close()), this._back);
       let open = false;
@@ -217,7 +217,7 @@ export class Wizard extends Control {
   }
 
   private _button(text: string, onClick: () => void, primary?: boolean): HTMLButtonElement {
-    return this.run(() => button(text, onClick, {primary}));
+    return this.runInScope(() => button(text, onClick, {primary}));
   }
 
   private _focusStep(index: number): void {

--- a/libraries/u2/src/components/display/async-view.ts
+++ b/libraries/u2/src/components/display/async-view.ts
@@ -56,7 +56,7 @@ export class AsyncView<T> extends Control {
     this._skeleton = options?.skeleton ?? false;
     this.root.classList.add('u2-async-view');
     this.root.dataset.u2 = 'async-view';
-    this._retry = this.run(() => button('Retry', () => source.retry()));
+    this._retry = this.runInScope(() => button('Retry', () => source.retry()));
     this.own(() => this._releaseContent());
     this.effect(() => this._apply(source.state.value));
   }

--- a/libraries/u2/src/components/display/badge.ts
+++ b/libraries/u2/src/components/display/badge.ts
@@ -11,7 +11,7 @@ function owner(): Scope {
   const scope = Scope.ambient;
   if (!scope) {
     throw new Error('u2: signal binding needs an owner — ' +
-      'wrap the code in Control.build(...) or component.run(...)');
+      'wrap the code in Control.build(...) or component.runInScope(...)');
   }
   return scope;
 }

--- a/libraries/u2/src/components/display/progress.ts
+++ b/libraries/u2/src/components/display/progress.ts
@@ -43,7 +43,7 @@ export class ProgressBar extends Control {
 
     const description = options?.description;
     if (description !== undefined)
-      this.root.append(this.run(() => span(description, 'u2-progress-description')));
+      this.root.append(this.runInScope(() => span(description, 'u2-progress-description')));
 
     this.root.classList.toggle('u2-progress-indeterminate', this._indeterminate);
     this.effect(() => this._apply(this.value.value));

--- a/libraries/u2/src/components/display/stat-card.ts
+++ b/libraries/u2/src/components/display/stat-card.ts
@@ -40,7 +40,7 @@ export class StatCard extends Control {
     this.root.dataset.u2 = 'stat-card';
     this._valueEl = div(undefined, 'u2-stat-value');
     this._deltaEl = options.delta === undefined ? undefined : div(undefined, 'u2-stat-delta');
-    this.run(() => {
+    this.runInScope(() => {
       if (options.icon !== undefined)
         this.root.append(icon(options.icon, {cls: 'u2-stat-icon'}));
       this.root.append(this._valueEl, span(options.label, 'u2-stat-label'));

--- a/libraries/u2/src/components/inputs/message-input.ts
+++ b/libraries/u2/src/components/inputs/message-input.ts
@@ -94,7 +94,7 @@ export class MessageInput extends Control {
     editor.dataset.placeholder = options.placeholder ?? '';
     editor.style.maxHeight = `${options.maxHeight ?? 160}px`;
 
-    this.run(() => {
+    this.runInScope(() => {
       const tools = document.createElement('div');
       tools.className = 'u2-msg-tools';
       for (const provider of this._providers) {

--- a/libraries/u2/src/core/elements.ts
+++ b/libraries/u2/src/core/elements.ts
@@ -9,7 +9,7 @@ export type Child = HTMLElement | Control | string | ReadonlySignal<unknown>;
 export type Text = string | ReadonlySignal<unknown>;
 
 const NO_OWNER = 'u2: signal binding needs an owner — ' +
-  'wrap the code in Control.build(...) or component.run(...)';
+  'wrap the code in Control.build(...) or component.runInScope(...)';
 
 function isSignal(x: unknown): x is ReadonlySignal<unknown> {
   return x instanceof Signal;

--- a/libraries/u2/src/core/input-base.ts
+++ b/libraries/u2/src/core/input-base.ts
@@ -86,7 +86,7 @@ export abstract class Input<T, O extends InputOptions<T> = InputOptions<T>> exte
     this._optionsRail = div([], 'u2-input-options');
     this._optionsRail.dataset.u2Part = 'options';
     this._error.dataset.u2Part = 'error';
-    this._editor = this.run(() => this.createEditor());
+    this._editor = this.runInScope(() => this.createEditor());
     this._editor.classList.add('u2-input-editor');
     this._editor.dataset.u2Part = 'editor';
     // prepended: a subclass that filled the rail from createEditor already attached it

--- a/libraries/u2/src/dg/designer/bind-picker.ts
+++ b/libraries/u2/src/dg/designer/bind-picker.ts
@@ -102,9 +102,9 @@ export function bindPicker(instance: SpecInstance, onPick: (path: string) => boo
   const dialog = new Dialog(options.prop === undefined ? 'Bind to' : `${options.prop} — bind to`);
   dialog.root.classList.add('u2-bind-picker');
   const groups = bindGroups(instance, bindTree(instance));
-  const search = dialog.run(() =>
+  const search = dialog.runInScope(() =>
     new TextInput({search: true, inline: true, placeholder: 'Search bindings'}));
-  const tree = dialog.run(() => new VirtualTree<BindTreeNode>());
+  const tree = dialog.runInScope(() => new VirtualTree<BindTreeNode>());
   const empty = span('', 'u2-picker-empty');
   tree.expanded.value = new Set(groups.map((group) => group.title));
   dialog.effect(() => {

--- a/libraries/u2/src/dg/designer/func-picker.ts
+++ b/libraries/u2/src/dg/designer/func-picker.ts
@@ -155,7 +155,7 @@ export function funcPicker(options: FuncPickerOptions): Dialog {
   dialog.root.classList.add('u2-func-picker');
   const entries = funcEntries(DG.Func.find({}) as unknown as FuncLike[]);
   const renderer = handlerRenderer<FuncLike>();
-  const search = dialog.run(() =>
+  const search = dialog.runInScope(() =>
     new TextInput({search: true, inline: true, placeholder: 'Search functions'}));
   const empty = span('', 'u2-picker-empty');
   const host = div([], 'u2-func-picker-params');
@@ -199,7 +199,7 @@ export function funcPicker(options: FuncPickerOptions): Dialog {
         continue;
       input.root.setAttribute('data-u2-prop', name);
       // owned by the dialog, not by the pane the pick rebuilds — the bind picker outlives it
-      bindPickerButton(input, name, () => dialog.run(() => bindPicker(options.instance, (path) => {
+      bindPickerButton(input, name, () => dialog.runInScope(() => bindPicker(options.instance, (path) => {
         binds[name] = path;
         showParams();
       })));
@@ -207,7 +207,7 @@ export function funcPicker(options: FuncPickerOptions): Dialog {
     host.append(form.root);
   };
 
-  const list = dialog.run(() => new VirtualList<FuncEntry>({
+  const list = dialog.runInScope(() => new VirtualList<FuncEntry>({
     itemHeight: 28,
     keyOf: (entry) => entry.name,
     render: (entry, _index, row) => {

--- a/libraries/u2/src/dg/designer/palette.ts
+++ b/libraries/u2/src/dg/designer/palette.ts
@@ -36,8 +36,8 @@ export class Palette extends Control {
     super();
     this.root.classList.add('u2-palette');
     this.root.dataset.u2 = 'palette';
-    this.filter = this.run(() => new TextInput({search: true, inline: true, placeholder: 'Filter'}));
-    const accordion = this.run(() => new Accordion());
+    this.filter = this.runInScope(() => new TextInput({search: true, inline: true, placeholder: 'Filter'}));
+    const accordion = this.runInScope(() => new Accordion());
     accordion.root.classList.add('u2-palette-list');
     this.root.append(this.filter.root, accordion.root);
 

--- a/libraries/u2/src/dg/designer/tray.ts
+++ b/libraries/u2/src/dg/designer/tray.ts
@@ -174,13 +174,13 @@ export class Tray extends Control {
   }
 
   private _addFunc(instance: SpecInstance): void {
-    this.run(() => funcPicker({title: 'Data source: function or query', instance,
+    this.runInScope(() => funcPicker({title: 'Data source: function or query', instance,
       onPick: (pick) => this._options.onAdd(nameForTag(FUNC), (name) =>
         funcSourceNode(instance.registry.get(FUNC), name, pick))}));
   }
 
   private _addEntities(instance: SpecInstance): void {
-    this.run(() => {
+    this.runInScope(() => {
       const collection = new ChoiceInput({label: 'Collection', items: COLLECTIONS, value: COLLECTIONS[0]});
       const filter = new TextInput({label: 'Filter', placeholder: 'A smart-search filter'});
       const pageSize = new NumberInput({label: 'Page size', mode: 'int', value: 20});

--- a/libraries/u2/src/dg/designer/view.ts
+++ b/libraries/u2/src/dg/designer/view.ts
@@ -78,7 +78,7 @@ export class SpecDesigner extends Control {
     this.root.dataset.u2 = 'designer';
     // the shortcuts below are the view's own: the root has to be able to hold focus for them
     this.root.tabIndex = 0;
-    this._tray = this.run(() => new Tray({
+    this._tray = this.runInScope(() => new Tray({
       onSelect: (node) => this._select(node),
       onContext: (node, x, y) => {
         this._select(node);
@@ -86,11 +86,11 @@ export class SpecDesigner extends Control {
       },
       onAdd: (base, seed) => this._dragLayer.addComponent(base, seed),
     }));
-    this._tree = this.run(() => new VirtualTree<SpecNode>({
+    this._tree = this.runInScope(() => new VirtualTree<SpecNode>({
       onRename: (node, label) => this._rename(node, label),
       contextActions: (node) => this._rowActions(node),
     }));
-    this._mode = this.run(() => new ButtonGroup({
+    this._mode = this.runInScope(() => new ButtonGroup({
       items: [{id: 'design', label: 'Design'}, {id: 'run', label: 'Run'}],
       toggle: 'single',
       density: 'ribbon',
@@ -197,7 +197,7 @@ export class SpecDesigner extends Control {
 
     this.open(spec);
 
-    this._palette = this.run(() => new Palette(this._instance?.registry ?? this._registry));
+    this._palette = this.runInScope(() => new Palette(this._instance?.registry ?? this._registry));
     this.toolbox = divV([h3('Palette'), this._palette.root, h3('Structure'), this._tree.root],
       'u2-designer-toolbox');
     this._listen(this._palette.root, 'mousedown', (e) => this._dragLayer.onPaletteDown(e as MouseEvent));
@@ -231,7 +231,7 @@ export class SpecDesigner extends Control {
   }
 
   ribbon(): HTMLElement[] {
-    return this.run(() => this._ribbon.build());
+    return this.runInScope(() => this._ribbon.build());
   }
 
   /** Renders `spec` in place of what the canvas holds, with a fresh editor — an instance and its
@@ -255,7 +255,7 @@ export class SpecDesigner extends Control {
     this._selection.multi = [];
     this._hovered = null;
     this._pendingSelect = null;
-    this._instance = this.run(() => renderSpec(parsed, this._ctx, this._registry,
+    this._instance = this.runInScope(() => renderSpec(parsed, this._ctx, this._registry,
       {designTime: this._mode.selected.peek()[0] !== 'run'}));
     this._surface.append(this._instance.root);
     this._editor.value = new SpecEditor(this._instance);

--- a/libraries/u2/src/dg/entities/func-call-history-browser.ts
+++ b/libraries/u2/src/dg/entities/func-call-history-browser.ts
@@ -63,7 +63,7 @@ export class FuncCallHistoryBrowser extends Control {
     this.own(() => this._pager.dispose());
 
     const itemHeight = options.itemHeight ?? 36;
-    this._list = this.run(() => new VirtualList<DG.FuncCall>({
+    this._list = this.runInScope(() => new VirtualList<DG.FuncCall>({
       itemHeight,
       keyOf: (call) => call.id,
       render: (call, _index, row) => this._renderRow(call, row),
@@ -79,7 +79,7 @@ export class FuncCallHistoryBrowser extends Control {
     this.own(() => this._list.root.removeEventListener('scroll', onScroll));
 
     const emptyMessage = span('', 'u2-fch-empty-message');
-    const retry = this.run(() => button('Retry', () => this._pager.loadMore()));
+    const retry = this.runInScope(() => button('Retry', () => this._pager.loadMore()));
     retry.dataset.u2 = 'fch-retry';
     const stateArea = divV([emptyMessage, retry], 'u2-async-empty u2-fch-state');
     stateArea.dataset.u2 = 'fch-state';

--- a/libraries/u2/src/dg/forms/object-form.ts
+++ b/libraries/u2/src/dg/forms/object-form.ts
@@ -346,11 +346,11 @@ export class ObjectForm extends Form {
       nullable: prop.nullable,
       ...rest,
     };
-    const registered = custom ? null : this.run(() => Editors.resolve(prop, options));
+    const registered = custom ? null : this.runInScope(() => Editors.resolve(prop, options));
     const platform = (custom ?? registered) != null ? null :
       ObjectForm.platformInput(this, prop, this.target, this._auto);
     const input = custom ?? registered ?? platform ??
-      this.run(() => inputForProperty(prop, options));
+      this.runInScope(() => inputForProperty(prop, options));
     const native = input === platform;
     if (!native) {
       input.value.value = this._read(prop, kind);
@@ -397,7 +397,7 @@ export class ObjectForm extends Form {
       return null;
     try {
       const input = dg.InputBase.forProperty(prop as any, target);
-      return input == null ? null : form.run(() => fromDartInput(input, prop.name));
+      return input == null ? null : form.runInScope(() => fromDartInput(input, prop.name));
     } catch {
       return null;
     }

--- a/libraries/u2/src/dg/funcs/func-form.ts
+++ b/libraries/u2/src/dg/funcs/func-form.ts
@@ -260,7 +260,7 @@ export class FuncCallForm extends Form {
   }
 
   private _buildRunButton(show: LiveOption<boolean>): void {
-    const run = this.run(() => button('Run', () => void this._runAndSave(), {primary: true}));
+    const run = this.runInScope(() => button('Run', () => void this._runAndSave(), {primary: true}));
     run.dataset.u2 = 'ff-run';
     this.addButtons((row) => row.append(run));
     if (show instanceof Signal)
@@ -297,7 +297,7 @@ export class FuncCallForm extends Form {
   }
 
   private _buildHistoryIcon(show: LiveOption<boolean>): void {
-    const icon = this._historyIcon = this.run(() => iconButton('history',
+    const icon = this._historyIcon = this.runInScope(() => iconButton('history',
       () => this._toggleHistory(), {tooltip: 'Apply a previous run'}));
     icon.dataset.u2 = 'ff-history-icon';
     this.addButtons((row) => row.prepend(icon));
@@ -479,7 +479,7 @@ export class FuncCallForm extends Form {
     // auto-hide machinery and the category skin stay exactly where they were; a header owning
     // no fields (a group heading, a duplicate) renders plain — a chevron over nothing lies
     const section = (name: string, collapsible: boolean, levelClass?: string): Section => {
-      const s = this.run(() => new Section({title: name, collapsible}));
+      const s = this.runInScope(() => new Section({title: name, collapsible}));
       s.header.classList.add('u2-form-category');
       if (levelClass !== undefined)
         s.header.classList.add(levelClass);
@@ -590,18 +590,18 @@ export class FuncCallForm extends Form {
       postfix: prop.units || prop.options?.['units'] || undefined,
       ...rest,
     };
-    const registered = custom ? null : this.run(() => Editors.resolve(prop, options));
+    const registered = custom ? null : this.runInScope(() => Editors.resolve(prop, options));
     // a custom editor owns its field entirely and gets no dynamic wiring (the W1 override contract)
     const route: FuncField['route'] = (custom ?? registered) != null ? 'field' : routed;
     const filter = route === 'column' || route === 'columns' ? columnPredicate(prop) : undefined;
     let input: Input<any>;
     let kind: Kind | null;
     if (route === 'choices') {
-      input = this.run(() => new ChoiceInput({...options, items: []}));
+      input = this.runInScope(() => new ChoiceInput({...options, items: []}));
       kind = 'choice';
     }
     else if (route === 'multiChoices') {
-      input = this.run(() => new MultiChoiceInput({...options, items: [], showSummaryCheckbox: true}));
+      input = this.runInScope(() => new MultiChoiceInput({...options, items: [], showSummaryCheckbox: true}));
       kind = 'list';
     }
     else if (route === 'suggestions') {
@@ -610,16 +610,16 @@ export class FuncCallForm extends Form {
     }
     else if (route === 'table') {
       const {label: caption, ...tableOptions} = options;
-      input = this.run(() => tableInput(caption ?? param.name, tableOptions));
+      input = this.runInScope(() => tableInput(caption ?? param.name, tableOptions));
       kind = 'string';
     }
     else if (route === 'column') {
-      input = this.run(() => new ColumnInput({...options,
+      input = this.runInScope(() => new ColumnInput({...options,
         table: asTable(parent?.value), filter}));
       kind = 'string';
     }
     else if (route === 'columns') {
-      input = this.run(() => new ColumnsInput({...options,
+      input = this.runInScope(() => new ColumnsInput({...options,
         table: asTable(parent?.value), filter}));
       kind = 'list';
     }
@@ -627,7 +627,7 @@ export class FuncCallForm extends Form {
       const platform = (custom ?? registered) != null ? null :
         ObjectForm.platformInput(this, prop, this._call, this._formOptions.editors === 'auto');
       input = custom ?? registered ?? platform ??
-        this.run(() => inputForProperty(prop, {...options, assumeWritable: true}));
+        this.runInScope(() => inputForProperty(prop, {...options, assumeWritable: true}));
       kind = platform !== null && input === platform ? null : kindOf(prop, true);
     }
     const field: FuncField = {param, input, kind, route, filter, orphaned: false,
@@ -741,7 +741,7 @@ export class FuncCallForm extends Form {
 
   private _suggestInput(name: string, options: InputOptions<any>): Input<string> {
     let tooltips: Record<string, string> = {};
-    return this.run(() => new SuggestInput({
+    return this.runInScope(() => new SuggestInput({
       ...options,
       minChars: 1,
       source: async (text: string, abort: AbortSignal) => {
@@ -777,7 +777,7 @@ export class FuncCallForm extends Form {
         retry: () => this._wireSource(field)});
       return;
     }
-    field.source = this.run(() => new ParamSource(this._call, field.param.name,
+    field.source = this.runInScope(() => new ParamSource(this._call, field.param.name,
       (r) => this._applyItems(field, r), state));
   }
 
@@ -794,7 +794,7 @@ export class FuncCallForm extends Form {
   private _stateOf(field: FuncField): ParamState {
     let state = field.state;
     if (state === undefined) {
-      const created = this.run(() => new ParamState());
+      const created = this.runInScope(() => new ParamState());
       state = created;
       field.state = created;
       field.input.box.append(created.root);
@@ -1136,7 +1136,7 @@ export class FuncCallForm extends Form {
     for (const field of this._fields) {
       if (field.orphaned || (field.route !== 'table' && !dependents.has(field)))
         continue;
-      const binding = this.run(() => new TableBinding(this._call, field.param,
+      const binding = this.runInScope(() => new TableBinding(this._call, field.param,
         (name) => tableByName(name), dependents.get(field) ?? [],
         (dep, oldTableName) => this._clearedNotice(dep.field, oldTableName)));
       this._tableBindings.push(binding);

--- a/libraries/u2/src/dg/inputs/pickers.ts
+++ b/libraries/u2/src/dg/inputs/pickers.ts
@@ -317,7 +317,7 @@ function importAction(input: Input<any, any>, pick: (name: string) => void): voi
   };
   picker.addEventListener('change', onChange);
   input.own(() => picker.removeEventListener('change', onChange));
-  const open = input.run(() => iconButton('folder-open', () => picker.click(), {tooltip: 'Open file'}));
+  const open = input.runInScope(() => iconButton('folder-open', () => picker.click(), {tooltip: 'Open file'}));
   optionsRail(input).append(picker, open);
 }
 

--- a/libraries/u2/src/dg/viewers/viewer-control.ts
+++ b/libraries/u2/src/dg/viewers/viewer-control.ts
@@ -91,7 +91,7 @@ function build<V extends DG.Viewer, S>(make: (df: DG.DataFrame, look: Partial<S>
       REPOINTING.delete(viewer);
     }
   });
-  viewer.run(() => {
+  viewer.runInScope(() => {
     for (const [name, source] of bound)
       viewer.link(name, source, isWritableSignal(source));
   });

--- a/libraries/u2/src/spec/spec.ts
+++ b/libraries/u2/src/spec/spec.ts
@@ -157,7 +157,7 @@ export class SpecInstance extends Control {
     this.root.classList.add('u2-spec');
     // two phases (Q1): the tray is built first, so a visual bind resolves against it, and started
     // last, so a source param can bind to an input declared anywhere in the form
-    this.run(() => {
+    this.runInScope(() => {
       for (const node of spec.components ?? [])
         this._mountComponent(node);
       this.root.append(SpecInstance._element(this._render(spec.root)));

--- a/packages/U2Demo/src/package.ts
+++ b/packages/U2Demo/src/package.ts
@@ -120,7 +120,7 @@ export function u2DemoApp(path?: string): DG.ViewBase {
   content.own(disposePanel);
   const view = appView({
     name: 'U2 Demo', content, status,
-    ribbon: [content.run(() => demoRibbon(shell))],
+    ribbon: [content.runInScope(() => demoRibbon(shell))],
     path: computed(() => APP_PATH + pathOf(shell.current.value)),
   });
   demoView = view;


### PR DESCRIPTION
## The failure

`Compute` and `DevTools` are the two remaining packages failing to build on this error (both via `libraries/compute-utils`):

```
libraries/compute-utils/old-views/src/function-view.ts(774,16)
TS2416: Property 'run' in type 'FunctionView' is not assignable to
        the same property in base type 'ViewBase'
```

The u2 refactor put a scope helper on the `Component` base:

```ts
run<T>(fn: () => T): T { return Scope.runWith(this.scope, fn); }
```

Every view and widget inherits it, so any subclass with its own `run()` stops matching.

## Why rename this side rather than FunctionView

No signature satisfies both — a subclass may drop parameters but cannot return `Promise<void>` where the base returns `T`. One of the two names has to move, and publication status decides which:

| | version in repo | on npm | consequence of renaming |
|---|---|---|---|
| `FunctionView.run` (`compute-utils`) | 1.46.9 | **1.46.9 published** | breaks callers outside this repo; also marked `@stability Stable` |
| `Component.run` (u2) | — | **unpublished** — `datagrok-api` on npm is 1.27.9 (pre-u2); `@datagrok-libraries/u2` returns 404 | costs nothing outside this repo |

The new, unreleased, generically-named helper should yield to the released API.

## Scope and precision

Every `Component.run` call passes an arrow, so `.run((` selects them exactly. **52 call sites across 25 files**, plus three error strings naming the helper.

The other `run` methods are deliberately untouched, checked by hand:

```
action.run(this)              runner.run(this.func, values, abort, …)
host.run(name)                host.run(DELETE)
_verbs.run(name)              action.run()
```

Verified afterwards that no `.run((` remains and all six of the above survive.

## Verification

`function-view.ts` compiled against the current js-api sources:

| | TS2416 |
|---|---|
| before | 1 — `function-view.ts(774,16)` |
| after | **0** |

`FunctionView.run()` is unchanged, so `compute-utils`' public API is preserved.

## Note on #4010

This also removes the need for the `Tutorial.run` → `start()` rename that already merged. I renamed on the consumer side there without checking npm — `@datagrok-libraries/tutorials` is published at 1.7.8, so that change did alter a published API. Impact is small in practice (external tutorials implement the protected `_run()` hook rather than calling `run()`), but `Tutorial.run` could be restored on top of this if the published name matters.

Generated with [Claude Code](https://claude.com/claude-code)