### PR TITLE
TestTrack: Bio Analyze expects the Sequence Activity Cliffs title

### DIFF
--- a/packages/UsageAnalysis/CHANGELOG.md
+++ b/packages/UsageAnalysis/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v.next
 
+* TestTrack: Bio Analyze expected the Activity Cliffs dialog to be titled `Activity Cliffs`; the sequence viewer is now `Sequence Activity Cliffs`, which failed the umbrella spec on FASTA, HELM and MSA alike
+
 * TestTrack: Fixed 104 specs failing at login — every spec shared one session token, and the relogin scenarios POST /users/logout, which invalidates that session server-side for every spec logging in afterwards; each browser context now mints its own session
 * Release: Added a Benchmarks tab to the `/release` dashboard, fed by the new `ReleaseBenchmarks` (per build, instance- and branch-scoped) and `ReleaseBenchmarkVersions` (per release line) queries. One row per benchmark with a duration sparkline over the last builds and a second over release lines (`1.26` → `1.27` → `bleeding-edge`), a per-package summary, and a drilldown. A benchmark is flagged slower when its latest run exceeds the median of the prior builds in the window, or the previous release's average, by more than the tab's threshold (default 20%); the Overview grows a Benchmarks card and raises a "slower than expected" alert listing each regression with both deltas
 * GROK-20687: Cloud Logs: Fixed the archive tab being unusable on a managed instance — it required an archive connection to be picked, but a SaaS tenant has none and reads the bucket with its pod role, the same contract the CloudWatch tabs already used. The Prefix box also defaulted to `cw/`, which on a scoped instance resolved under the scope again (`cw/tenant-x/cw/`) and listed nothing; it now defaults to empty

--- a/packages/UsageAnalysis/files/TestTrack/Bio/analyze-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Bio/analyze-spec.ts
@@ -88,7 +88,7 @@ for (const ds of datasets) {
       await bio.openBioAnalyze(page, 'div-Bio---Analyze---Activity-Cliffs...');
       await page.locator('.d4-dialog [name="button-OK"]').waitFor({timeout: 60_000});
       const title = await page.locator('.d4-dialog .d4-dialog-title').textContent();
-      expect(title?.trim()).toBe('Activity Cliffs');
+      expect(title?.trim()).toBe('Sequence Activity Cliffs');
       const baseCols: number = await page.evaluate(() => grok.shell.tv.dataFrame.columns.length);
       await page.locator('.d4-dialog [name="button-OK"]').click();
       await page.waitForFunction(


### PR DESCRIPTION
The Bio Analyze umbrella spec fails on FASTA, HELM and MSA alike, all on the same step:

```
Bio > Analyze > Activity Cliffs - run with defaults
  Expected: "Activity Cliffs"
  Received: "Sequence Activity Cliffs"
```

The sequence viewer is titled `Sequence Activity Cliffs` (distinguishing it from
Chem s `Activity Cliffs`); the spec still asserted the old title, so one stale
expectation took down three cases in nightly #1311.

Only the assertion changes - the dialog is still opened via the same
`div-Bio---Analyze---Activity-Cliffs...` menu item, so the spec keeps checking
that the right dialog appeared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
