### PR TITLE
GROK-19272: js-api, help: AdminUrlAliases constant, URL aliases note

### DIFF
--- a/help/develop/advanced/url-parameters.md
+++ b/help/develop/advanced/url-parameters.md
@@ -63,6 +63,16 @@ Parameterized commands use the `command(param)` syntax:
 | `v`       | viewer ID           |         | Show a single viewer (used with `mode=embed`)      |
 | `q`       | search text         |         | Pre-fill the search filter in the functions browser|
 
+### URL aliases
+
+A URL alias is a stable, readable address on the platform origin — `https://host/sales` —
+that opens a dashboard, any other entity, or another URL. Administrators create and re-point
+aliases under **Browse > Platform > URL Aliases** (or from an entity's context menu,
+**Create URL alias...**), so a link keeps working after the dashboard behind it is
+republished. Query parameters on an alias URL are passed to the target: `/sales?region=EU`
+opens the dashboard with `region` set. Platform routes (`/p`, `/files`, `/apps`, ...) and
+view URLs cannot be aliased.
+
 ## Functions
 
 Any function - a script, a query, or a package function - can be opened by URL, with its

--- a/js-api/src/api/grok_shared.api.g.ts
+++ b/js-api/src/api/grok_shared.api.g.ts
@@ -161,6 +161,8 @@ export class Permission {
 
   static ADMIN_SYNC = 'AdminSync';
 
+  static ADMIN_URL_ALIASES = 'AdminUrlAliases';
+
   static CREATE_REPOSITORY = 'CreateRepository';
 
   static CREATE_GROUP = 'CreateGroup';


### PR DESCRIPTION
Public half of GROK-19272 (URL aliases: stable, readable links that open a dashboard, any entity, or another URL, re-pointable without changing the link).

- `js-api/src/api/grok_shared.api.g.ts`: regenerated `Permission.ADMIN_URL_ALIASES = 'AdminUrlAliases'` (codegen output of the core change).
- `help/develop/advanced/url-parameters.md`: a "URL aliases" note under Navigation.

Core PR (Bitbucket `skalkin/reddata`, same branch `claude/GROK-19272`): https://bitbucket.org/skalkin/reddata/pull-requests/972

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNxAiiuLTUEZECpz41ysUS
