### PR TITLE
Security: Baseline the Grokky broker OAuth client ID

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -26,6 +26,11 @@
 # the script changed to read it from the environment.
 packages/RevvitySignalsLink/scripts/revvity_etl.py:generic-api-key:14
 
+# --- OAuth client ID (public by design) ---
+# Client IDs are sent in the authorization URL and are not secrets - the same
+# reasoning that puts connectors/oauth.dart in the .gitleaks.toml allowlist.
+packages/Grokky/dockerfiles/claude-runtime/src/broker/broker.ts:generic-api-key:11
+
 # --- Algolia search-only key ---
 docusaurus/docusaurus-debug.config.js:generic-api-key:196
 docusaurus/docusaurus-wiki-debug.config.js:generic-api-key:184


### PR DESCRIPTION
## Why

Master's gitleaks gate is still failing on one finding. It landed after the
tree the baseline in #4020 was generated from, so it was never covered:

```
packages/Grokky/dockerfiles/claude-runtime/src/broker/broker.ts:11
```

## What it is

`const OAUTH_CLIENT_ID = '...'` — an OAuth **client ID**, not a client secret.
Client IDs are sent in the authorization URL and are public by design; this is
the same reasoning that already allowlists `connectors/oauth.dart` in
`.gitleaks.toml`. Nothing needs rotating.

Verified green: the identical baseline passed on the fix branch with
`no leaks found` in 1m9s.

Generated with [Claude Code](https://claude.com/claude-code)