### PR TITLE
Bio tests: address the Match-with-Monomer-Library dialog by its new name

### DIFF
--- a/packages/Bio/playwright/bio-manage-libraries-crud.test.ts
+++ b/packages/Bio/playwright/bio-manage-libraries-crud.test.ts
@@ -284,9 +284,9 @@ test('Bio Manage Monomer Libraries CRUD (app + tree browser + Monomers view + Ma
         const leaf = await wait('[name="div-Bio---Manage---Match-with-Monomer-Library..."]');
         if (leaf) leaf.click();
       });
-      await page.locator('[name="dialog-matchWithMonomerLibrary"]').waitFor({state: 'visible', timeout: 30_000});
+      await page.locator('[name="dialog-Match-with-Monomer-Library"]').waitFor({state: 'visible', timeout: 30_000});
       const result = await page.evaluate(() => {
-        const dialog = document.querySelector('[name="dialog-matchWithMonomerLibrary"]');
+        const dialog = document.querySelector('[name="dialog-Match-with-Monomer-Library"]');
         const hostTable = dialog?.querySelector('[name="input-host-Table"]') ?? null;
         const hostMolecules = dialog?.querySelector('[name="input-host-Molecules"]') ?? null;
         const hostPolymer = dialog?.querySelector('[name="input-host-Polymer-Type"]') ?? null;

--- a/packages/Bio/playwright/bio-top-menu-sweep.test.ts
+++ b/packages/Bio/playwright/bio-top-menu-sweep.test.ts
@@ -43,7 +43,7 @@ const BIO_LEAVES: Leaf[] = [
   {group: 'Annotate', leaf: 'Apply-Numbering-Scheme...', dialog: 'Apply-Antibody-Numbering'},
   {group: 'Annotate', leaf: 'Scan-Liabilities...', dialog: 'Scan-Sequence-Liabilities'},
   {group: 'Annotate', leaf: 'Manage-Annotations...', dialog: 'Manage-Annotations'},
-  {group: 'Manage', leaf: 'Match-with-Monomer-Library...', dialog: 'matchWithMonomerLibrary'},
+  {group: 'Manage', leaf: 'Match-with-Monomer-Library...', dialog: 'Match-with-Monomer-Library'},
   {group: 'Manage', leaf: 'Monomer-Libraries', view: 'Manage Monomer Libraries'},
   {group: 'Manage', leaf: 'Monomers', view: 'Manage Monomers'},
   {group: 'Search', leaf: 'Similarity-Search', viewer: 'Sequence Similarity Search', viewerReady: 'idxs'},


### PR DESCRIPTION
The function was given an explicit name in "Bio: BDD tests" (e130657a26), so the platform now names its auto-generated dialog element after that display name, the way every other Bio dialog is already addressed (dialog-Get-Sequence-Region, dialog-Apply-Antibody-Numbering). Two specs still waited for the old method-derived selector, timed out, and left the dialog open over the menu, which then failed the following Monomer Libraries leaf as well.

