### PR TITLE
GROK-20779: Help: where a scheduled run's creations land

### DIFF
--- a/help/datagrok/concepts/functions/functions.md
+++ b/help/datagrok/concepts/functions/functions.md
@@ -109,6 +109,12 @@ By default, scheduled functions run with "All users" permissions. Use `schedule.
 - You must be a member of the specified group or role to use `schedule.runAs`
 - Only applies to server-based functions (scripts and queries)
 
+A scheduled run executes as the `System` user with the group's permissions, so everything it reads
+must be shared with that group. Everything it creates (for example, a table uploaded with
+`grok.tables.upload` from a Python script) lands in the group's space, a root space named after the
+group (`AllUsers`, `Administrators`) that is created on first use and shared with the group with full
+access; when the group is a user's personal group, in that user's own project.
+
 ## Filtering
 
 You can use these fields to filter functions with [smart search](../../../visualize/table-view-1.md#search-patterns):


### PR DESCRIPTION
Help note for [GROK-20779](https://reddata.atlassian.net/browse/GROK-20779): a scheduled run is System acting with the run-as group's permissions, and what it creates now lands in the group's space (a user's own project for a personal group). Server side: Bitbucket PR on `claude/GROK-20779-group-space`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9znnWwTVUKzE3pnTamXXR


[GROK-20779]: https://reddata.atlassian.net/browse/GROK-20779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ