### PR TITLE
GROK-19272: Help: URL alias Preserve URL option

### DIFF
--- a/help/develop/advanced/url-parameters.md
+++ b/help/develop/advanced/url-parameters.md
@@ -70,8 +70,10 @@ that opens a dashboard, any other entity, or another URL. Administrators create 
 aliases under **Browse > Platform > URL Aliases** (or from an entity's context menu,
 **Create URL alias...**), so a link keeps working after the dashboard behind it is
 republished. Query parameters on an alias URL are passed to the target: `/sales?region=EU`
-opens the dashboard with `region` set. Platform routes (`/p`, `/files`, `/apps`, ...) and
-view URLs cannot be aliased.
+opens the dashboard with `region` set. By default the address bar then shows the target's
+own URL; an alias saved with **Preserve URL** keeps `/sales` there and only the query
+parameters change as you work. Platform routes (`/p`, `/files`, `/apps`, ...) and view
+URLs cannot be aliased.
 
 ## Functions
 

--- a/help/develop/advanced/url-parameters.md
+++ b/help/develop/advanced/url-parameters.md
@@ -68,7 +68,8 @@ Parameterized commands use the `command(param)` syntax:
 A URL alias is a stable, readable address on the platform origin — `https://host/sales` —
 that opens a dashboard, any other entity, or another URL. Administrators create and re-point
 aliases under **Browse > Platform > URL Aliases** (or from an entity's context menu,
-**Create URL alias...**), so a link keeps working after the dashboard behind it is
+**Create URL alias...** — an open dashboard offers it under **Dashboard** in its view menu),
+so a link keeps working after the dashboard behind it is
 republished. Query parameters on an alias URL are passed to the target: `/sales?region=EU`
 opens the dashboard with `region` set. By default the address bar then shows the target's
 own URL; an alias saved with **Preserve URL** keeps `/sales` there and only the query


### PR DESCRIPTION
## Summary

Documents the new **Preserve URL** option on URL aliases (core PR: https://bitbucket.org/skalkin/reddata/pull-requests/982 — GROK-19272 follow-up): an alias saved with it keeps `/sales` in the address bar once the target opens; only the query parameters change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj3YDoBSVBoktYFzF7Dihj
