### PR TITLE
Docs: JS API versioning rule — release pipeline owns js-api/package.json

### DIFF
--- a/help/develop/dev-process/versioning-policy.md
+++ b/help/develop/dev-process/versioning-policy.md
@@ -70,6 +70,8 @@ Before publishing the release, the new version goes through all [quality assuran
 including the QA Engineer's manual testing of critical changes. The full process of release can be found
 in [wiki](ci-flow.mdx#release-cicd-flow).
 
+> **JS API version.** `datagrok-api` is versioned by the core release (`release-datagrok` bumps `js-api/package.json` to the release version and CI publishes it). Do not bump it in a feature PR — a `master` push with an unpublished version publishes immediately, and plugins built against it will not load on servers of an older version.
+
 How to request the release:
 
 1. **PATCH** release can be requested by anyone on the team. The main difference between other releases is that patch

--- a/js-api/CLAUDE.md
+++ b/js-api/CLAUDE.md
@@ -5,6 +5,10 @@
 This is `datagrok-api`, the JavaScript/TypeScript API for the Datagrok platform - a data analytics and visualization 
 platform. The API provides TypeScript bindings that communicate with a Dart backend via an interop layer.
 
+## Versioning
+
+Never change `version` in `package.json` in a feature PR. Any push to `master` with a version that is not on npm publishes it (`.github/workflows/js-api.yml`), and js-api versions are set by the core release pipeline (`release-datagrok`, see `core/docs/RELEASE_CYCLE.md`): a server only loads plugins whose `datagrok-api` range it satisfies, so an unmatched publish breaks plugin loading on shipped stands. In-repo consumers use `"datagrok-api": "../../js-api"` until the release bumps it.
+
 ## Build Commands
 
 ```bash

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -331,6 +331,10 @@ If the package ships `dockerfiles/*/container.json` naming an `image`, remember 
 the version (see above), so the images for the new version must exist in the registry *before*
 the bump lands on master.
 
+### js-api version
+
+Do not bump `js-api/package.json` in a feature PR — the core release pipeline owns that version and a `master` push auto-publishes it (see `js-api/CLAUDE.md` → Versioning). Depend on the in-repo API with `"datagrok-api": "../../js-api"`; the release rewrites it to the published range.
+
 ## Naming Conventions
 
 - Package folder: **PascalCase** (`PowerGrid`, `BiostructureViewer`)


### PR DESCRIPTION
## Summary
One short paragraph in the three places a developer (or an agent) reads before touching the JS API version: `js-api/CLAUDE.md` (new "Versioning" section), `packages/CLAUDE.md`, and `help/develop/dev-process/versioning-policy.md`.

The rule: never bump `js-api/package.json` in a feature PR. The core release pipeline (`release-datagrok`) sets the js-api version; any `master` push with an unpublished version auto-publishes to npm; a server only loads plugins whose `datagrok-api` range it satisfies, so an unmatched publish breaks plugin loading on shipped stands. In-repo consumers use `"datagrok-api": "../../js-api"`.

Context: the 1.27.10 / 1.27.11 publishes discussed in #build. Docs only; the js-api workflow will run on merge (path filter) and skip the publish since 1.27.11 is already on the registry.