### PR TITLE
playwright-public: follow the renamed legend and user-menu automation names

### DIFF
--- a/playwright-public/legend/scatterplot.test.ts
+++ b/playwright-public/legend/scatterplot.test.ts
@@ -45,8 +45,8 @@ test('Legend scatterplot — Color + Marker combined', async ({page}) => {
     const item = page.locator('[name="viewer-Scatter-plot"] [name="legend"] .d4-legend-item').first();
     await item.waitFor({timeout: 10000});
     await item.hover();
-    await page.locator('[name="viewer-Scatter-plot"] [name="legend-icon-color-picker"]')
-      .first().waitFor({timeout: 5000});
+    // The picker is appended to document.body, not to the viewer root.
+    await page.locator('[name="legend-icon-color-picker"]').first().waitFor({timeout: 5000});
   });
 
   await softStep('Sc1 step 5: change category color via legend picker (UI + API fallback)', async () => {

--- a/playwright-public/user groups/users.test.ts
+++ b/playwright-public/user groups/users.test.ts
@@ -187,7 +187,7 @@ test.describe('Users View (Users-*)', () => {
 
   test('Users-14 — user context menu items', async ({ page }) => {
     await openCardContextMenu(page, TARGET_NAME);
-    for (const name of ['Details', 'Chat', 'Block', 'Groups...', 'Roles...', 'Add to favorites'])
+    for (const name of ['Details', 'Chat', 'Disable...', 'Groups...', 'Roles...', 'Add to favorites'])
       await expect(contextMenuItemByName(page, name), `menu item "${name}" should be present`)
         .toBeVisible({ timeout: 5_000 });
     await closeMenu(page);
@@ -267,9 +267,9 @@ test.describe('Users View (Users-*)', () => {
     }
   });
 
-  // Users-20: block AND unblock a user fully through the UI. After Block the gallery card is stale
-  // (it doesn't react to ENTITY_MODIFIED), so the menu only flips to "Unblock" after the view is
-  // refreshed — the test reloads to exercise the real UI unblock. API is used only for verification
+  // Users-20: disable AND enable a user fully through the UI. After Disable the gallery card is stale
+  // (it doesn't react to ENTITY_MODIFIED), so the menu only flips to "Enable" after the view is
+  // refreshed — the test reloads to exercise the real UI path. API is used only for verification
   // reads and as a finally safety-net.
   test('Users-20 — block then unblock a user via UI (refresh clears the stale card)', async ({ page }) => {
     const waitForStatus = async (want: string): Promise<string> => {
@@ -282,19 +282,19 @@ test.describe('Users View (Users-*)', () => {
       return s;
     };
     try {
-      // Block.
+      // Disable.
       await openCardContextMenu(page, TARGET_NAME);
-      await contextMenuItemByName(page, 'Block').click();
-      await page.locator('.d4-dialog button[name="button-YES"]').click();
+      await contextMenuItemByName(page, 'Disable...').click();
+      await page.locator('.d4-dialog button[name="button-DISABLE"]').click();
       expect(await waitForStatus('blocked'), 'user should be blocked').toBe('blocked');
 
-      // Refresh the view so the card picks up the new state, then unblock via the UI.
+      // Refresh the view so the card picks up the new state, then enable via the UI.
       await page.reload();
       await page.locator(GALLERY_GRID).first().waitFor({ state: 'visible', timeout: 20_000 });
       await page.waitForTimeout(800);
       await openCardContextMenu(page, TARGET_NAME);
-      await contextMenuItemByName(page, 'Unblock').click();
-      await page.locator('.d4-dialog button[name="button-YES"]').click();
+      await contextMenuItemByName(page, 'Enable').click();
+      await page.locator('.d4-dialog button[name="button-ENABLE"]').click();
       expect(await waitForStatus('active'), 'user should be unblocked via UI').toBe('active');
     } finally {
       // Safety net: guarantee the account is restored even if the UI path failed mid-way.


### PR DESCRIPTION
Nightly 1320 turned two core specs red on renames that landed the same night.

legend/scatterplot.test.ts waited for the colour picker inside the viewer root. The legend item's marker swatch was renamed to legend-item-marker, and the real picker icon is appended to document.body, so the scoped selector matches nothing. Unscoped, the whole file is 5/5 green on dev.

user groups/users.test.ts still expected the Block and Unblock context-menu commands. They are now "Disable..." and "Enable", and Disable opens a modal with its own OK text, so the confirm button is button-DISABLE, not button-YES. The menu names and the dialog buttons were read off dev directly; button-ENABLE comes from the same construction and is confirmed by the next nightly.

Refs: GROK-19888