### PR TITLE
CI-CD tests: report Playwright verdicts the way Playwright does

### DIFF
--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Datagrok-tools changelog
 
+## 6.5.8 (2026-08-31)
+
+* `grok test` — fixed the Playwright CSV counting known-failing tests as CI failures.
+
+  Playwright lets a spec declare "this test is expected to fail" (`test.fail()`) — the normal way to
+  track an open product bug without leaving the suite red. Playwright runs such a test, sees it fail
+  as declared, and counts it as a pass; if the product gets fixed the test stops failing, no longer
+  matches the declaration, and Playwright turns it red on its own.
+
+  That means a test has two different statuses: what happened on one attempt (`passed`/`failed`/…)
+  and Playwright's verdict on the test (`expected`/`unexpected`/`flaky`/`skipped`). We were reading
+  the attempt, so every `test.fail()` test — whose attempt is of course `failed` — was written into
+  the CSV as a failure. Build-Deploy #1297 reported Bio as 4 failures where Playwright reported 1,
+  which is why that suite has been permanently UNSTABLE, and why using `test.fail()` at all made a
+  suite look broken.
+
+  The CSV now takes the verdict. Checked against all 12 package suites in that build: each matches
+  Playwright's own summary exactly, and Bio is the only one that changes, being the only suite using
+  the feature. A test that failed and then passed on retry still counts as passing, but is now marked
+  `flaking` instead of being reported as clean.
+
 ## 6.5.7 (2026-08-28)
 
 * GROK-20789: `grok s packages` — full package lifecycle from the CLI: `install <name>... [--version <v>]` (server pulls released versions from the configured package repository / npm, `latest` by default), `uninstall`, `update <name>... | --all` (preserves `latest` auto-update tracking; pins pinned packages to the concrete registry-latest), `outdated`, `versions`, `set-version`, and `share`. Multi-package install/update runs sequentially with a per-package status table; a nonexistent package or version is a per-package `error` and exit code 1. Also fixed the generic `packages delete`, which was hitting a nonexistent `/public/v1` endpoint.

--- a/tools/bin/utils/playwright-runner.ts
+++ b/tools/bin/utils/playwright-runner.ts
@@ -43,6 +43,7 @@ interface PwTestResult {
 }
 
 interface PwTest {
+  status?: 'expected' | 'unexpected' | 'flaky' | 'skipped';
   results?: PwTestResult[];
 }
 
@@ -101,8 +102,12 @@ function flattenSuites(
           if (!result)
             continue;
           const status = result.status;
-          const skipped = status === 'skipped';
-          const success = status === 'passed';
+          const skipped = t.status === 'skipped' || status === 'skipped';
+          // `t.status` is Playwright's verdict on the test; `result.status` is only what the last
+          // attempt did. The two differ for a test the spec declared as expected to fail
+          // (`test.fail()`), which Playwright counts as a pass — reading the attempt reported
+          // every one of those as a CI failure.
+          const success = !skipped && (t.status ? t.status !== 'unexpected' : status === 'passed');
           var errMsg = '';
           if (!success && !skipped && result.errors && result.errors.length > 0)
             errMsg = result.errors.map((e) => e.message || e.stack || '').filter((s) => s.length > 0).join('\n');
@@ -124,7 +129,7 @@ function flattenSuites(
             owner: owner,
             package: pkgName,
             widgetsDifference: '',
-            flaking: false,
+            flaking: t.status === 'flaky',
           });
         }
       }

--- a/tools/package.json
+++ b/tools/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/datagrok-ai/public.git"
   },
-  "version": "6.5.7",
+  "version": "6.5.8",
   "description": "Utility to upload and publish packages to Datagrok",
   "homepage": "https://github.com/datagrok-ai/public/tree/master/tools#readme",
   "dependencies": {


### PR DESCRIPTION
grok test writes the package Playwright CSV from the raw run outcome of a test's last result instead of the test's own verdict. A test.fail() xfail runs to a failed result while Playwright reports the test as expected, so every xfail is recorded as a CI failure.

In nightly Build-Deploy #1297, Bio was reported as 4 failures against Playwright's own 43 expected / 1 unexpected — this is why that suite has been permanently UNSTABLE. Checked against all 12 package reports from that build: each now matches Playwright's expected/unexpected counts exactly, and Bio is the only suite that changes, because it is the only one using xfails. Nightly-wide the package Playwright failure count goes 22 → 19. flaking is now carried through instead of being hardcoded false.

Version bumped to 6.5.8 — the Tools Package workflow publishes only when package.json carries a version npm does not have yet.

- Needed after merge, otherwise the fix does not reach CI: the Package tests stage runs grok from the datagrok/grok_tester:6.5.3 image, pinned in infra/jenkins/_libs/js.groovy in five places. The image has to be rebuilt (its Dockerfile installs datagrok-tools@latest, so a plain rebuild is enough) and the pipeline pointed at the new tag. 

- Side note for DevOps: CI is currently running tools 6.5.3 while the repo is at 6.5.7 — the image is four versions behind.