### PR TITLE
Chembl: ship the ChEMBL DB as a package container, version 37.0.0

### DIFF
--- a/packages/Chembl/CHANGELOG.md
+++ b/packages/Chembl/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChEMBL changelog
 
+## 37.0.0 (2026-08-31)
+
+* Chembl: Replaced the db.datagrok.ai demo database with a package-owned Docker container built on `datagrok/demo_db_chembl`
+* Chembl: Versioned the package after the ChEMBL release it ships — ChEMBL 37 is 37.0.0
+
 ## 1.4.12 (2026-03-16)
 
 * Chembl: Add descriptions to all queries

--- a/packages/Chembl/CLAUDE.md
+++ b/packages/Chembl/CLAUDE.md
@@ -10,8 +10,13 @@ package is **SQL queries** against a Postgres ChEMBL instance with the **RDKit c
 plus a small TypeScript layer that wires those queries into context panels, info panels, the
 `CHEMBL_ID` semantic type, the database explorer, the HitTriage data-source picker, and the demo app.
 
-Auth / credentials: built-in. The three connections in `connections/` point at the public Datagrok
-demo Postgres at `db.datagrok.ai:54325/54326` with hard-coded credentials — no secrets to set.
+Auth / credentials: built-in — no secrets to set. `Chembl` and `ChemblSql` resolve their server from
+the package's own Docker container (`dockerfiles/`, `${Chembl<DockerContainer>}`); `Unichem` still
+points at the public Datagrok demo Postgres at `db.datagrok.ai:54326`.
+
+The package version tracks the ChEMBL release it ships: the container's base image is
+`datagrok/demo_db_chembl:<release>` and the package version is `<release>.0.0`, so ChEMBL 37 ships as
+37.0.0. Bumping to a new release means bumping the `FROM` tag and the major version together.
 
 ## Architecture
 
@@ -40,6 +45,9 @@ demo Postgres at `db.datagrok.ai:54325/54326` with hard-coded credentials — no
 - **`connections/*.json`** — `Chembl` (Postgres provider, used by everything that needs `Choices` /
   `batchMode` / parameterised inputs), `ChemblSql` (PostgresDart provider, used **only** by the
   converters in `converters.sql`), `Unichem` (separate DB, used by one unit-test query).
+- **`dockerfiles/`** — the ChEMBL database itself, a thin layer over `datagrok/demo_db_chembl` that
+  adds the read-only `datagrok` role the connections log in as. `on_demand`, so the first query
+  after an idle period pays a container start.
 - **`enrichments/*.json`** — declarative DBExplorer enrichments (extra columns pulled in on the fly
   when a CHEMBL ID / molregno is materialised). One file per logical enrichment, each specifying a
   key table/column and a join plan against `Chembl:Chembl`. Not queries — don't confuse with

--- a/packages/Chembl/README.md
+++ b/packages/Chembl/README.md
@@ -6,8 +6,12 @@ companion [UniChem](https://www.ebi.ac.uk/unichem/) database. The package ships 
 TypeScript layer on top of a large collection of SQL queries against a Postgres ChEMBL instance with
 the [RDKit cartridge](https://rdkit.org/docs/Cartridge.html) installed.
 
-The bundled connections point at the public Datagrok demo ChEMBL database, so the package works
-out of the box — no credentials required.
+The package ships the database with it: `dockerfiles/` builds a Postgres + RDKit container from the
+ChEMBL release the package is versioned after, and the `Chembl` / `ChemblSql` connections resolve
+their server from that container. The package works out of the box — no credentials required, and
+nothing to deploy alongside it.
+
+The package version is the ChEMBL release plus `.0.0` — 37.0.0 ships ChEMBL 37.
 
 ## Features
 
@@ -40,6 +44,8 @@ out of the box — no credentials required.
 * [connections](https://github.com/datagrok-ai/public/tree/master/packages/Chembl/connections)
   — `Chembl` (Postgres, used for most queries), `ChemblSql` (PostgresDart, used by the
   dataframe-in/dataframe-out converters), and `Unichem`.
+* [dockerfiles](https://github.com/datagrok-ai/public/tree/master/packages/Chembl/dockerfiles)
+  — the ChEMBL database container the first two connections run against.
 * [queries](https://github.com/datagrok-ai/public/tree/master/packages/Chembl/queries) —
   `cartridge.sql` (RDKit substructure/similarity), `converters.sql` (ID conversion),
   `queries.sql` (user-facing browse/search + info-panel widgets), `browser.sql` (internal

--- a/packages/Chembl/connections/chembl.json
+++ b/packages/Chembl/connections/chembl.json
@@ -3,8 +3,7 @@
   "name": "Chembl",
   "friendlyName": "CHEMBL",
   "parameters": {
-    "server": "db.datagrok.ai",
-    "port": 54325,
+    "server": "${Chembl<DockerContainer>}",
     "db": "chembl",
     "cacheResults": true
   },

--- a/packages/Chembl/connections/chemblsql.json
+++ b/packages/Chembl/connections/chemblsql.json
@@ -1,19 +1,21 @@
 {
-    "#type": "DataConnection",
-    "name": "ChemblSql",
-    "friendlyName": "CHEMBLSQL",
-    "parameters":{
-      "server": "db.datagrok.ai",
-      "port": 54325,
-      "db": "chembl"
-    },
-    "credentials" : {
-      "parameters" : {
-        "login": "datagrok",
-        "password": "datagrok"
-      }
-    },
-    "dataSource": "PostgresDart",
-    "description": "CHEMBL DB",
-    "tags": ["demo", "chem"]
-  }
+  "#type": "DataConnection",
+  "name": "ChemblSql",
+  "friendlyName": "CHEMBLSQL",
+  "parameters": {
+    "server": "${Chembl<DockerContainer>}",
+    "db": "chembl"
+  },
+  "credentials": {
+    "parameters": {
+      "login": "datagrok",
+      "password": "datagrok"
+    }
+  },
+  "dataSource": "PostgresDart",
+  "description": "CHEMBL DB",
+  "tags": [
+    "demo",
+    "chem"
+  ]
+}

--- a/packages/Chembl/dockerfiles/Dockerfile
+++ b/packages/Chembl/dockerfiles/Dockerfile
@@ -1,0 +1,11 @@
+# The ChEMBL release this package ships is the base image tag, and the package
+# version is that release plus `.0.0` — bump both together.
+FROM datagrok/demo_db_chembl:37
+
+# The base only sets the superuser; the demo-db entrypoint needs these to create
+# the read-only role the package connections log in as.
+ENV DB_NAME=chembl
+ENV DB_USER=datagrok
+ENV DB_PASSWORD=datagrok
+
+EXPOSE 5432

--- a/packages/Chembl/dockerfiles/container.json
+++ b/packages/Chembl/dockerfiles/container.json
@@ -1,0 +1,7 @@
+{
+  "cpu": 2,
+  "memory": 4096,
+  "storage": 64,
+  "on_demand": true,
+  "shutdown_timeout": 60
+}

--- a/packages/Chembl/package.json
+++ b/packages/Chembl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@datagrok/chembl",
   "friendlyName": "ChEMBL",
-  "version": "1.4.12",
+  "version": "37.0.0",
   "description": "ChEMBL integration, commonly used queries and browser",
   "author": {
     "name": "Maria Dolotova",


### PR DESCRIPTION
The `Chembl` and `ChemblSql` connections pointed at the shared demo Postgres on
`db.datagrok.ai:54325`, so the package only worked where that host was reachable, and
whatever ChEMBL release the demo stack happened to run was the one users got.

The package now carries the database with it:

- `dockerfiles/Dockerfile` layers the read-only `datagrok` role onto
  `datagrok/demo_db_chembl:37` and exposes 5432; `dockerfiles/container.json` sizes it
  (`cpu 2`, `memory 4096`, `storage 64` — the 21 GB default is too small for ChEMBL) and
  makes it `on_demand` with a 60-minute idle shutdown.
- Both connections resolve their server from that container via
  `${Chembl<DockerContainer>}`, the same mechanism SureChembl and DBTests already use.
- `Unichem` is a separate database and still points at `db.datagrok.ai:54326`.

The package version is now the ChEMBL release plus `.0.0`, so ChEMBL 37 ships as 37.0.0.
Moving to a new release means bumping the `FROM` tag and the major version together.

The base image is built and published by the existing weekly Jenkins job
`Tools/Scheduled/Docker/demo_db_chembl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bh3Yz1wW77ZyVPTb2GUGyF