### PR TITLE
TestTrack: sequence Activity Cliffs dialog title

### DIFF
--- a/packages/UsageAnalysis/files/TestTrack/Bio/sequence-activity-cliffs-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Bio/sequence-activity-cliffs-spec.ts
@@ -65,7 +65,7 @@ for (const ds of datasets) {
       await bio.openBioAnalyze(page, 'div-Bio---Analyze---Activity-Cliffs...');
       await page.locator('.d4-dialog [name="button-OK"]').waitFor({timeout: 60_000});
       const title = await page.locator('.d4-dialog .d4-dialog-title').textContent();
-      expect(title?.trim()).toBe('Activity Cliffs');
+      expect(title?.trim()).toBe('Sequence Activity Cliffs');
     });
     await softStep(`${ds.name}: Run with default parameters — ScatterPlot + embeddings appended`, async () => {
       const baseCols: number = await page.evaluate(() => grok.shell.tv.dataFrame.columns.length);


### PR DESCRIPTION
Same stale title as #4049, in the other Bio spec.

```
Expected: "Activity Cliffs"
Received: "Sequence Activity Cliffs"
```

Fails Bio Sequence Activity Cliffs on FASTA, HELM and MSA in nightly #1311.
The viewer is titled `Sequence Activity Cliffs`; #4049 fixed the umbrella spec
and missed this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
