### PR TITLE
CVMTests: build the celery image without a ghcr.io COPY

### DIFF
--- a/packages/CVMTests/dockerfiles/celery/Dockerfile
+++ b/packages/CVMTests/dockerfiles/celery/Dockerfile
@@ -6,7 +6,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+# uv from PyPI, not a ghcr.io cross-registry COPY: every other image in this
+# package builds from Docker Hub plus PyPI and succeeds on the CI stand, while
+# this one never produced an image (builds #120-#124).
+RUN pip install --no-cache-dir uv
 
 RUN useradd -m datagrok
 


### PR DESCRIPTION
The 14 `Celery: datagrok-celery-task` cases fail because the image never
materialises:

```
Container b4374a44-... failed to start: Image validation failed
Image datagrok/cvm-tests-celery:1.5.1.X-8c6739d9
  not found locally, in registry, or on Docker Hub
```

## Why this Dockerfile and not the others

Comparing what builds against what does not, on the same stand in the same run
(build #124):

| image | build | base | external | result |
|---|---|---|---|---|
| `cvmtests-docker-test1` | multi-stage | Docker Hub | PyPI | passes |
| `node-worker` | pass-through | pre-pulled | none | passes |
| `celery` | multi-stage | Docker Hub | PyPI + **ghcr.io** | fails |

`CVMTests.Docker` (3 cases) and `Celery: node worker` (12 cases) pass, so the
stand does build real multi-stage images, and does so for `on_demand: true`
containers — `cvmtests-docker-test1` is one. PyPI is reachable, since that image
installs from it.

The one variable left is `COPY --from=ghcr.io/astral-sh/uv:latest`, the only
cross-registry pull among these images. This installs `uv` from PyPI instead, so
the build depends on the same two hosts every sibling image already uses. The
`uv pip install --system` lines below are unchanged.

## Honesty about confidence

This is comparative evidence, not a captured build log — the recorded image log
holds the validation not-found, not build output. Prior timeout-shaped theories
on these 14 were refuted by measurement (see reddata `b286cd8f95`,
`3dff1c6231`, which made the real error visible and cut these cases from
90-900s to 1-20s). If this run still fails, the next step is capturing the
spawner's build output rather than another change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
