### PR TITLE
Security: Unbreak the gitleaks gate (free CLI, allowlist, baseline)

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,9 +1,16 @@
 name: "Secret scan (gitleaks)"
 
 # Server-side secret scanning — the backstop for the gitleaks pre-commit hook,
-# which developers can bypass. Scans the commits in each push / pull request
-# against the ruleset + allowlist in .gitleaks.toml. Defense-in-depth with
-# GitHub's native push protection (enable it in repo Settings → Code security).
+# which developers can bypass. Scans the working TREE (`gitleaks dir`, not
+# history) with the ruleset + allowlist in .gitleaks.toml, so it never trips
+# over secrets already scrubbed from HEAD; anything still on disk is baselined
+# in .gitleaksignore. Defense-in-depth with GitHub's native push protection
+# (enable it in repo Settings → Code security).
+#
+# Runs the gitleaks CLI image directly rather than gitleaks/gitleaks-action:
+# the action requires a paid GITLEAKS_LICENSE for org-owned repos (public or
+# not) and fails closed without one. The CLI is free. Same image and version
+# pin as the reddata Secret-Scan job (infra/jenkins/secret-scan.groovy).
 
 on:
   push:
@@ -24,11 +31,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
+      # Scanned as `dir .` from the mount root, not `dir /scan`: gitleaks derives
+      # fingerprints from the path it is given, so a relative scan keeps them
+      # repo-relative. That makes .gitleaksignore entries match here and under a
+      # plain local `gitleaks dir .`, instead of being pinned to the mount point.
+      # gitleaks auto-loads .gitleaks.toml and .gitleaksignore from the scan root.
       - name: Scan for secrets
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # gitleaks auto-loads .gitleaks.toml from the repo root.
-          # datagrok-ai/public is a public repo, so no GITLEAKS_LICENSE is needed.
+        run: |
+          docker run --rm -w /scan -v "${GITHUB_WORKSPACE}:/scan:ro" -v "${RUNNER_TEMP}:/out" \
+            ghcr.io/gitleaks/gitleaks:v8.30.1 \
+            dir . --redact --no-banner \
+            --report-format sarif --report-path /out/gitleaks-report.sarif --exit-code 1
+
+      - name: Archive report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: ${{ runner.temp }}/gitleaks-report.sarif
+          if-no-files-found: ignore

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,7 +2,15 @@
 #
 # Extends the upstream default ruleset (every built-in secret detector) and adds
 # a Datagrok allowlist so data fixtures and clearly-fake placeholder values do
-# not produce noise. Real credentials must never live in the repo.
+# not produce noise.
+#
+# Two different mechanisms, deliberately kept apart:
+#   - this file excludes whole PATH CLASSES that structurally cannot hold our
+#     secrets (fixtures, vendored specs, test trees). Nothing in them is ever
+#     scanned, now or later, so keep the list tight.
+#   - .gitleaksignore pins INDIVIDUAL reviewed findings (file:rule:line). The
+#     demo and test-database credentials this repo publishes on purpose live
+#     there, so a NEW secret in one of those same files still fails the scan.
 #
 # Used by: the gitleaks pre-commit hook (.pre-commit-config.yaml) and the
 # "Secret scan (gitleaks)" GitHub Actions workflow (.github/workflows/gitleaks.yaml).
@@ -23,9 +31,17 @@ paths = [
   '''.*\.min\.js$''',
   '''(^|/)ApiSamples/''',
   '''(^|/)ApiTests/''',
-  '''(^|/)test/''',
+  '''(^|/)tests?/''',
   '''.*_test\.dart$''',
   '''.*\.(test|spec)\.(ts|js)$''',
+  # Vendored third-party OpenAPI specs. These describe secret-store and OAuth
+  # endpoints, so every schema field name and example value ("secret:",
+  # "oauth2State:", an example presigned S3 downloadURL) trips a detector.
+  # They are upstream API documentation, not our credentials.
+  '''(^|/)KnimeLink/openapi/''',
+  '''(^|/)BenchlingLink/swaggers/''',
+  # Multiple sequence alignments — residue strings read as high entropy.
+  '''.*\.a3m$''',
   '''(^|/)cfg/local2/''',
   '''(^|/)users/''',
   # Browser-facing client code — anything here ships to the browser by design

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,76 @@
+# gitleaks baseline for datagrok-ai/public.
+#
+# Each entry pins ONE known finding (file:rule:line) that has been reviewed. A
+# NEW secret in any of these files still fails the scan - this is a baseline,
+# not an allowlist. Structural false positives (vendored OpenAPI specs,
+# bioinformatics fixtures, test trees) are excluded by path in .gitleaks.toml
+# instead, so they never reach this file.
+#
+# Two kinds of entry, and the difference matters:
+#   - PUBLISHED ON PURPOSE: demo and test-database credentials this repo ships
+#     so users can open Northwind/Chembl. Permanent; they are meant to be public.
+#   - REMEDIATION DEBT: real secrets that were committed and are still live.
+#     Kept here only so the gate starts green while they are worked off. Remove
+#     the line once the secret is rotated and read from the environment.
+#
+# Regenerate after review with:
+#   gitleaks dir . --report-format json --report-path leaks.json
+
+# ============================================================================
+# REMEDIATION DEBT - rotate + externalise, then delete these lines
+# ============================================================================
+# Revvity Signals API key for the dgrok-snb-intg tenant, sent as x-api-key
+# against https://dgrok-snb-intg.signalsresearch2.revvitycloud.com. Public in
+# git history since 2025-11-18, so scrubbing HEAD alone does NOT undo the
+# exposure - the key must be revoked in the Signals tenant and reissued, and
+# the script changed to read it from the environment.
+packages/RevvitySignalsLink/scripts/revvity_etl.py:generic-api-key:14
+
+# --- Algolia search-only key ---
+docusaurus/docusaurus-debug.config.js:generic-api-key:196
+docusaurus/docusaurus-wiki-debug.config.js:generic-api-key:184
+docusaurus/docusaurus.config.js:generic-api-key:211
+
+# --- DB connection (demo/test) ---
+packages/Chembl/connections/unichem.json:generic-api-key:13
+packages/DBTests/connections/cached-postgresql-test.json:generic-api-key:15
+packages/DBTests/connections/clickhouse-adbc-db-tests.json:generic-api-key:14
+packages/DBTests/connections/clickhouse-db-tests.json:generic-api-key:13
+packages/DBTests/connections/mariadb-db-tests.json:generic-api-key:13
+packages/DBTests/connections/mssql-db-tests.json:generic-api-key:13
+packages/DBTests/connections/mssql-test.json:generic-api-key:13
+packages/DBTests/connections/mysql-db-tests.json:generic-api-key:13
+packages/DBTests/connections/neo4j-db-tests.json:generic-api-key:13
+packages/DBTests/connections/oracle-db-tests.json:generic-api-key:13
+packages/DBTests/connections/postgres-db-tests.json:generic-api-key:13
+packages/DBTests/connections/postgresnet-test.json:generic-api-key:13
+packages/DBTests/connections/postgresql-test.json:generic-api-key:13
+packages/DBTests/connections/snowflake-db-tests.json:generic-api-key:15
+packages/Samples/connections/clickhouse-northwind.json:generic-api-key:15
+packages/Samples/connections/mariadb-northwind.json:generic-api-key:15
+packages/Samples/connections/mssql-northwind.json:generic-api-key:15
+packages/Samples/connections/mysql-northwind.json:generic-api-key:15
+packages/Samples/connections/neo4j-northwind.json:generic-api-key:15
+packages/Samples/connections/oracle-northwind.json:generic-api-key:15
+packages/Samples/connections/postgres-northwind.json:generic-api-key:15
+packages/Samples/connections/postgres-world.json:generic-api-key:15
+packages/Samples/projects/coffee-company/connections/postgres-starbucks.json:generic-api-key:15
+
+# --- documentation example ---
+help/govern/_deprecated/group.md:generic-api-key:57
+help/govern/access-control/users-and-groups.md:generic-api-key:250
+
+# --- localhost demo default ---
+packages/NodeJSDemo/dockerfiles/todo-app/src/server.ts:generic-api-key:8
+
+# --- map-tile provider key ---
+packages/GIS/src/gis-openlayer.ts:generic-api-key:811
+packages/GIS/src/package.ts:generic-api-key:340
+
+# --- saved notebook session_token ---
+packages/Samples/_deprecated/projects/demo-notebooks/notebooks/rigid_body_transformations_in_a_plane_2d.json:generic-api-key:1391
+packages/Samples/projects/demo-notebooks/notebooks/rigid_body_transformations_in_a_plane_2d.json:generic-api-key:1391
+
+# --- tutorial demo credential ---
+packages/Tutorials/src/tracks/data-access/tutorials/data-connectors.ts:generic-api-key:60
+packages/Tutorials/src/tracks/eda/tutorials/dashboard.ts:generic-api-key:64


### PR DESCRIPTION
## Why

The gate landed in a state that **fails every run**. `gitleaks/gitleaks-action`
requires a paid `GITLEAKS_LICENSE` for org-owned repos — public or not — so it
exits with `missing gitleaks license` on the push to master and on every PR.
Master is red right now.

## What

- **Run the gitleaks CLI image directly.** Free, and the same image and version
  pin (`ghcr.io/gitleaks/gitleaks:v8.30.1`) that the reddata `Secret-Scan` job
  already uses. Scanned as `dir .` from the mount root so fingerprints stay
  repo-relative and match the baseline both in CI and under a local
  `gitleaks dir .`.
- **`.gitleaks.toml`** — exclude structural false positives by path: vendored
  KNIME and Benchling OpenAPI specs (they describe secret-store and OAuth
  endpoints, so every schema field name trips a detector), `.a3m` sequence
  alignments, and `tests/` alongside `test/`.
- **`.gitleaksignore`** — pin the 36 reviewed findings that remain.

## Triage of the 155 findings on a clean tree

| Count | Disposition |
|---:|---|
| 119 | structural false positives → path rules |
| 35 | published on purpose (demo/test DB credentials, Algolia search-only key, map-tile keys, doc examples) → baseline |
| 1 | **remediation debt** → baseline, annotated |

The allowlist and the baseline are kept deliberately separate: path rules blind
the scanner to a directory permanently, whereas a fingerprint pins one reviewed
line and still fails on anything *new* in the same file.

## Needs a follow-up

`packages/RevvitySignalsLink/scripts/revvity_etl.py` holds a live Revvity Signals
API key for the `dgrok-snb-intg` tenant, public in git history since 2025-11-18.
It is baselined as annotated debt so the gate can go green, but **it must be
revoked in the Signals tenant and reissued** — scrubbing HEAD alone does not
undo the exposure.

Generated with [Claude Code](https://claude.com/claude-code)