### PR TITLE
playwright-public: turn pie labels off in the legend corner-stability spec

### DIFF
--- a/playwright-public/legend/legend-corner-stability.test.ts
+++ b/playwright-public/legend/legend-corner-stability.test.ts
@@ -77,7 +77,8 @@ test('Pie and bar corner stability on repeated shrinks (demog)', async ({page}) 
   await softStep('A fresh pie legend settles directly, with no docked flash before the corner', async () => {
     await recordPlacements(page);
     await page.evaluate(() => {
-      (window as any).grok.shell.tv.addViewer('Pie chart', {categoryColumnName: 'RACE'});
+      // labels off: a pie whose every segment is labeled hides its Auto legend (GROK-20793)
+      (window as any).grok.shell.tv.addViewer('Pie chart', {categoryColumnName: 'RACE', showLabel: false});
     });
     await v.waitForLegendIdle(page, 'Pie chart');
     const seen = await moves(page);


### PR DESCRIPTION
Nightly 1320 turned "Pie and bar corner stability" red: the square-viewer step expected corner/rightTop and read undefined/undefined.

The pie hides its Auto legend on purpose once every segment carries an on-chart label (pie_chart_core.dart legendVisibilityOverride). Measured on dev at 620x620: 4 slices, 4 labels shown, no legend anywhere in the document; at
400x400 one label drops and the legend appears docked/top. So the step was asserting a legend the product deliberately suppresses at that size, and the two steps before it - which watch placement moves - were passing vacuously on a pie that had no legend at all.

The 25K-row test in the same file already adds its pie with `showLabel: false` for exactly this reason; do the same here. The file is 3/3 green on dev, and the fixed test is green 3 of 3 repeats.

