### PR TITLE
GROK-20298: Domains: row ownership in the help and schema descriptions

### DIFF
--- a/help/develop/how-to/db/domain-schemas.md
+++ b/help/develop/how-to/db/domain-schemas.md
@@ -90,8 +90,8 @@ Every table automatically gets the system columns `id` (UUID, also the row's ent
 |------------------------|-----------|-------------------------------------------------------------------------------------------------|
 | `securityMode`         | `table`   | `table`, `master`, or `row` — see [security modes](#security-modes)                              |
 | `delegate`             | —         | Master mode: the `ref` column whose target row's security applies                                |
-| `promotion`            | `lazy`    | Row mode: when the row becomes an individually sharable entity (`lazy` = on first share, `eager` = on insert) |
-| `defaultRowVisibility` | `table`   | Row/master modes: whether table-level View shows unshared rows (`none` hides them)               |
+| `promotion`            | `lazy`    | Row mode: when the row becomes an individually sharable entity (`lazy` = on first share, `eager` = on insert, with the author granted View/Edit/Delete/Share) |
+| `defaultRowVisibility` | `table`   | Row/master modes: whether table-level View shows unshared rows (`none` hides them from everyone but their author) |
 | `businessKey`          | —         | Natural-key column list: powers deduplication on insert, upsert matching, and search handles     |
 | `audit`                | `true`    | In-transaction audit trail with before/after diffs; also enables row history and row-level watch |
 | `softDelete`           | `true`    | Deletes mark `is_deleted` instead of removing rows                                               |
@@ -307,7 +307,8 @@ one above — a `master`-mode junction delegating to the owner, so Edit on an is
 on its links (and unlinking needs no separate Delete grant). A relation whose junction or
 target table you cannot View is invisible everywhere, exactly like a name nobody declared.
 Do not set `defaultRowVisibility: "none"` on a junction or a relation target — rows
-created there could never be linked, and the manifest is rejected.
+created there would reach only their own author, nobody else could link them, and the
+manifest is rejected.
 
 ### Default filters
 
@@ -352,7 +353,7 @@ Each table declares how its rows are protected:
 |----------|------------------------------------------|-------------------------------------------------------------------------------------------------|
 | `table`  | Lookup and reference tables (default)    | One permission check against the table itself: a View grant shows all rows, Edit allows writes  |
 | `master` | Detail tables (issue → project, well → plate) | Each row inherits the security of the row it references through the `delegate` column; chains up to two hops deep |
-| `row`    | Registration masters (studies, plates)   | Individual rows can be shared with users and groups; unshared rows follow the table-level grant (or stay hidden with `defaultRowVisibility: "none"`) |
+| `row`    | Registration masters (studies, plates), user-owned records (models, files) | Individual rows can be shared with users and groups; a row's author always sees, edits, deletes and shares it; unshared rows otherwise follow the table-level grant, or stay hidden from everyone else with `defaultRowVisibility: "none"` (private to the author, shareable by them) |
 
 Grants use the standard permissions (View, Edit, Delete, Share) on the schema, table, and
 property-schema entities. Grant them from the UI (the table's **Sharing** pane) or

--- a/tools/domain-schema.schema.json
+++ b/tools/domain-schema.schema.json
@@ -77,12 +77,12 @@
         "promotion": {
           "enum": ["lazy", "eager"],
           "default": "lazy",
-          "description": "Row mode only. lazy: entities row created on first share; eager: at insert."
+          "description": "Row mode only. lazy: entities row created on first share; eager: at insert, with the author granted View/Edit/Delete/Share."
         },
         "defaultRowVisibility": {
           "enum": ["table", "none"],
           "default": "table",
-          "description": "Row/master modes: whether table-level View shows unshared rows."
+          "description": "Row/master modes: whether table-level View shows unshared rows. Their author always sees, edits and shares them; none hides them from everyone else."
         },
         "delegate": {
           "$ref": "#/definitions/identifier",


### PR DESCRIPTION
## Summary

Help page and `domain-schema.schema.json` descriptions for row ownership: a row-mode row always reaches its author (`defaultRowVisibility: none` hides unshared rows from everyone else), and `promotion: eager` promotes at insert with the author granted View/Edit/Delete/Share. Server change: core PR on the same branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeddW7TvMbpU8gj2UCR3Ub
