### PR TITLE
Chem: Reaction Enumerator: Modifications of config and templates

### DIFF
--- a/packages/Chem/src/tests/reaction-enumeration-tests.ts
+++ b/packages/Chem/src/tests/reaction-enumeration-tests.ts
@@ -57,8 +57,9 @@ function canonicalizer(rdkit: any): (s: string) => string {
 // (e.g. a product correctly formed but mis-tagged as round 1 instead of round 2, or built via the
 // wrong template) — sort by a composite key so row order (which can differ between the two run
 // paths) doesn't matter, then compare field-by-field for a precise failure message.
+const stepsKey = (r: OutputRow): string => r.steps.map((s) => `${s.reactionName}|${s.template}`).join('>');
 function rowSortKey(r: OutputRow): string {
-  return [r.product, r.round, r.reaction_name, r.template, r.route].join('');
+  return [r.product, r.round, stepsKey(r), r.route].join('');
 }
 function expectSameRows(a: OutputRow[], b: OutputRow[], label: string): void {
   const sa = [...a].sort((x, y) => rowSortKey(x).localeCompare(rowSortKey(y)));
@@ -67,9 +68,7 @@ function expectSameRows(a: OutputRow[], b: OutputRow[], label: string): void {
   for (let i = 0; i < sa.length; i++) {
     expect(sa[i].product, sb[i].product, `${label}: row[${i}].product differs`);
     expect(sa[i].round, sb[i].round, `${label}: row[${i}].round differs for product "${sa[i].product}"`);
-    expect(sa[i].reaction_name, sb[i].reaction_name,
-      `${label}: row[${i}].reaction_name differs for product "${sa[i].product}"`);
-    expect(sa[i].template, sb[i].template, `${label}: row[${i}].template differs for product "${sa[i].product}"`);
+    expect(stepsKey(sa[i]), stepsKey(sb[i]), `${label}: row[${i}].steps differ for product "${sa[i].product}"`);
     expect(sa[i].route, sb[i].route, `${label}: row[${i}].route differs for product "${sa[i].product}"`);
   }
 }
@@ -385,11 +384,12 @@ category('Reaction Enumeration', () => {
 
     // Peptide coupling: every AA pair (incl. self) -> dipeptide -> at least 20 products,
     // all containing the C-N peptide bond pattern N-C(=O)-C.
-    const peptideRows = rows.filter((r) => r.reaction_name === 'Peptide coupling');
+    const lastReaction = (r: OutputRow): string | undefined => r.steps[r.steps.length - 1]?.reactionName;
+    const peptideRows = rows.filter((r) => lastReaction(r) === 'Peptide coupling');
     expect(peptideRows.length > 0, true, 'Peptide coupling produced no rows');
 
     // Disulfide: only Cys-Cys can react (only Cys has a thiol). Expect exactly one canonical product.
-    const disulfideRows = rows.filter((r) => r.reaction_name === 'Disulfide formation');
+    const disulfideRows = rows.filter((r) => lastReaction(r) === 'Disulfide formation');
     expect(disulfideRows.length > 0, true, 'Disulfide formation produced no rows — Cys + Cys should match');
     expect(disulfideRows[0].product.includes('SS') || /S.{0,3}S/.test(disulfideRows[0].product), true,
       `Disulfide product missing SS link: ${disulfideRows[0].product}`);

--- a/packages/Chem/src/utils/reaction-enumeration/config-form.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/config-form.ts
@@ -58,18 +58,24 @@ export function buildCombinationLimitFields(initial: EnumeratorConfig): {
   inputs: DG.InputBase<unknown>[];
   syncToConfig: (target: EnumeratorConfig) => void;
 } {
-  const keepBBs = boolInput('Keep building blocks in output', initial.keep_building_blocks_in_final_output,
-    'Include the original building blocks (round 0) in the final product list.');
+  const maxComponents = intInput('Max # components', initial.max_num_components,
+    'Templates with more reactant components than this are skipped. Leave blank for no cap.', 1);
+  const maxRoutes = intInput('Max routes per compound', initial.max_num_routes_per_compound,
+    'Cap on the number of routes saved per product. Leave blank for no cap.', 1);
   const maxCombos = intInput('Max combinations per template', initial.max_num_combinations_per_template,
-    'Per template per round: cap on the number of reactant combinations actually run. If the ' +
+    'Per template per step: cap on the number of reactant combinations actually run. If the ' +
     'cartesian product exceeds this, the enumerator runs the first N and stops. Leave blank for no cap.', 1);
+  const keepBBs = boolInput('Keep building blocks in output', initial.keep_building_blocks_in_final_output,
+    'Include the original building blocks (step 0) in the final product list.');
 
   const syncToConfig = (target: EnumeratorConfig): void => {
-    target.keep_building_blocks_in_final_output = keepBBs.get();
+    target.max_num_components = maxComponents.get();
+    target.max_num_routes_per_compound = maxRoutes.get();
     target.max_num_combinations_per_template = maxCombos.get();
+    target.keep_building_blocks_in_final_output = keepBBs.get();
   };
 
-  return {inputs: [keepBBs.input, maxCombos.input], syncToConfig};
+  return {inputs: [maxComponents.input, maxRoutes.input, maxCombos.input, keepBBs.input], syncToConfig};
 }
 
 // Product-level filters: atom counts, charge/radical/isotope rejection.

--- a/packages/Chem/src/utils/reaction-enumeration/config.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/config.ts
@@ -42,7 +42,7 @@ export interface EnumeratorConfig {
 
 export const DEFAULT_CONFIG: EnumeratorConfig = {
   keep_building_blocks_in_final_output: false,
-  max_num_components: 4,
+  max_num_components: -1,
   max_num_routes_per_compound: -1,
   max_num_combinations_per_template: -1,
   products_specs: {

--- a/packages/Chem/src/utils/reaction-enumeration/data-panel.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/data-panel.ts
@@ -91,13 +91,13 @@ export interface DataPanelDeps {
   refreshCfgRibbon: () => void;
 }
 
-/** One grid plus a round-tab strip: "All rounds" shows the full library (with the global "Subset by
- * selection"); "Round k" shows a display-only clone whose rows are that round's subset. Switching
+/** One grid plus a step-tab strip: "All steps" shows the full library (with the global "Subset by
+ * selection"); "Step k" shows a display-only clone whose rows are that step's subset. Switching
  * tabs swaps what the single grid displays — there is never a second grid. */
 export class DataPanel {
   readonly panel: HTMLElement;
 
-  private selStep = 0; // 0 = All rounds; 1..rounds = that round's subset
+  private selStep = 0; // 0 = All steps; 1..rounds = that round's subset
   private filtersOn = false;
   // host -> what was last mounted there, so the second of the two renders a table swap triggers
   // (input.onChanged plus the caller's own explicit render) is a no-op.
@@ -109,7 +109,7 @@ export class DataPanel {
   private readonly stepState: StepState[] = [];
   private readonly stepTabsHost: HTMLElement;
   private stepTabsSub: Subscription | null = null;
-  private readonly stepDots: (HTMLElement | null)[] = []; // index 0 ("All rounds") unused
+  private readonly stepDots: (HTMLElement | null)[] = []; // index 0 ("All steps") unused
   // Each pane owns its own barHost/gridHost — relocating a live grid between panes corrupts it.
   private paneHosts: {barHost: HTMLElement; gridHost: HTMLElement}[] = [];
 
@@ -191,7 +191,7 @@ export class DataPanel {
     if (!global) return null;
     // Display-only clone, never registered in the workspace.
     const work = global.clone(null);
-    work.name = `${global.name} · round ${k}`;
+    work.name = `${global.name} · step ${k}`;
     detectChemSemTypes(work);
     this.setStepWork(k, work);
     return work;
@@ -202,7 +202,7 @@ export class DataPanel {
     const w = this.stepState[k - 1]?.df;
     if (!w) return;
     const subset = cloneSubsetByRows(w,
-      `${SELECT_ROWS_OR_FILTER} to use only those ${this.opts.noun} in round ${k}.`);
+      `${SELECT_ROWS_OR_FILTER} to use only those ${this.opts.noun} in step ${k}.`);
     if (!subset) return;
     this.setStepWork(k, subset);
     this.stepState[k - 1].committed = true;
@@ -211,7 +211,7 @@ export class DataPanel {
     this.deps.viewerHost.deferredFilterReset(subset);
   }
 
-  // Drops the clone entirely so the round re-derives from "All rounds" lazily.
+  // Drops the clone entirely so the step re-derives from "All steps" lazily.
   private useAllForStep(k: number): void {
     this.setStepWork(k, null);
     this.stepState[k - 1].committed = false;
@@ -303,15 +303,15 @@ export class DataPanel {
       return ui.div([barHost, gridHost], {style: {
         height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden'}});
     };
-    const allPane = tc.addPane('All rounds', makePaneContent(0));
-    ui.tooltip.bind(allPane.header, 'Narrow this component for one round only. "All rounds" is the full ' +
-      'library used by every round; pick a round to restrict just that round. Per-round building-block ' +
-      'subsets apply in depth-first / reagents mode; in breadth-first mode a round draws from all earlier ' +
+    const allPane = tc.addPane('All steps', makePaneContent(0));
+    ui.tooltip.bind(allPane.header, 'Narrow this component for one step only. "All steps" is the full ' +
+      'library used by every step; pick a step to restrict just that step. Per-step building-block ' +
+      'subsets apply in depth-first / reagents mode; in breadth-first mode a step draws from all earlier ' +
       'products, so a BB subset has no effect. Resets when you swap the input file (in-range overrides ' +
-      'survive a round-count change).');
+      'survive a step-count change).');
     this.stepDots.push(null);
     for (let k = 1; k <= this.roundCount(); k++) {
-      const pane = tc.addPane(`Round ${k}`, makePaneContent(k));
+      const pane = tc.addPane(`Step ${k}`, makePaneContent(k));
       // Absolute, with a positive left offset (a negative one bleeds into the flush adjacent tab)
       // and a fixed top (the header box shrinks ~7px when selected, so a percentage would drift).
       const dot = ui.div([], {style: {...CHANGED_DOT_STYLE, position: 'absolute', left: '5px', top: '12px',
@@ -358,19 +358,19 @@ export class DataPanel {
         const prevValue = this.opts.input.value;
         action();
         if (hadOverride && !isSameTrackedTable(prevValue, this.opts.input.value)) {
-          grok.shell.info(`Per-round ${this.opts.noun} overrides were cleared — every round now uses the ` +
+          grok.shell.info(`Per-step ${this.opts.noun} overrides were cleared — every step now uses the ` +
             `${clearedSuffix}.`);
         }
       };
       const btn = ui.link('Subset by selection', () => doGlobalAction(
         () => this.doSubsetBySelection(), `new ${this.opts.noun} subset`));
       ui.tooltip.bind(btn, `Replace the ${this.opts.noun} library with only the selected rows, or — if nothing ` +
-        `is selected — the currently filtered rows (applies to every round). Click "Use all" to restore the ` +
+        `is selected — the currently filtered rows (applies to every step). Click "Use all" to restore the ` +
         `full set.`);
       const useAll = ui.link('Use all', () => doGlobalAction(
         () => this.doRestoreFullTable(), `full ${this.opts.noun} library again`));
       ui.tooltip.bind(useAll, `Restore the full ${this.opts.noun} library (undo "Subset by selection").`);
-      barHost.append(hintEl(`Full ${this.opts.noun} library — used by every round unless a round overrides it.`),
+      barHost.append(hintEl(`Full ${this.opts.noun} library — used by every step unless a step overrides it.`),
         filterIcon, btn, useAll);
     } else {
       const entry = this.stepState[this.selStep - 1];
@@ -391,15 +391,15 @@ export class DataPanel {
       const status = ui.divText(statusText,
         {style: {fontSize: '11px', color: 'var(--grey-5)', flex: '0 0 auto'}});
       const btn = ui.link('Subset by selection', () => this.subsetStepBySelection(this.selStep));
-      ui.tooltip.bind(btn, `Narrow round ${this.selStep} to only the selected rows (Ctrl/Shift+click), or — if ` +
+      ui.tooltip.bind(btn, `Narrow step ${this.selStep} to only the selected rows (Ctrl/Shift+click), or — if ` +
         `nothing is selected — the currently filtered rows. Click "Use all" to go back to the full ` +
         `${this.opts.noun} library.`);
       const useAll = ui.link('Use all', () => this.useAllForStep(this.selStep));
-      ui.tooltip.bind(useAll, `Undo "Subset by selection" so round ${this.selStep} uses the full ${this.opts.noun} ` +
-        `library (same as "All rounds").`);
+      ui.tooltip.bind(useAll, `Undo "Subset by selection" so step ${this.selStep} uses the full ${this.opts.noun} ` +
+        `library (same as "All steps").`);
       barHost.append(
         hintEl(`${SELECT_ROWS_OR_FILTER}, then "Subset by selection" to use only those ${this.opts.noun} in ` +
-          `round ${this.selStep}.`),
+          `step ${this.selStep}.`),
         status, filterIcon, btn, useAll);
     }
   }

--- a/packages/Chem/src/utils/reaction-enumeration/enumerate.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/enumerate.ts
@@ -315,11 +315,20 @@ function addRouteIfNew(rec: ProductRecord, route: Route, cap: number): boolean {
   return true;
 }
 
+/** Same "-1 means no cap" convention as the other config limits. */
+function exceedsComponentCap(numReactants: number, cap: number): boolean {
+  return cap >= 0 && numReactants > cap;
+}
+
+export interface OutputStep {
+  template: string;
+  reactionName: string;
+}
+
 export interface OutputRow {
   product: string;
   route: string;
-  template: string;
-  reaction_name: string;
+  steps: OutputStep[];
   round: number;
   n_routes: number;
 }
@@ -364,10 +373,11 @@ export async function enumerate(opts: EnumerateOptions): Promise<{rows: OutputRo
   }
 
   // The round loop silently skips over-arity templates; warn once here rather than every round.
-  const overArityCount = parsedTemplates.filter((t) => t.numReactants > config.max_num_components).length;
+  const componentCap = config.max_num_components;
+  const overArityCount = parsedTemplates.filter((t) => exceedsComponentCap(t.numReactants, componentCap)).length;
   if (overArityCount > 0) {
     warnings.push(`${overArityCount} template(s) need more reactants than Max # components ` +
-      `(${config.max_num_components}) allows and will be skipped in every round.`);
+      `(${config.max_num_components}) allows and will be skipped in every step.`);
   }
 
   const exclusion = buildExclusionQmols(rdkit, exclusionSmarts);
@@ -391,23 +401,23 @@ export async function enumerate(opts: EnumerateOptions): Promise<{rows: OutputRo
       if (intersects)
         roundAllowedTemplateKeys.push(allowed);
       else {
-        warnings.push(`Round ${r + 1}: template override matches none of the global reaction templates; ` +
+        warnings.push(`Step ${r + 1}: template override matches none of the global reaction templates; ` +
           `using the global template set instead.`);
         roundAllowedTemplateKeys.push(null);
       }
     } else {
-      if (o?.templates) warnings.push(`Round ${r + 1}: empty template override; using the global template set instead.`);
+      if (o?.templates) warnings.push(`Step ${r + 1}: empty template override; using the global template set instead.`);
       roundAllowedTemplateKeys.push(null);
     }
-    const bbs = o?.buildingBlocks ? canonUnique(o.buildingBlocks, 'round BB') : null;
+    const bbs = o?.buildingBlocks ? canonUnique(o.buildingBlocks, 'step BB') : null;
     if (o?.buildingBlocks && (!bbs || bbs.length === 0)) {
-      warnings.push(`Round ${r + 1}: building-block override has no valid SMILES after ` +
+      warnings.push(`Step ${r + 1}: building-block override has no valid SMILES after ` +
         `canonicalization; using the global building-block pool instead.`);
     }
     roundBBs.push(bbs && bbs.length > 0 ? bbs : null);
-    const rgs = o?.reagents ? canonUnique(o.reagents, 'round reagent') : null;
+    const rgs = o?.reagents ? canonUnique(o.reagents, 'step reagent') : null;
     if (o?.reagents && (!rgs || rgs.length === 0)) {
-      warnings.push(`Round ${r + 1}: reagent override has no valid SMILES after canonicalization; ` +
+      warnings.push(`Step ${r + 1}: reagent override has no valid SMILES after canonicalization; ` +
         `using the global reagent pool instead.`);
     }
     roundReagents.push(rgs && rgs.length > 0 ? rgs : null);
@@ -479,18 +489,18 @@ export async function enumerate(opts: EnumerateOptions): Promise<{rows: OutputRo
       // eligibleSmiles never reads activeBBs in breadth-first, nor activeReagents outside reagents
       // mode; these two warnings are the only thing surfacing an otherwise silent no-op.
       if (!useReagents && !config.enumeration.depth_first && roundBBs[round - 1] != null) {
-        warnings.push(`Round ${round}: building-block override has no effect in breadth-first ` +
-          `mode — a round draws from all earlier products regardless of the per-step BB subset.`);
+        warnings.push(`Step ${round}: building-block override has no effect in breadth-first ` +
+          `mode — a step draws from all earlier products regardless of the per-step BB subset.`);
       }
       if (!useReagents && roundReagents[round - 1] != null) {
-        warnings.push(`Round ${round}: reagent override has no effect outside reagents mode — a ` +
-          `round only draws from the reagents library when a reagents file is active.`);
+        warnings.push(`Step ${round}: reagent override has no effect outside reagents mode — a ` +
+          `step only draws from the reagents library when a reagents file is active.`);
       }
 
       for (let ti = 0; ti < parsedTemplates.length; ti++) {
         if (isCancelled?.()) break;
         const t = parsedTemplates[ti];
-        if (t.numReactants > max_num_components) continue;
+        if (exceedsComponentCap(t.numReactants, max_num_components)) continue;
         if (allowedTemplateKeys && !allowedTemplateKeys.has(templateOverrideKey(t))) continue;
 
         progressContext = {
@@ -761,25 +771,20 @@ export async function enumerate(opts: EnumerateOptions): Promise<{rows: OutputRo
 
   const rows: OutputRow[] = [];
   for (const rec of finalProducts.values()) {
-    if (rec.routes.length === 0) {
-      rows.push({product: rec.smiles, route: '', template: '', reaction_name: '',
-        round: rec.firstRound, n_routes: 0});
-    } else {
+    if (rec.routes.length === 0)
+      rows.push({product: rec.smiles, route: '', steps: [], round: rec.firstRound, n_routes: 0});
+    else {
       for (const route of rec.routes) {
-        const last = route[route.length - 1];
         rows.push({
           product: rec.smiles,
           route: formatRoute(route),
-          template: last.templateSmarts,
-          reaction_name: last.reactionName,
+          steps: route.map((s) => ({template: s.templateSmarts, reactionName: s.reactionName})),
           round: rec.firstRound,
           n_routes: rec.routes.length,
         });
       }
-      if (rec.isOriginalBB) {
-        rows.push({product: rec.smiles, route: '', template: '', reaction_name: '',
-          round: 0, n_routes: 0});
-      }
+      if (rec.isOriginalBB)
+        rows.push({product: rec.smiles, route: '', steps: [], round: 0, n_routes: 0});
     }
   }
 

--- a/packages/Chem/src/utils/reaction-enumeration/enumerator-app.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/enumerator-app.ts
@@ -109,7 +109,7 @@ export async function buildEnumeratorView(): Promise<DG.ViewBase> {
     input: configForm.reagentsInput, badge: reagentsBadge,
     apply: (o, work, cfg) => {o.reagents = extractReagents(cfg, work);},
     noTableMsg: 'No reagents file selected.', emptyMsg: 'No reagents file selected. Add one in the Extras ' +
-      'section to subset reagents per round.'}, dataPanelDeps);
+      'section to subset reagents per step.'}, dataPanelDeps);
   const dataCtls = [templatesCtl, bbsCtl, reagentsCtl];
 
   view.subs.push(configForm.numRoundsInput.onChanged.subscribe(() => ctx.refreshValidation()));

--- a/packages/Chem/src/utils/reaction-enumeration/enumerator-config-form.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/enumerator-config-form.ts
@@ -143,8 +143,6 @@ export class EnumeratorConfigForm {
   private readonly bbColInput: DG.InputBase<DG.Column | null>;
   private readonly reagentsColInput: DG.InputBase<DG.Column | null>;
   private readonly exclusionColInput: DG.InputBase<DG.Column | null>;
-  private readonly maxComponentsInput: DG.InputBase<number | null>;
-  private readonly maxRoutesInput: DG.InputBase<number | null>;
 
   private combinationLimitFields: ReturnType<typeof buildCombinationLimitFields>;
   private productFilterFields: ReturnType<typeof buildProductFilterFields>;
@@ -204,7 +202,7 @@ export class EnumeratorConfigForm {
     this.rxnNameColInput = makeColInput('Reaction name (optional)', templatesDf,
       this.config.enumeration.reaction_name_col, isStringCol,
       'Optional column with a friendly name for each reaction template. Surfaces in the output ' +
-      '"reaction_name" column.', true);
+      '"reaction_names" column, one line per step.', true);
 
     this.bbsInput = ui.input.table('Building blocks file', {
       value: bbsDf ?? undefined, nullable: false,
@@ -216,8 +214,8 @@ export class EnumeratorConfigForm {
     this.reagentsInput = ui.input.table('Reagents file (optional)', {
       value: reagentsDf ?? undefined, nullable: true,
       tooltipText: 'Optional table of reagent SMILES. When set, switches to reagents mode: every ' +
-        'round uses exactly one building block (or product of an earlier round) and fills every ' +
-        'remaining slot with reagents from this file — produces derivatives of each BB across rounds.',
+        'step uses exactly one building block (or product of an earlier step) and fills every ' +
+        'remaining slot with reagents from this file — produces derivatives of each BB across steps.',
     });
     const REAGENTS_COL_TOOLTIP = 'Column in the reagents file that contains the reagent SMILES.';
     this.reagentsColInput = makeColInput('Reagent SMILES column', reagentsDf,
@@ -255,41 +253,27 @@ export class EnumeratorConfigForm {
 
     // nullable: true throughout — without it, clearing the box makes .value NaN rather than null,
     // and NaN slips past every `?? fallback` downstream uncaught.
-    this.numRoundsInput = ui.input.int('Number of rounds',
+    this.numRoundsInput = ui.input.int('Number of steps',
       {value: this.config.enumeration.num_rounds, nullable: true, min: 1, max: MAX_ROUNDS, showPlusMinus: true});
     this.numRoundsInput.setTooltip(
-      'Number of consecutive enumeration rounds. Round 1 reacts BBs only; round 2 takes round-1 ' +
+      'Number of consecutive enumeration steps. Step 1 reacts BBs only; step 2 takes step-1 ' +
       `products and (in depth-first mode) reacts each one with original BBs. Increase for deeper ` +
-      `libraries (capped at ${MAX_ROUNDS} — a round tab is built for every round, and product counts ` +
+      `libraries (capped at ${MAX_ROUNDS} — a step tab is built for every step, and product counts ` +
       `grow combinatorially with each one).`);
     fixNullableIntStepper(this.numRoundsInput, 1);
     // `min`/`max` above only affect the tooltip/spinner, not validation — add that separately.
     this.numRoundsInput.addValidator((v) => {
       const n = Number(v);
       if (!Number.isFinite(n) || n < 1) return 'Must be at least 1.';
-      if (n > MAX_ROUNDS) return `Must be at most ${MAX_ROUNDS} — the round strip shows the first ${MAX_ROUNDS} rounds only.`;
+      if (n > MAX_ROUNDS) return `Must be at most ${MAX_ROUNDS} — the step strip shows the first ${MAX_ROUNDS} steps only.`;
       return null;
     });
 
     this.depthFirstInput = ui.input.bool('Depth first', {value: this.config.enumeration.depth_first});
     this.depthFirstInput.setTooltip(
-      'When checked, each round r > 1 must combine EXACTLY ONE round-(r-1) product with original ' +
+      'When checked, each step r > 1 must combine EXACTLY ONE step-(r-1) product with original ' +
       'BBs (linear chain extension, no merging two complex products). Off (breadth-first) allows any ' +
-      'combination from rounds 0..r-1 — typically explodes the search space and produces convergent routes.');
-
-    this.maxComponentsInput = ui.input.int('Max # components',
-      {value: this.config.max_num_components, nullable: true, min: 1, showPlusMinus: true});
-    this.maxComponentsInput.setTooltip('Max number of reactant components a template may have.');
-    fixNullableIntStepper(this.maxComponentsInput, 1);
-    // -1 is the config's "no cap" sentinel; blank means the same thing and reads better.
-    this.maxRoutesInput = ui.input.int('Max routes per compound', {
-      value: this.config.max_num_routes_per_compound < 0 ? undefined : this.config.max_num_routes_per_compound,
-      nullable: true, min: 1, showPlusMinus: true,
-    });
-    this.maxRoutesInput.setTooltip('Cap on the number of routes saved per product. Leave blank for no cap.');
-    // A cap of 0 would blank every product's route/template/reaction_name with no error, so floor
-    // the stepper at 1; validate() rejects a typed or loaded 0.
-    fixNullableIntStepper(this.maxRoutesInput, 1);
+      'combination from steps 0..r-1 — typically explodes the search space and produces convergent routes.');
 
     // Bound to live factories so hovering always reflects current state.
     const mkIcon = (): HTMLElement => {
@@ -309,7 +293,6 @@ export class EnumeratorConfigForm {
     // Re-validate on every input change so the Run button stays accurate.
     [this.smartsColInput, this.blockingColInput, this.rxnNameColInput, this.bbColInput, this.reagentsColInput,
       this.exclusionInput, this.exclusionColInput, this.numRoundsInput, this.depthFirstInput,
-      this.maxComponentsInput, this.maxRoutesInput,
     ].forEach((inp) => this.deps.view.subs.push(this.wireValidationOne(inp)));
     [...this.combinationLimitFields.inputs, ...this.productFilterFields.inputs].forEach((inp) =>
       this.limitFieldSubs.push(this.wireValidationOne(inp)));
@@ -338,7 +321,7 @@ export class EnumeratorConfigForm {
       let msg = 'Saved settings only — the template/building-block/reagent files aren\'t included; ' +
         'select those again yourself when loading this config.';
       if (this.deps.hasAnyPerRoundOverride())
-        msg += ' Per-round subsets ("Subset by selection") aren\'t included either, for the same reason.';
+        msg += ' Per-step subsets ("Subset by selection") aren\'t included either, for the same reason.';
 
       grok.shell.info(msg);
     }, 'Download the current config as a YAML file.');
@@ -350,8 +333,7 @@ export class EnumeratorConfigForm {
       bbsInput: this.bbsInput, bbColInput: this.bbColInput,
       reagentsInput: this.reagentsInput, reagentsColInput: this.reagentsColInput,
       exclusionInput: this.exclusionInput, exclusionColInput: this.exclusionColInput,
-      numRoundsInput: this.numRoundsInput, maxComponentsInput: this.maxComponentsInput,
-      maxRoutesInput: this.maxRoutesInput, depthFirstInput: this.depthFirstInput,
+      numRoundsInput: this.numRoundsInput, depthFirstInput: this.depthFirstInput,
       configInfoIcon: this.configInfoIcon,
       getCombinationLimitInputs: () => this.combinationLimitFields.inputs,
       getProductFilterInputs: () => this.productFilterFields.inputs,
@@ -398,8 +380,6 @@ export class EnumeratorConfigForm {
     const config = this.config;
     config.enumeration.num_rounds = this.numRoundsInput.value ?? config.enumeration.num_rounds;
     config.enumeration.depth_first = !!this.depthFirstInput.value;
-    config.max_num_components = this.maxComponentsInput.value ?? config.max_num_components;
-    config.max_num_routes_per_compound = this.maxRoutesInput.value ?? -1; // blank == no cap
     // Column inputs hold a Column; persist its name, keeping the previous value if unselected.
     config.enumeration.smarts_col = this.smartsColInput.value?.name ?? config.enumeration.smarts_col;
     config.enumeration.reactant_blocking_groups_per_template_column =
@@ -437,8 +417,6 @@ export class EnumeratorConfigForm {
       if (config.enumeration.num_rounds > MAX_ROUNDS) config.enumeration.num_rounds = MAX_ROUNDS;
       this.setAndFire(this.numRoundsInput, config.enumeration.num_rounds);
       this.setAndFire(this.depthFirstInput, config.enumeration.depth_first);
-      this.setAndFire(this.maxComponentsInput, config.max_num_components);
-      this.setAndFire(this.maxRoutesInput, config.max_num_routes_per_compound < 0 ? null : config.max_num_routes_per_compound);
       const tDf = this.templatesInput.value;
       if (tDf) {
         const sc = tDf.col(config.enumeration.smarts_col);
@@ -512,16 +490,17 @@ export class EnumeratorConfigForm {
       return 'Select an exclusion substructures column or clear the exclusion file.';
 
     const rounds = this.numRoundsInput.value ?? 0;
-    if (rounds < 1) return 'Number of rounds must be at least 1.';
-    if (rounds > MAX_ROUNDS) return `Number of rounds must be at most ${MAX_ROUNDS}.`;
+    if (rounds < 1) return 'Number of steps must be at least 1.';
+    if (rounds > MAX_ROUNDS) return `Number of steps must be at most ${MAX_ROUNDS}.`;
 
-    // Reads the input, not this.config: the sync above falls back to the previous config value on a
-    // cleared box, so config alone can never observe "the user just cleared this".
-    if ((this.maxComponentsInput.value ?? 0) < 1) return 'Max # components must be at least 1.';
-    if (this.config.max_num_routes_per_compound === 0)
-      return 'Max routes per compound must be at least 1, or blank for no cap.';
-    if (this.config.max_num_combinations_per_template === 0)
-      return 'Max combinations per template must be at least 1, or blank for no cap.';
+    // Blank is -1 (no cap) in every limit below; only a typed or loaded 0 is rejected.
+    const caps: [number, string][] = [
+      [this.config.max_num_components, 'Max # components'],
+      [this.config.max_num_routes_per_compound, 'Max routes per compound'],
+      [this.config.max_num_combinations_per_template, 'Max combinations per template'],
+    ];
+    for (const [cap, label] of caps)
+      if (cap === 0) return `${label} must be at least 1, or blank for no cap.`;
 
     // The only min+max pair in products_specs. Both active and inverted means every product fails
     // both checks: 0 rows, with nothing indicating the two thresholds contradict.
@@ -541,18 +520,18 @@ export class EnumeratorConfigForm {
     const card = ui.div([], {style: {fontSize: '12px', maxWidth: '520px', lineHeight: '1.5', padding: '4px 2px'}});
     card.innerHTML = `
       <div style="font-weight: bold; font-size: 13px; margin-bottom: 4px;">Chemical library enumeration</div>
-      <p style="margin: 0 0 6px 0;">Generate a product library from reaction SMARTS templates and a set of starting materials. Each round can take products from the previous round and grow them further.</p>
+      <p style="margin: 0 0 6px 0;">Generate a product library from reaction SMARTS templates and a set of starting materials. Each step can take products from the previous step and grow them further.</p>
       <div style="font-weight: bold; margin-top: 8px; margin-bottom: 2px;">Inputs</div>
       <ul style="margin: 0 0 6px 16px; padding: 0;">
         <li><b>Reaction templates file</b> — reaction SMARTS (LHS&gt;&gt;RHS). Optional blocking SMARTS exclude unwanted matches per template; optional reaction names surface in the output.</li>
         <li><b>Building blocks file</b> — SMILES of starting materials.</li>
-        <li><b>Reagents file</b> (optional) — switches to <i>reagents mode</i>: every round uses exactly one BB or earlier-round product, with reagents in the remaining slots. Yields derivatives of each BB across rounds.</li>
+        <li><b>Reagents file</b> (optional) — switches to <i>reagents mode</i>: every step uses exactly one BB or earlier-step product, with reagents in the remaining slots. Yields derivatives of each BB across steps.</li>
         <li><b>Exclusion substructures</b> (optional) — SMARTS patterns; any product matching one is rejected.</li>
       </ul>
       <div style="font-weight: bold; margin-top: 8px; margin-bottom: 2px;">Enumeration modes</div>
       <ul style="margin: 0 0 6px 16px; padding: 0;">
-        <li><b>Depth-first</b> — round 1 combines BBs; round R extends each round-(R-1) product with original BBs (linear chains, no merging of two complex products).</li>
-        <li><b>Breadth-first</b> — each round may combine any products from earlier rounds with BBs (convergent routes possible).</li>
+        <li><b>Depth-first</b> — step 1 combines BBs; step R extends each step-(R-1) product with original BBs (linear chains, no merging of two complex products).</li>
+        <li><b>Breadth-first</b> — each step may combine any products from earlier steps with BBs (convergent routes possible).</li>
         <li><b>Reagents</b> — active whenever a reagents file is selected; overrides depth/breadth-first.</li>
       </ul>
       <div style="font-weight: bold; margin-top: 8px; margin-bottom: 2px;">Tips</div>
@@ -588,9 +567,9 @@ export class EnumeratorConfigForm {
     ], {style: {justifyContent: 'space-between', padding: '1px 0', gap: '12px'}});
 
     card.appendChild(sectionTitle('Enumeration'));
-    card.appendChild(row('Rounds', String(en.num_rounds)));
+    card.appendChild(row('Steps', String(en.num_rounds)));
     card.appendChild(row('Mode', modeLabel));
-    card.appendChild(row('Max components', String(config.max_num_components)));
+    card.appendChild(row('Max components', fmtNum(config.max_num_components)));
     card.appendChild(row('Max combinations / template', fmtNum(config.max_num_combinations_per_template)));
     card.appendChild(row('Max routes / compound', fmtNum(config.max_num_routes_per_compound)));
     card.appendChild(row('Keep BBs in final output', yn(config.keep_building_blocks_in_final_output)));

--- a/packages/Chem/src/utils/reaction-enumeration/enumerator-nav.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/enumerator-nav.ts
@@ -30,8 +30,6 @@ export interface EnumeratorNavDeps {
   exclusionInput: DG.InputBase<DG.DataFrame | null>;
   exclusionColInput: DG.InputBase<DG.Column | null>;
   numRoundsInput: DG.InputBase<number | null>;
-  maxComponentsInput: DG.InputBase<number | null>;
-  maxRoutesInput: DG.InputBase<number | null>;
   depthFirstInput: DG.InputBase<boolean>;
   configInfoIcon: HTMLElement;
   // Getters, not snapshots: both field groups are rebuilt wholesale on every YAML load, so the
@@ -97,7 +95,7 @@ export class EnumeratorNav {
       ui.span([' Reagents mode active — set via a reagents file in Extras.'])],
     {style: {fontSize: '11px', color: 'var(--grey-6)', gap: '6px', alignItems: 'center',
       padding: '6px 10px', display: 'none'}});
-    ui.tooltip.bind(this.reagentsModeNote, 'Every round uses exactly one building block or earlier-round product, ' +
+    ui.tooltip.bind(this.reagentsModeNote, 'Every step uses exactly one building block or earlier-step product, ' +
       'with reagents filling the remaining slots. Automatically selected as soon as a reagents file is loaded ' +
       'in the Extras tab — to go back to Depth-first/Breadth-first, clear the reagents file there.');
 
@@ -198,7 +196,7 @@ export class EnumeratorNav {
         this.deps.configInfoIcon,
       ], {style: {alignItems: 'center', gap: '4px'}}),
       ui.divV([this.stratDepthCard.root, this.stratBreadthCard.root, this.reagentsModeNote], {style: {gap: '6px'}}),
-      ui.div([ui.form([this.deps.numRoundsInput, this.deps.maxComponentsInput, this.deps.maxRoutesInput])],
+      ui.div([ui.form([this.deps.numRoundsInput])],
         {style: {marginLeft: `${CHEM_ENUM_NESTED_ACCORDION_INDENT}px`}}),
       limitsAccordion.root,
       // First pane in the chain — no Back target.
@@ -253,9 +251,9 @@ export class EnumeratorNav {
       const root = ui.divH([dot, textEl], {classes: 'chem-enum-chip', style: {alignItems: 'center', gap: '4px'}});
       return {root, textEl, dot};
     };
-    this.chipReactionsC = cfgChipEl('One or more rounds use a custom subset of reaction templates.');
-    this.chipBbsC = cfgChipEl('One or more rounds use a custom subset of building blocks.');
-    this.chipExtrasC = cfgChipEl('One or more rounds use a custom subset of reagents.');
+    this.chipReactionsC = cfgChipEl('One or more steps use a custom subset of reaction templates.');
+    this.chipBbsC = cfgChipEl('One or more steps use a custom subset of building blocks.');
+    this.chipExtrasC = cfgChipEl('One or more steps use a custom subset of reagents.');
     this.chipCombineC = cfgChipEl('Changed from platform defaults.');
     this.cfgEstEl = ui.divText('');
     this.cfgEstEl.className = 'chem-enum-chip';

--- a/packages/Chem/src/utils/reaction-enumeration/preview-panel.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/preview-panel.ts
@@ -26,7 +26,7 @@ function shuffleInPlace<T>(arr: T[]): T[] {
 // Biased 70/30 toward multi-step routes — the more interesting case to eyeball in a quick preview.
 function pickPreviewSamples(rows: OutputRow[], n: number): OutputRow[] {
   if (rows.length <= n) return shuffleInPlace(rows.slice());
-  const stepCount = (r: OutputRow) => r.route ? Math.max(0, r.route.split('>>').length - 1) : 0;
+  const stepCount = (r: OutputRow): number => r.steps.length;
   const multi = shuffleInPlace(rows.filter((r) => stepCount(r) > 1));
   const single = shuffleInPlace(rows.filter((r) => stepCount(r) <= 1));
   const targetMulti = Math.min(multi.length, Math.ceil(n * 0.7));
@@ -89,7 +89,7 @@ export class PreviewPanel {
     };
 
     addRow('Strategy', `${MODE_LABEL[mode]} · ${roundsLabel(rounds)}`);
-    if (rounds > MAX_ROUNDS) addRow('', `Showing the first ${MAX_ROUNDS} rounds — capped at ${MAX_ROUNDS}.`);
+    if (rounds > MAX_ROUNDS) addRow('', `Showing the first ${MAX_ROUNDS} steps — capped at ${MAX_ROUNDS}.`);
 
     // Only rounds with a custom subset get a row; the rest would just repeat the total.
     const overrides = tDf && bDf ? this.deps.buildPerRoundOverrides(this.deps.getConfig()) : undefined;
@@ -101,7 +101,7 @@ export class PreviewPanel {
       addRow(label, `${df.rowCount}`);
       for (let r = 1; r <= displayRounds; r++) {
         const oc = this.deps.overrideCountFor(overrides, mode, r, key);
-        if (oc != null) addRow(`Round ${r}`, `${oc} of ${df.rowCount} (custom subset)`, true);
+        if (oc != null) addRow(`Step ${r}`, `${oc} of ${df.rowCount} (custom subset)`, true);
       }
     };
     addComponentRows('Reactions', tDf, 'templates');
@@ -205,6 +205,6 @@ export class PreviewPanel {
     this.deps.viewerHost.mountDf(this.host, df, false, {rowHeight: 110, extendLastColumn: false});
     this.status.textContent =
       `${samples.length} samples of ${rows.length} preview rows (≤ ${previewConfig.enumeration.num_rounds} ` +
-      `rounds, ≤ ${PREVIEW_MAX_COMBOS_PER_TEMPLATE} combos / template)`;
+      `steps, ≤ ${PREVIEW_MAX_COMBOS_PER_TEMPLATE} combos / template)`;
   }
 }

--- a/packages/Chem/src/utils/reaction-enumeration/run-controls.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/run-controls.ts
@@ -4,7 +4,7 @@ import * as DG from 'datagrok-api/dg';
 import {cloneConfig, EnumeratorConfig} from './config';
 import {enumerate, EnumerationProgress, PerRoundOverride} from './enumerate';
 import {getRdKitModule} from '../chem-common-rdkit';
-import {buildInputs, buildResultDataFrame} from './shared';
+import {addResultFilters, buildInputs, buildResultDataFrame} from './shared';
 
 export interface RunControlsDeps {
   getConfig: () => EnumeratorConfig;
@@ -121,17 +121,17 @@ export class RunControls {
     const reagentsPart = inputs.reagents.length > 0 ? ` × ${inputs.reagents.length} reagents` : '';
     this.progressLabel.textContent =
       `Running: ${inputs.templates.length} templates × ${inputs.buildingBlocks.length} BBs${reagentsPart} × ` +
-      `${config.enumeration.num_rounds} round(s)`;
+      `${config.enumeration.num_rounds} step(s)`;
     const onProgress = (p: EnumerationProgress): void => {
       const combo = p.combosTotal && p.combosTotal > 0 ?
         `, combos ${p.combosDone}/${p.combosTotal}` : '';
       this.progressLabel.textContent =
-        `Round ${p.round}/${p.numRounds}, template ${p.templateIndex + 1}/${p.numTemplates}${combo}, ` +
+        `Step ${p.round}/${p.numRounds}, template ${p.templateIndex + 1}/${p.numTemplates}${combo}, ` +
         `products: ${p.productsSoFar}`;
     };
 
     const perRoundOverrides = this.deps.buildPerRoundOverrides(config);
-    if (perRoundOverrides) this.progressLabel.textContent += ' · per-round subsets active';
+    if (perRoundOverrides) this.progressLabel.textContent += ' · per-step subsets active';
 
     const start = performance.now();
     const {rows, warnings} = await enumerate({
@@ -151,6 +151,6 @@ export class RunControls {
       const more = warnings.length > 3 ? ` (+${warnings.length - 3} more; see console)` : '';
       grok.shell.warning(`${preview}${more}`);
     }
-    if (rows.length > 0) grok.shell.addTableView(buildResultDataFrame(rows));
+    if (rows.length > 0) addResultFilters(grok.shell.addTableView(buildResultDataFrame(rows)));
   }
 }

--- a/packages/Chem/src/utils/reaction-enumeration/shared.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/shared.ts
@@ -125,6 +125,8 @@ function getStringColumn(df: DG.DataFrame, name: string): string[] {
 }
 
 const STEP_RXN_PREFIX = '~reaction_name_';
+/** Past this many products the step hierarchy filter is too slow to build and redraw. */
+const HIERARCHICAL_MAX_PRODUCTS = 500_000;
 
 export function buildResultDataFrame(rows: OutputRow[], name = 'Enumeration result'): DG.DataFrame {
   const maxSteps = rows.reduce((m, r) => Math.max(m, r.steps.length), 0);
@@ -143,7 +145,8 @@ export function buildResultDataFrame(rows: OutputRow[], name = 'Enumeration resu
     ...templateCols,
     DG.Column.fromInt32Array('round', new Int32Array(rows.map((r) => r.round))),
     DG.Column.fromInt32Array('n_routes', new Int32Array(rows.map((r) => r.n_routes))),
-    ...perStep((k) => `${STEP_RXN_PREFIX}${k}`, (s) => s.reactionName),
+    ...(maxSteps > 1 && rows.length <= HIERARCHICAL_MAX_PRODUCTS ?
+      perStep((k) => `${STEP_RXN_PREFIX}${k}`, (s) => s.reactionName) : []),
   ]);
   df.name = name;
   df.col('product')!.semType = DG.SEMTYPE.MOLECULE;
@@ -159,7 +162,8 @@ export function buildResultDataFrame(rows: OutputRow[], name = 'Enumeration resu
 export function defaultFilterState(col: DG.Column): DG.FilterState {
   const type = col.isNumerical ?
     (col.stats.min === col.stats.max ? DG.FILTER_TYPE.CATEGORICAL : DG.FILTER_TYPE.HISTOGRAM) :
-    col.semType === DG.SEMTYPE.MOLECULE ? DG.FILTER_TYPE.SUBSTRUCTURE : DG.FILTER_TYPE.CATEGORICAL;
+    col.semType === DG.SEMTYPE.MOLECULE ? DG.FILTER_TYPE.SUBSTRUCTURE :
+      col.meta.multiValueSeparator ? DG.FILTER_TYPE.MULTI_VALUE : DG.FILTER_TYPE.CATEGORICAL;
   return {type, column: col.name};
 }
 

--- a/packages/Chem/src/utils/reaction-enumeration/shared.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/shared.ts
@@ -1,27 +1,29 @@
 import * as ui from 'datagrok-api/ui';
 import * as DG from 'datagrok-api/dg';
 import {DEFAULT_CONFIG, EnumeratorConfig} from './config';
-import {OutputRow, TemplateInput} from './enumerate';
+import {OutputRow, OutputStep, TemplateInput} from './enumerate';
 
 export type Mode = 'depth' | 'breadth' | 'reagents';
 export type DataKey = 'templates' | 'buildingBlocks' | 'reagents';
 
 export const MODE_LABEL = {depth: 'Depth-first', breadth: 'Breadth-first', reagents: 'Reagents'} as const;
-export const roundsLabel = (n: number): string => `${n} round${n === 1 ? '' : 's'}`;
+export const roundsLabel = (n: number): string => `${n} step${n === 1 ? '' : 's'}`;
 
 export const OVERRIDE_DOT_COLOR = 'var(--orange-2, #c98a1b)';
 export const CHANGED_DOT_STYLE = {width: '6px', height: '6px', borderRadius: '50%', background: OVERRIDE_DOT_COLOR};
 
 export const MAX_ROUNDS = 10;
 
-/** Every per-round loop that builds DOM must clamp: "Number of rounds" can transiently hold a much
+/** Every per-round loop that builds DOM must clamp: "Number of steps" can transiently hold a much
  * larger typed value, which would freeze the tab building thousands of rows per keystroke. */
 export function clampRounds(rounds: number): number {
   return Math.min(MAX_ROUNDS, Math.max(1, rounds));
 }
 
 export function combinationLimitsChanged(cfg: EnumeratorConfig): boolean {
-  return cfg.max_num_combinations_per_template !== DEFAULT_CONFIG.max_num_combinations_per_template ||
+  return cfg.max_num_components !== DEFAULT_CONFIG.max_num_components ||
+    cfg.max_num_routes_per_compound !== DEFAULT_CONFIG.max_num_routes_per_compound ||
+    cfg.max_num_combinations_per_template !== DEFAULT_CONFIG.max_num_combinations_per_template ||
     cfg.keep_building_blocks_in_final_output !== DEFAULT_CONFIG.keep_building_blocks_in_final_output;
 }
 
@@ -122,20 +124,60 @@ function getStringColumn(df: DG.DataFrame, name: string): string[] {
   return out;
 }
 
+const STEP_RXN_PREFIX = '~reaction_name_';
+
 export function buildResultDataFrame(rows: OutputRow[], name = 'Enumeration result'): DG.DataFrame {
+  const maxSteps = rows.reduce((m, r) => Math.max(m, r.steps.length), 0);
+  // maxSteps is the longest route; shorter routes leave their tail cells blank.
+  const perStep = (colName: (k: number) => string, pick: (s: OutputStep) => string): DG.Column[] =>
+    Array.from({length: maxSteps}, (_, k) =>
+      DG.Column.fromStrings(colName(k + 1), rows.map((r) => (r.steps[k] ? pick(r.steps[k]) : ''))));
+  // Per-step templates stay visible (a SMARTS is only readable drawn); per-step reaction names are
+  // hidden and exist to feed the step hierarchy filter.
+  const templateCols = perStep((k) => `template_${k}`, (s) => s.template);
   const df = DG.DataFrame.fromColumns([
     DG.Column.fromStrings('product', rows.map((r) => r.product)),
     DG.Column.fromStrings('route', rows.map((r) => r.route)),
-    DG.Column.fromStrings('template', rows.map((r) => r.template)),
-    DG.Column.fromStrings('reaction_name', rows.map((r) => r.reaction_name)),
+    DG.Column.fromStrings('reaction_names',
+      rows.map((r) => r.steps.map((s, i) => `Step ${i + 1}: ${s.reactionName}`).join('\n'))),
+    ...templateCols,
     DG.Column.fromInt32Array('round', new Int32Array(rows.map((r) => r.round))),
     DG.Column.fromInt32Array('n_routes', new Int32Array(rows.map((r) => r.n_routes))),
+    ...perStep((k) => `${STEP_RXN_PREFIX}${k}`, (s) => s.reactionName),
   ]);
   df.name = name;
   df.col('product')!.semType = DG.SEMTYPE.MOLECULE;
   df.col('route')!.semType = 'ChemicalReaction';
-  df.col('template')!.semType = 'ChemicalReaction';
+  for (const c of templateCols) c.semType = 'ChemicalReaction';
+  // A filter on this column then offers each "Step k: …" line as its own category.
+  df.col('reaction_names')!.meta.multiValueSeparator = '\n';
   return df;
+}
+
+/** The filter type the platform picks for a column, except that a zero-variance numeric column gets
+ * the categorical filter: the histogram one clobbers the whole frame's .filter to all-false. */
+export function defaultFilterState(col: DG.Column): DG.FilterState {
+  const type = col.isNumerical ?
+    (col.stats.min === col.stats.max ? DG.FILTER_TYPE.CATEGORICAL : DG.FILTER_TYPE.HISTOGRAM) :
+    col.semType === DG.SEMTYPE.MOLECULE ? DG.FILTER_TYPE.SUBSTRUCTURE : DG.FILTER_TYPE.CATEGORICAL;
+  return {type, column: col.name};
+}
+
+/** Per-column filters for the result view, minus `route` (every value is distinct) and, when there is
+ * a step tree, minus the summary column it duplicates; plus a "step 1 reaction → step 2 reaction → …"
+ * tree over the hidden per-step columns, which the hierarchical filter's own column picker (visible
+ * columns only) could not build. */
+export function addResultFilters(tv: DG.TableView): void {
+  const df = tv.dataFrame;
+  const stepCols = df.columns.names().filter((c) => c.startsWith(STEP_RXN_PREFIX));
+  const tree = stepCols.length > 1;
+  const skip = new Set(tree ? ['route', 'reaction_names'] : ['route']);
+  const fg = tv.getFiltersGroup({createDefaultFilters: false});
+  // The newest filter shows on top, so add bottom-up: the panel then follows column order, tree first.
+  const cols = df.columns.toList().filter((c) => !c.name.startsWith('~') && !skip.has(c.name)).reverse();
+  for (const c of cols) fg.updateOrAdd(defaultFilterState(c), false);
+  // 'hierarchical' isn't in DG.FILTER_TYPE; the state shape is what the group itself serializes.
+  if (tree) fg.updateOrAdd({type: 'hierarchical', colNames: stepCols}, false);
 }
 
 export interface BuiltInputs {

--- a/packages/Chem/src/utils/reaction-enumeration/strategy-summary.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/strategy-summary.ts
@@ -28,7 +28,7 @@ export class StrategySummary {
   constructor(private readonly deps: StrategySummaryDeps) {
     this.host = ui.div([], {style: {padding: '16px'}});
     this.panel = tabPanel(
-      panelHeader('How the current strategy and round count combine the reaction templates and building blocks.'),
+      panelHeader('How the current strategy and step count combine the reaction templates and building blocks.'),
       this.host, true);
   }
 
@@ -54,7 +54,7 @@ export class StrategySummary {
       {style: {fontWeight: 'bold', fontSize: '13px', marginBottom: '10px'}}));
     if (rounds > MAX_ROUNDS) {
       card.appendChild(ui.divText(
-        `Showing the first ${MAX_ROUNDS} rounds — Number of rounds is capped at ${MAX_ROUNDS}.`,
+        `Showing the first ${MAX_ROUNDS} steps — Number of steps is capped at ${MAX_ROUNDS}.`,
         {style: {fontSize: '11px', color: 'var(--grey-5)', marginBottom: '8px'}}));
     }
 
@@ -68,7 +68,7 @@ export class StrategySummary {
         for (let r = 1; r <= displayRounds; r++) {
           const oc = overrideCount(r, key);
           const rowChildren: HTMLElement[] = [
-            ui.divText(`Round ${r}`, {style: {color: 'var(--grey-6)', width: '64px', flex: '0 0 auto'}}),
+            ui.divText(`Step ${r}`, {style: {color: 'var(--grey-6)', width: '64px', flex: '0 0 auto'}}),
             ui.divText(oc != null ? `${oc} of ${total} (custom subset)` : `all ${total}`,
               oc != null ? {style: {fontWeight: '600'}} : undefined),
           ];
@@ -86,7 +86,7 @@ export class StrategySummary {
       if (mode === 'reagents' && rDf)
         card.appendChild(componentSection('Reagents', rDf.rowCount, 'reagents'));
     } else {
-      card.appendChild(ui.divText('Pick reaction templates and building blocks to see round-by-round details.',
+      card.appendChild(ui.divText('Pick reaction templates and building blocks to see step-by-step details.',
         {style: {color: 'var(--grey-5)', fontSize: '12px', marginTop: '4px'}}));
     }
 

--- a/packages/Chem/src/utils/reaction-enumeration/viewer-mount.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/viewer-mount.ts
@@ -2,6 +2,7 @@ import {Subscription} from 'rxjs';
 import * as grok from 'datagrok-api/grok';
 import * as ui from 'datagrok-api/ui';
 import * as DG from 'datagrok-api/dg';
+import {defaultFilterState} from './shared';
 
 // A freshly-mounted Filters viewer asynchronously reapplies a stale per-column selection over the
 // DataFrame's .filter shortly after construction; this is how long to wait past that window.
@@ -94,15 +95,7 @@ export class MountedViewerRegistry {
       // ChemicalReaction has no meaningful substructure-filter semantics for a whole template, and
       // `~`-prefixed columns are internal (e.g. the substructure filter's own fingerprint cache).
       .filter((col) => col.semType !== 'ChemicalReaction' && !col.name.startsWith('~'))
-      .map((col) => ({
-        // A zero-variance numeric column (common right after subsetting) makes the histogram filter
-        // widget clobber the whole frame's .filter to all-false. The categorical filter has no
-        // degenerate-range path, so route those there instead of ever building the histogram.
-        type: col.isNumerical ?
-          (col.stats.min === col.stats.max ? DG.FILTER_TYPE.CATEGORICAL : DG.FILTER_TYPE.HISTOGRAM) :
-          col.semType === DG.SEMTYPE.MOLECULE ? DG.FILTER_TYPE.SUBSTRUCTURE : DG.FILTER_TYPE.CATEGORICAL,
-        column: col.name,
-      }));
+      .map(defaultFilterState);
     const filtersViewer = DG.Viewer.filters(df, {filters: filterStates});
     this.mountedViewers.set(host, [grid, filtersViewer]);
     filtersViewer.root.style.width = '100%';

--- a/packages/Flow/CHANGELOG.md
+++ b/packages/Flow/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* Fixed: The mouse wheel over an on-node editor (the sketcher, the HELM box, any inline value input) zoomed the canvas instead of going to the editor — the node's editor host now keeps the wheel, like the in-node preview already did
 * Added: To Semantic Value utility node — wraps any value into a `DG.SemanticValue` of a configurable semantic type (default Molecule) via `DG.SemanticValue.fromValueType`
 * Improved: An input node whose Choices qualifier is a reference (a `Pkg:func()` call or a `query("…")` — e.g. the organism input of Biologics' Assays by Organism query) now resolves it into the real item list in the value editor, node body and panel alike; a Property Input adopting such a parameter keeps the reference (and, for query references, the owning query's connection) instead of dropping it — including when the platform hands the reference JSON-escaped — and references never leak into the emitted `//input:` header
 * Added: Property Input — a universal input node that mimics the function input it connects to: the target parameter's property drives the node's type, value editor, qualifiers, and context panel (a Molecule string becomes a sketcher, a Macromolecule a HELM editor, an int gets min/max, and so on), it re-picks the property whenever connected elsewhere (user renames survive), it leads the suggestion menu when a connection is dragged out of a function input, and with a non-function target the type is set manually via the panel's new Type combo

--- a/packages/Flow/src/rete/node-component.tsx
+++ b/packages/Flow/src/rete/node-component.tsx
@@ -385,6 +385,10 @@ export function DgControlComponent(props: {data: InputValueControl}): React.JSX.
       ref={ref}
       onPointerDown={(e) => e.stopPropagation()}
       onDoubleClick={(e) => e.stopPropagation()}
+      // The event has already reached the editor by the time this fires, so a
+      // scrollable one still scrolls and an inert one (the sketcher) does
+      // nothing — either way the canvas must not zoom under the cursor.
+      onWheel={(e) => e.stopPropagation()}
     />
   );
 }

--- a/packages/Flow/src/tests/input-value-tests.ts
+++ b/packages/Flow/src/tests/input-value-tests.ts
@@ -210,6 +210,34 @@ category('Flow: input values', () => {
     }
   });
 
+  test('a wheel over the on-node editor does not zoom the canvas', async () => {
+    const e = makeEditor();
+    try {
+      await addNode(e.flow, 'Inputs/Int Input');
+      const rendered = await until(() =>
+        e.container.querySelector('[data-testid="ff-node-value-input"] input') != null, 4000);
+      expect(rendered, true, 'the node body hosts a DG input');
+
+      const wheel = (el: Element): void => {
+        const r = el.getBoundingClientRect();
+        el.dispatchEvent(new WheelEvent('wheel', {bubbles: true, cancelable: true, deltaY: -120,
+          clientX: r.left + r.width / 2, clientY: r.top + r.height / 2}));
+      };
+      const before = e.flow.getZoom();
+      const moved = (): boolean => Math.abs(e.flow.getZoom() - before) > 1e-6;
+
+      wheel(e.container.querySelector('[data-testid="ff-node-value-input"] input')!);
+      await until(moved, 500);
+      expect(moved(), false, 'the editor keeps the wheel — the canvas must not zoom under the cursor');
+
+      // The same gesture on empty canvas still zooms — the guard is scoped, not global.
+      wheel(e.container.querySelector('.ff-canvas')!);
+      expect(await until(moved, 2000), true, 'the canvas itself still zooms on wheel');
+    } finally {
+      destroyEditor(e);
+    }
+  });
+
   test('editing through the editor reports params-changed exactly once', async () => {
     registerBuiltinNodes();
     const edits: GraphEdit[] = [];


### PR DESCRIPTION
Changes made:

- Changes `Rounds` to `Steps`
- Moved `Max # of components` and `Max routes per compound` to `Combination limits (optional)`
- Added in `reaction_names` all steps in one cell, while keeping for `template` and individual template for each step