### PR TITLE
CVMTests: let the first celery call outlast a cold worker build

### DIFF
--- a/packages/CVMTests/CHANGELOG.md
+++ b/packages/CVMTests/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* Tests: Raised the first `Celery: datagrok-celery-task` call to 15 min. On CI the cold start builds the worker image and overran the 300s budget, which timed out that case and took the other thirteen with it; the stand now allows 20 min for the container to reach STARTED
 * GROK-20642: Tests: `Docker`'s `Proxy WebSocket` now waits for the container to answer before opening the socket — `run(id, true)` returns when the platform marks it started, which is earlier than the app inside binding its port, so the proxy failed with `Connection refused, errno = 111` on a loaded stand
 * GROK-20642: Tests: Gave the per-language `Escaping` test a 180s budget (it makes one server round-trip per string against the 30s default) and raised the first test of each language category to 300s, since it pays the kernel cold start while the rest of the suite loads the same stand
 * Tests: Fixed the container-start flakes — `Docker`'s `before()` no longer awaits a start over the framework's fixed 100s budget (which failed the whole category), and `Proxy WebSocket`, `Get response: On demand` and the first Celery call in each worker category now get budgets that cover a cold start instead of reporting EXECUTION TIMEOUT on one still in progress

--- a/packages/CVMTests/src/celery/celery_tests.ts
+++ b/packages/CVMTests/src/celery/celery_tests.ts
@@ -14,9 +14,12 @@ category('Celery: datagrok-celery-task', () => {
     const big = '9007199254740993'; // 2^53 + 1 — survives only as a string
     expect(String(await grok.functions.call('CVMTests:cvmBigInt', {x: big})), big);
     // First call pays the worker container cold start, which datlas bounds at
-    // containerStatusTimeout (5 min) — anything shorter reports EXECUTION TIMEOUT
-    // for a start still legitimately in progress.
-  }, {timeout: 300000, node: true});
+    // containerStatusTimeout — anything shorter reports EXECUTION TIMEOUT for a
+    // start still legitimately in progress. On CI that cold start builds the
+    // worker image and overran the old 5-min pairing: this case burned exactly
+    // its 300s and took the other thirteen down with it (builds #120, #121).
+    // Keep it aligned with the stand's containerStatusTimeoutMinutes (20).
+  }, {timeout: 900000, node: true});
 
   test('String escaping', async () => {
     for (const s of escapingTestStrings)


### PR DESCRIPTION
The 14 `Celery: datagrok-celery-task` cases have failed as a block in every
recent run (nightly #1310, Build-Datagrok #120 and #121).

## What is actually happening

The first case pays the worker container's cold start, and on CI that cold
start includes building the worker image. Its budget was 300s, chosen to match
datlas' old 5-minute `containerStatusTimeout`. The build does not fit:

```
CVMTests.Celery  Scalars round-trip   dur=300.0s  EXECUTION TIMEOUT
CVMTests.Celery  DataFrame round-trip dur= 90.0s  EXECUTION TIMEOUT
... 12 more at 90-120s
```

`Scalars round-trip` burns exactly its 300s, and because the whole category
shares one container, the remaining thirteen then time out at their own 90-120s
budgets without the container ever being ready.

Earlier attempts confirmed what it is *not*: the `celery_node_worker` image is
present (`REFRESH_TEST_IMAGES` pulls it on the same node that runs these tests),
and raising datlas' `containerStatusTimeout` alone changed nothing, because the
test gives up long before datlas does. Build #121 shows the `awaitContainer`
message gone and only the test-level `EXECUTION TIMEOUT` remaining.

## Change

Raise the first call to 15 min, so it can outlast a cold build, and keep it
aligned with the stand's `containerStatusTimeoutMinutes` (raised to 20 in
reddata `ee0f0303b1`). The pairing has to hold from both sides: the platform
must still be waiting when the test is.

This follows the precedent already in this package's changelog — earlier entries
raised the first call of each language category for the same cold-start reason.

## Verification

Not yet verified end to end. The reddata side is on master; this is the other
half. A Build-Datagrok run with `RUN_TESTS=true` covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
