### PR TITLE
Playwright: fixed five test bugs found by the daily CI triage

### DIFF
--- a/packages/Bio/playwright/bio-lifecycle-monomer-library.test.ts
+++ b/packages/Bio/playwright/bio-lifecycle-monomer-library.test.ts
@@ -192,6 +192,11 @@ test('Bio monomer_library source-class lifecycle: load → edit/save round-trip 
           const span = r.querySelector('span');
           return span ? (span.textContent || '').trim() : '';
         }).filter((s: string) => s.length > 0);
+        // GROK-20714 made manageMonomerLibraries focus an already-open Manage Monomer Libraries
+        // view instead of showing the dialog, and S1.3 leaves that view open.
+        for (const v of Array.from(grok.shell.views))
+          if (v.name === 'Manage Monomer Libraries') v.close();
+        await new Promise((r) => setTimeout(r, 500));
         try {
           // Fire-and-forget — awaiting would deadlock (promise resolves on dialog close).
           (grok as any).functions.call('Bio:manageMonomerLibraries', {}).catch(() => {});

--- a/packages/Chem/playwright/sketcher-backends.test.ts
+++ b/packages/Chem/playwright/sketcher-backends.test.ts
@@ -41,7 +41,7 @@ async function switchBackendViaMenu(page: import('@playwright/test').Page, frien
   await page.locator('.d4-menu-item-label').filter({hasText: new RegExp(`^${friendlyName}$`)}).first().click();
   // external backends load a remote widget — wait until the switch lands on the same handle
   await page.waitForFunction((b) =>
-    (window as any).DG?.chem?.currentSketcherType === b && (window as any).__sk?.sketcher,
+    (window as any).DG?.chem?.currentSketcherType === b && (window as any).__sk?.sketcher?.isInitialized,
   friendlyName, {timeout: 60000});
   await page.waitForTimeout(3000);
 }
@@ -66,7 +66,7 @@ async function runBattery(page: import('@playwright/test').Page, backend: string
     {
       const t0 = Date.now();
       while (Date.now() - t0 < 15000) {
-        if (/V2000|V3000/.test(sk.getMolFile() ?? '')) break;
+        if (/V2000|V3000/.test(sk.getMolFile() ?? '') && !sk.isEmpty()) break;
         await sleep(400);
       }
     }

--- a/playwright-public/Viewers/pie-chart.test.ts
+++ b/playwright-public/Viewers/pie-chart.test.ts
@@ -1,4 +1,4 @@
-import {test, expect} from '@playwright/test';
+import {test, expect, Page} from '@playwright/test';
 import {loginToDatagrok, specTestOptions, softStep} from '@datagrok-libraries/test/src/playwright/spec-login';
 import * as v from '@datagrok-libraries/test/src/playwright/viewers';
 
@@ -6,6 +6,31 @@ test.use(specTestOptions);
 
 const datasetPath = 'System:DemoFiles/demog.csv';
 const spgiPath = 'System:DemoFiles/chem/SPGI.csv';
+
+// The pie shrinks to make room for outside labels, so a fixed fraction of the canvas is not
+// reliably on a slice. Aim at the middle of the drawn ring instead.
+async function slicePoint(page: Page): Promise<{x: number, y: number}> {
+  return page.evaluate(() => {
+    const pieEl = document.querySelector('[name="viewer-Pie-chart"]') as HTMLElement;
+    const canvas = pieEl.querySelector('canvas') as HTMLCanvasElement;
+    const rect = canvas.getBoundingClientRect();
+    const img = canvas.getContext('2d')!.getImageData(0, 0, canvas.width, canvas.height);
+    const dpr = canvas.width / rect.width;
+    const painted = (lx: number, ly: number) => {
+      const i = (Math.round(ly * dpr) * canvas.width + Math.round(lx * dpr)) * 4;
+      return img.data[i + 3] > 10 && !(img.data[i] > 240 && img.data[i + 1] > 240 && img.data[i + 2] > 240);
+    };
+    const cx = rect.width / 2, cy = rect.height / 2, k = Math.SQRT1_2;
+    let inner = -1, outer = 0;
+    for (let d = 1; d < Math.min(cx, cy); d++)
+      if (painted(cx + d * k, cy - d * k)) {
+        if (inner < 0) inner = d;
+        outer = d;
+      }
+    const dist = (inner + outer) / 2;
+    return {x: rect.left + cx + dist * k, y: rect.top + cy - dist * k};
+  });
+}
 
 test('Pie chart tests', async ({page}) => {
   test.setTimeout(600_000);
@@ -324,9 +349,14 @@ test('Pie chart tests', async ({page}) => {
 
   // #### Selection and interaction
   await softStep('Selection and interaction', async () => {
-    const result = await page.evaluate(async () => {
+    await page.evaluate(async () => {
       const pie = Array.from(grok.shell.tv.viewers).find((v: any) => v.type === 'Pie chart') as any;
       pie.props.categoryColumnName = 'RACE';
+      await new Promise(r => setTimeout(r, 500));
+    });
+    const pt = await slicePoint(page);
+    const result = await page.evaluate(async (pt) => {
+      const pie = Array.from(grok.shell.tv.viewers).find((v: any) => v.type === 'Pie chart') as any;
       const df = grok.shell.tv.dataFrame;
 
       const pieEl = document.querySelector('[name="viewer-Pie-chart"]') as HTMLElement;
@@ -334,8 +364,8 @@ test('Pie chart tests', async ({page}) => {
       const rect = canvas.getBoundingClientRect();
 
       // Click slice
-      const x = rect.left + rect.width * 0.65;
-      const y = rect.top + rect.height * 0.4;
+      const x = pt.x;
+      const y = pt.y;
       canvas.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, clientX: x, clientY: y}));
       canvas.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, clientX: x, clientY: y}));
       canvas.dispatchEvent(new MouseEvent('click', {bubbles: true, clientX: x, clientY: y}));
@@ -356,7 +386,7 @@ test('Pie chart tests', async ({page}) => {
 
       df.selection.setAll(false);
       return {sel1, sOff, sOn, mOff, mOn};
-    });
+    }, pt);
     expect(result.sel1).toBeGreaterThan(0);
     expect(result.sOff).toBe(false);
     expect(result.sOn).toBe(true);
@@ -366,9 +396,14 @@ test('Pie chart tests', async ({page}) => {
 
   // #### On Click modes
   await softStep('On Click modes', async () => {
-    const result = await page.evaluate(async () => {
+    await page.evaluate(async () => {
       const pie = Array.from(grok.shell.tv.viewers).find((v: any) => v.type === 'Pie chart') as any;
       pie.props.categoryColumnName = 'RACE';
+      await new Promise(r => setTimeout(r, 500));
+    });
+    const pt = await slicePoint(page);
+    const result = await page.evaluate(async (pt) => {
+      const pie = Array.from(grok.shell.tv.viewers).find((v: any) => v.type === 'Pie chart') as any;
       const df = grok.shell.tv.dataFrame;
       const r: any[] = [];
 
@@ -376,8 +411,8 @@ test('Pie chart tests', async ({page}) => {
       const pieEl = document.querySelector('[name="viewer-Pie-chart"]') as HTMLElement;
       const canvas = pieEl.querySelector('canvas') as HTMLCanvasElement;
       const rect = canvas.getBoundingClientRect();
-      const x = rect.left + rect.width * 0.65;
-      const y = rect.top + rect.height * 0.4;
+      const x = pt.x;
+      const y = pt.y;
 
       canvas.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, clientX: x, clientY: y}));
       canvas.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, clientX: x, clientY: y}));
@@ -404,7 +439,7 @@ test('Pie chart tests', async ({page}) => {
       pie.props.onClick = 'Select';
       df.selection.setAll(false);
       return r;
-    });
+    }, pt);
     expect(result[0].selected).toBeGreaterThan(0);
     expect(result[1].filtered).toBeLessThan(result[1].total);
     expect(result[2].filtered).toBe(result[1].total);
@@ -412,7 +447,8 @@ test('Pie chart tests', async ({page}) => {
 
   // #### Selection between grid and pie chart
   await softStep('Selection between grid and pie chart', async () => {
-    const result = await page.evaluate(async () => {
+    const pt = await slicePoint(page);
+    const result = await page.evaluate(async (pt) => {
       const df = grok.shell.tv.dataFrame;
       df.selection.init((i: number) => i < 50);
       await new Promise(res => setTimeout(res, 300));
@@ -421,8 +457,8 @@ test('Pie chart tests', async ({page}) => {
       const pieEl = document.querySelector('[name="viewer-Pie-chart"]') as HTMLElement;
       const canvas = pieEl.querySelector('canvas') as HTMLCanvasElement;
       const rect = canvas.getBoundingClientRect();
-      const x = rect.left + rect.width * 0.65;
-      const y = rect.top + rect.height * 0.4;
+      const x = pt.x;
+      const y = pt.y;
       canvas.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, clientX: x, clientY: y}));
       canvas.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, clientX: x, clientY: y}));
       canvas.dispatchEvent(new MouseEvent('click', {bubbles: true, clientX: x, clientY: y}));
@@ -431,7 +467,7 @@ test('Pie chart tests', async ({page}) => {
 
       df.selection.setAll(false);
       return {gridSel, pieSel};
-    });
+    }, pt);
     expect(result.gridSel).toBe(50);
     expect(result.pieSel).toBeGreaterThan(0);
   });

--- a/playwright-public/legend/legend-corner.test.ts
+++ b/playwright-public/legend/legend-corner.test.ts
@@ -349,6 +349,13 @@ test('Markers selector — picking a column works, including after a tooltip cyc
     await page.mouse.click(sel!.x, sel!.y);
     await page.waitForFunction(() =>
       document.querySelector('.d4-column-selector-backdrop') != null, {timeout: 8000}).catch(() => null);
+    // the backdrop is in the DOM before its column grid has been laid out, and a row click
+    // on the unsized grid is silently dropped — wait for the grid canvas to take its size
+    await page.waitForFunction(() => {
+      const backdrop = document.querySelector('.d4-column-selector-backdrop') as HTMLElement;
+      return backdrop != null && Array.from(backdrop.querySelectorAll('canvas'))
+        .some((c) => c.getBoundingClientRect().width > 350 && c.getBoundingClientRect().height > 300);
+    }, {timeout: 8000}).catch(() => null);
     const popup = await page.evaluate(() => {
       const backdrop = document.querySelector('.d4-column-selector-backdrop') as HTMLElement;
       if (!backdrop) return null;

--- a/playwright-public/queries/helpers.ts
+++ b/playwright-public/queries/helpers.ts
@@ -574,7 +574,21 @@ export async function focusQueryEditorTab(page: Page, queryName: string): Promis
     const editor = handles.find((h) => h.querySelector('[name="icon-data-query"]')) as HTMLElement | undefined;
     editor?.click();
   }, queryName);
-  await page.waitForTimeout(400);
+  await page.waitForSelector('[name="input-Name"]', { timeout: 15_000 });
+}
+
+/// `Run query...` opens a result table view whose ribbon also carries `[name="button-Save"]`, and
+/// clicking that one saves a project instead. The result view can also win the focus race after
+/// [focusQueryEditorTab] returns, so the editor has to be re-asserted right before Save.
+async function activateQueryEditorView(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    if (document.querySelector('[name="input-Name"]')) return;
+    (document.querySelector('.d4-dialog[name="dialog-Save-project"] .grok-font-icon-close') as HTMLElement)?.click();
+    const editor = Array.from(document.querySelectorAll('[name^="view-handle: "]'))
+      .find((h) => h.querySelector('[name="icon-data-query"]')) as HTMLElement | undefined;
+    editor?.click();
+  });
+  await page.waitForSelector('[name="input-Name"]', { timeout: 15_000 });
 }
 
 /** Click Save in the query editor ribbon and wait for the server commit. */
@@ -586,6 +600,7 @@ export async function saveQuery(page: Page, friendlyName: string): Promise<void>
   try {
     await expect(async () => {
       if (await findQueryByFriendlyName(page, friendlyName)) return;
+      await activateQueryEditorView(page);
       await page.locator('[name="button-Save"]').first().click({ timeout: 5_000 });
       await expect.poll(async () =>
         (await findQueryByFriendlyName(page, friendlyName)) !== null,


### PR DESCRIPTION
Viewers/pie-chart: the spec clicked a fixed fraction of the canvas, which stopped landing on a slice once the pie shrinks to make room for outside labels. It now aims at the middle of the drawn ring, measured from the painted pixels, so it no longer depends on the label text.

queries/helpers: after "Run query..." the active view is the result table, whose ribbon Save opens "Save project" instead. The retry loop re-clicked that same button for 90 s without ever refocusing the editor. saveQuery now re-asserts the query editor view before each attempt, and focusQueryEditorTab waits for the name input rather than a fixed 400 ms.

legend/legend-corner: the column-selector backdrop is in the DOM before its grid has been laid out, and a click on the unsized canvas is silently dropped. Wait for the grid canvas to take its size before picking a column.

Bio/bio-lifecycle-monomer-library: manageMonomerLibraries now focuses an already open Manage Monomer Libraries view instead of showing the dialog, and the earlier step leaves that view open. Close it before dispatching.

Chem/sketcher-backends: wait for the sketcher to report isInitialized after the backend switch, and require a non-empty molecule in the first check, so an empty molblock is reported where it happens instead of three checks later.