### PR TITLE
GROK-20848: packages, libraries: migrate off deprecated datagrok-api members

### DIFF
--- a/libraries/compute-utils/function-views/src/fitting-view.ts
+++ b/libraries/compute-utils/function-views/src/fitting-view.ts
@@ -2048,7 +2048,7 @@ export class FittingView {
         const color = colors[colorIdx];
         const rgb = DG.Color.toRgb(color);
 
-        catCol!.colors.setCategorical({
+        catCol!.meta.colors.setCategorical({
           'Simulation': color,
           'Target': simFuncColNames.length > 1 ? lightenRGB(rgb, SIZE.LIGHTER_PERC) : colors[colorIdx + 1],
         });

--- a/libraries/compute-utils/function-views/src/fitting/scalars-fit-radar.ts
+++ b/libraries/compute-utils/function-views/src/fitting/scalars-fit-radar.ts
@@ -68,7 +68,7 @@ export class ScalarsFitRadar {
     const catCol = this.table.col(NAME.CATEGORY);
 
     if (catCol !== null) {
-      catCol.colors.setCategorical({
+      catCol.meta.colors.setCategorical({
         'Simulation': DG.Color.categoricalPalette[INDICES.BLUE],
         'Target': DG.Color.categoricalPalette[INDICES.ORANGE],
       });

--- a/libraries/compute-utils/function-views/src/shared/utils.ts
+++ b/libraries/compute-utils/function-views/src/shared/utils.ts
@@ -120,7 +120,7 @@ export const getDfFromRuns = (
         DG.VIEWER.HISTOGRAM, DG.VIEWER.BOX_PLOT,
       ].includes(sender.temp[VIEWER_PATH]['type'])
     ) {
-      grok.shell.windows.showProperties = true;
+      grok.shell.windows.showContextPanel = true;
 
       const getAppendedDfs = (column: DG.Column) => {
         const appendedDf = column.get(0).clone() as DG.DataFrame;

--- a/libraries/compute-utils/model-catalog/src/model-catalog-view.ts
+++ b/libraries/compute-utils/model-catalog/src/model-catalog-view.ts
@@ -84,7 +84,7 @@ export class ModelCatalogView extends DG.CustomCardView {
     this.showTree = true;
     this.initRibbon();
     this.initMenu();
-    grok.shell.windows.showProperties = false;
+    grok.shell.windows.showContextPanel = false;
   }
 
   async initRibbon() {

--- a/libraries/ml/src/viewers/activity-cliffs.ts
+++ b/libraries/ml/src/viewers/activity-cliffs.ts
@@ -152,7 +152,7 @@ export async function getActivityCliffs(df: DG.DataFrame, seqCol: DG.Column,
   const saliMinMax = getSaliMinMax(cliffsMetrics.saliVals);
   const saliOpacityCoef = 0.8 / (saliMinMax.max - saliMinMax.min);
 
-  const view = grok.shell.tv?.dataFrame === df ? grok.shell.tv : grok.shell.getTableView(df.name);
+  const view = grok.shell.tv?.dataFrame === df ? grok.shell.tv : grok.shell.tableView(df.name);
   const sp = view.addViewer(DG.VIEWER.SCATTER_PLOT, {
     xColumnName: axesNames[0],
     yColumnName: axesNames[1],
@@ -384,7 +384,7 @@ export async function runActivityCliffs(sp: DG.ScatterPlotViewer, df: DG.DataFra
   // eslint-disable-next-line prefer-const
   let acc: DG.Accordion;
   let clickedSp = false;
-  const view = grok.shell.tv?.dataFrame === df ? grok.shell.tv : grok.shell.getTableView(df.name);
+  const view = grok.shell.tv?.dataFrame === df ? grok.shell.tv : grok.shell.tableView(df.name);
 
   let sparseMatrixRes: SparseMatrixResult | null = null;
   if (seqSpaceOptions.useWebGPU) {

--- a/libraries/statistics/src/compute-functions/dialog.ts
+++ b/libraries/statistics/src/compute-functions/dialog.ts
@@ -156,7 +156,7 @@ export async function chemFunctionsDialog(
     }
   }
 
-  const tc = ui.tabControl(tabControlArgs, true);
+  const tc = ui.tabControl(tabControlArgs, {vertical: true});
   tc.onTabChanged.subscribe(() => {try {tc.currentPane.content.style.removeProperty('max-width');} catch (e) {}});
   tc.header.style.overflow = 'scroll';
   tc.root.style.width = '100%';

--- a/libraries/u2/src/dg/funcs/param-tables.ts
+++ b/libraries/u2/src/dg/funcs/param-tables.ts
@@ -65,7 +65,7 @@ function openTables(): DG.DataFrame[] {
 /** Name → the open table (shell names are unique — `addTable` dedupes); one interop call,
  * where scanning `grok.shell.tables` wraps every open frame. */
 export function tableByName(name: string | null): DG.DataFrame | null {
-  return name == null ? null : (grok.shell.tableByName(name) as DG.DataFrame | null) ?? null;
+  return name == null ? null : (grok.shell.table(name) as DG.DataFrame | null) ?? null;
 }
 
 /** The auto-fill source (fpe:62-64): the current table, else the first open one. */

--- a/libraries/u2/src/dg/shell/source-backends.ts
+++ b/libraries/u2/src/dg/shell/source-backends.ts
@@ -100,7 +100,7 @@ backends.dapiFind = async (collection, id) => {
 };
 
 backends.workspace = {
-  table: (name) => (grok.shell.tableByName(name) as unknown as DataFrameLike) ?? null,
+  table: (name) => (grok.shell.table(name) as unknown as DataFrameLike) ?? null,
   tableNames: () => grok.shell.tableNames,
   onTablesChanged: {
     subscribe: (next) => {

--- a/packages/Admetica/src/tests/admetica-tests.ts
+++ b/packages/Admetica/src/tests/admetica-tests.ts
@@ -20,7 +20,7 @@ category('Admetica', () => {
 
   before(async () => {
     grok.shell.closeAll();
-    grok.shell.windows.showProperties = false;
+    grok.shell.windows.showContextPanel = false;
 
     try {
       await timeout(
@@ -89,7 +89,7 @@ category('Admetica', () => {
     const v = grok.shell.addTableView(molecules);
     await awaitCheck(() => document.querySelector('canvas') !== null, 'Table failed to load', 3000);
 
-    grok.shell.windows.showProperties = true;
+    grok.shell.windows.showContextPanel = true;
 
     const table = v.dataFrame;
     table.currentCell = table.cell(0, 'smiles');

--- a/packages/Admetica/src/utils/admetica-utils.ts
+++ b/packages/Admetica/src/utils/admetica-utils.ts
@@ -96,7 +96,7 @@ function applyPostProcessing(
   viewTable: DG.DataFrame, columnNames: string[],
   addPiechart: boolean, addForm: boolean, molColIdx: number, props?: any,
 ): void {
-  const tableView = grok.shell.getTableView(viewTable.name);
+  const tableView = grok.shell.tableView(viewTable.name);
   if (!tableView)
     return;
 
@@ -139,7 +139,7 @@ function applyColumnColorCoding(column: DG.Column, model: Model): void {
 export function addColorCoding(
   table: DG.DataFrame, columnNames: string[], showInPanel: boolean = false, props?: any,
 ): void {
-  const tableView = grok.shell.getTableView(table.name);
+  const tableView = grok.shell.tableView(table.name);
   if (!tableView && !showInPanel) return;
 
   for (const columnName of columnNames) {
@@ -238,7 +238,7 @@ function createPieSettings(table: DG.DataFrame, columnNames: string[], propertie
 export function addSparklines(
   table: DG.DataFrame, columnNames: string[], index: number, name?: string, props?: any,
 ): void {
-  const tv = grok.shell.getTableView(table.name);
+  const tv = grok.shell.tableView(table.name);
   if (!tv)
     return;
   const {grid} = tv;
@@ -287,7 +287,7 @@ function getTooltipContent(model: any, value: any): string {
 }
 
 export function addCustomTooltip(table: DG.DataFrame, props?: any): void {
-  const view = grok.shell.getTableView(table.name);
+  const view = grok.shell.tableView(table.name);
   view.grid.onCellTooltip((cell, x, y) => {
     if (!cell.isTableCell || typeof cell.cell.value !== 'number')
       return;
@@ -457,7 +457,7 @@ async function createPieChartPane(semValue: DG.SemanticValue): Promise<HTMLEleme
 
   const { dataFrame, column, rowIndex, value } = cell;
 
-  const view = grok.shell.getTableView(dataFrame.name);
+  const view = grok.shell.tableView(dataFrame.name);
   const gridCol = view.grid.col(column.name);
   const gridCell = view.grid.cell(column.name, rowIndex);
 

--- a/packages/ApiSamples/scripts/demo/med-chem.js
+++ b/packages/ApiSamples/scripts/demo/med-chem.js
@@ -92,7 +92,7 @@ const groups = {
 };
 
 // settings virtual columns
-const tv = grok.shell.getTableView('Med Chem');
+const tv = grok.shell.tableView('Med Chem');
 if (tv) {
   tv.grid.columns.add({gridColumnName: 'Toxicity risks', cellType: 'Tags'}).settings = {columns: toxicityRisks};
   tv.grid.columns.add({gridColumnName: 'plate', cellType: 'Plate'})

--- a/packages/ApiTests/src/ai/app/shell-table-view-lookup.ts
+++ b/packages/ApiTests/src/ai/app/shell-table-view-lookup.ts
@@ -18,13 +18,13 @@ category('AI: App: Shell Table/View Lookup', () => {
   after(async () => tv.close());
 
   test('getTableView returns the TableView for an open table', async () => {
-    const found = grok.shell.getTableView(tv.dataFrame.name);
+    const found = grok.shell.tableView(tv.dataFrame.name);
     expect(found instanceof DG.TableView, true);
     expect(found.dataFrame === tv.dataFrame, true);
   });
 
   test('tableView(name) is an alias of getTableView', async () => {
-    const a = grok.shell.getTableView(tv.dataFrame.name);
+    const a = grok.shell.tableView(tv.dataFrame.name);
     const b = grok.shell.tableView(tv.dataFrame.name);
     expect(a.dataFrame === b.dataFrame, true);
   });
@@ -40,7 +40,7 @@ category('AI: App: Shell Table/View Lookup', () => {
   });
 
   test('getTableView for an unknown table name is null-ish', async () => {
-    expect(grok.shell.getTableView(uniqueName('no-such-table')) == null, true);
+    expect(grok.shell.tableView(uniqueName('no-such-table')) == null, true);
   });
 
   test('dockElement docks an element and close removes it', async () => {

--- a/packages/ApiTests/src/packages/properties.ts
+++ b/packages/ApiTests/src/packages/properties.ts
@@ -36,7 +36,7 @@ category('Packages: Properties', () => {
 async function changeProp(name: string, value: any): Promise<void> {
   //@ts-ignore
   await _package.setSettings({[name]: value}, group);
-  const props = await _package.getSettings();
+  const props = _package.settings;
   //@ts-ignore
   expect(props[name], value);
 }

--- a/packages/ApiTests/src/shell/settings.ts
+++ b/packages/ApiTests/src/shell/settings.ts
@@ -48,7 +48,7 @@ category('Settings', () => {
     expect(gss.showMenu, !grok.shell.windows.simpleMode, 'showMenu');
     expect(gss.showTables, grok.shell.windows.showTables, 'showTables');
     expect(gss.showColumns, grok.shell.windows.showColumns, 'showColumns');
-    expect(gss.showProperties, grok.shell.windows.showProperties, 'showProperties');
+    expect(gss.showProperties, grok.shell.windows.showContextPanel, 'showProperties');
     expect(gss.showToolbox, grok.shell.windows.showToolbox, 'showToolbox');
     expect(gss.showStatusBar, grok.shell.windows.showStatusBar, 'showStatusBar');
     expect(gss.showVariables, grok.shell.windows.showVariables, 'showVariables');

--- a/packages/ApiTests/src/shell/shell.ts
+++ b/packages/ApiTests/src/shell/shell.ts
@@ -57,7 +57,7 @@ category('Shell', () => {
   test('tableByName', async () => {
     grok.shell.closeAll();
     const t = grok.shell.addTableView(demog);
-    expect(grok.shell.tableByName(demog.name), t.dataFrame)
+    expect(grok.shell.table(demog.name), t.dataFrame)
   }, {skipReason: nodeSkip});
 
   test('dockManager', async () => {

--- a/packages/Bio/src/demo/bio01-similarity-diversity.ts
+++ b/packages/Bio/src/demo/bio01-similarity-diversity.ts
@@ -52,7 +52,7 @@ export async function demoBio01UISteps() {
     await demoScript
       .step(`Load DNA sequences`, async () => {
         grok.shell.windows.showContextPanel = false;
-        grok.shell.windows.showProperties = false;
+        grok.shell.windows.showContextPanel = false;
 
         df = await _package.files.readCsv(dataFn);
         view = grok.shell.addTableView(df);

--- a/packages/Bio/src/demo/bio01a-hierarchical-clustering-and-sequence-space.ts
+++ b/packages/Bio/src/demo/bio01a-hierarchical-clustering-and-sequence-space.ts
@@ -46,7 +46,7 @@ export async function demoBio01aUI() {
         view.grid.columns.byName('is_cliff')!.visible = false;
 
         grok.shell.windows.showContextPanel = false;
-        grok.shell.windows.showProperties = false;
+        grok.shell.windows.showContextPanel = false;
       }, {
         description: `Load dataset with macromolecules of 'fasta' notation, 'DNA' alphabet.`,
         delay: 2000,

--- a/packages/Bio/src/demo/bio01b-hierarchical-clustering-and-activity-cliffs.ts
+++ b/packages/Bio/src/demo/bio01b-hierarchical-clustering-and-activity-cliffs.ts
@@ -33,7 +33,7 @@ export async function demoBio01bUI() {
     await demoScript
       .step(`Load DNA sequences`, async () => {
         grok.shell.windows.showContextPanel = false;
-        grok.shell.windows.showProperties = false;
+        grok.shell.windows.showContextPanel = false;
 
         [df, treeHelper, dendrogramSvc] = await Promise.all([
           _package.files.readCsv(dataFn),

--- a/packages/Bio/src/demo/bio03-atomic-level.ts
+++ b/packages/Bio/src/demo/bio03-atomic-level.ts
@@ -18,7 +18,7 @@ export async function demoBio03UI(): Promise<void> {
     await new DemoScript('Atomic Level', 'Atomic level structure of Macromolecules', false, {autoStartFirstStep: true})
       .step(`Loading Macromolecules notation 'Helm'`, async () => {
         grok.shell.windows.showContextPanel = false;
-        grok.shell.windows.showProperties = false;
+        grok.shell.windows.showContextPanel = false;
 
         df = await _package.files.readCsv(dataFn);
         view = grok.shell.addTableView(df);

--- a/packages/Bio/src/demo/bio05-helm-msa-sequence-space.ts
+++ b/packages/Bio/src/demo/bio05-helm-msa-sequence-space.ts
@@ -49,7 +49,7 @@ export async function demoBio05UI(): Promise<void> {
         view = grok.shell.addTableView(df);
 
         grok.shell.windows.showContextPanel = false;
-        grok.shell.windows.showProperties = false;
+        grok.shell.windows.showContextPanel = false;
 
         if (pepseaDcStatus === 'started' || pepseaDcStatus === 'checking') {
           _package.logger.debug(

--- a/packages/Bio/src/package.ts
+++ b/packages/Bio/src/package.ts
@@ -1899,8 +1899,7 @@ async function initBioInt() {
   // first make sure chem and rdkit module are loaded
   const rdKitModule = await getRdKitModule();
   // then load package settings
-  const pkgProps = await _package.getProperties();
-  const bioPkgProps = new BioPackageProperties(pkgProps);
+  const bioPkgProps = new BioPackageProperties(Object.entries(_package.settings ?? {}));
   _package.properties = bioPkgProps;
   // then load monomer lib
   const libHelper = await MonomerLibManager.getInstance();

--- a/packages/Bio/src/tests/WebLogo-project-tests.ts
+++ b/packages/Bio/src/tests/WebLogo-project-tests.ts
@@ -32,7 +32,7 @@ category('WebLogo.project', () => {
     await delay(500);
 
     const prj2 = await grok.dapi.projects.open(prjName);
-    const view2 = grok.shell.getTableView(tableName);
+    const view2 = grok.shell.tableView(tableName);
 
     const viewersA = wu(view2.viewers).toArray();
     expect(viewersA.length, 2);

--- a/packages/Bio/src/tests/detectors-tests.ts
+++ b/packages/Bio/src/tests/detectors-tests.ts
@@ -15,7 +15,7 @@ import { _testBilnDetection, detectorTestsDataForBiln } from './biln-tests';
 
 /*
 // snippet to list df columns of semType='Macromolecule' (false positive)
-const df = grok.shell.tableByName('SPGI');
+const df = grok.shell.table('SPGI');
 for (let i = 0; i < df.columns.length; i++) {
   const col = df.columns.byIndex(i);
   if (col.semType == 'Macromolecule') {

--- a/packages/Bio/src/tests/to-atomic-level-tests.ts
+++ b/packages/Bio/src/tests/to-atomic-level-tests.ts
@@ -24,7 +24,7 @@ import {getRdKitModule} from '@datagrok-libraries/bio/src/chem/rdkit-module';
 import {_package} from '../package-test';
 
 const appPath = 'System:AppData/Bio';
-const fileSource = new DG.FileSource(appPath);
+const fileSource = new DG.FilesDataSource(appPath);
 
 const complexMonomerAllylRgroup: Monomer = {
   'symbol': 'allyl_mon',

--- a/packages/BioNeMo/src/diffdock/diffdock-model.ts
+++ b/packages/BioNeMo/src/diffdock/diffdock-model.ts
@@ -50,7 +50,7 @@ export class DiffDockModel {
     const posesColumn = this.createColumn(DG.TYPE.STRING, CONSTANTS.POSES_COLUMN_NAME, this.ligands.length);
     const confidenceColumn = this.createColumn(DG.TYPE.FLOAT, CONSTANTS.CONFIDENCE_COLUMN_NAME, this.ligands.length);
     const virtualPosesColumn = this.createColumn(DG.TYPE.STRING, `${CONSTANTS.VIRTUAL_POSES_COLUMN_NAME}_${this.targetName}_${this.poses}`, this.ligands.length);
-    const grid = grok.shell.getTableView(this.df.name).grid;
+    const grid = grok.shell.tableView(this.df.name).grid;
 
     for (let i = 0; i < posesColumn.length; ++i) {
       const posesJson = await this.getPosesJson(this.ligands.get(i), this.ligands.getTag(DG.TAGS.UNITS));
@@ -175,7 +175,7 @@ export class DiffDockModel {
       const { bestId, bestPose, confidence } = this.findBestPose(poses);
       const combinedControl = await this.createCombinedControl(poses, bestPose, bestId);
 
-      const view = grok.shell.getTableView(this.df.name);
+      const view = grok.shell.tableView(this.df.name);
       if (this.currentViewer)
         view.dockManager.close(this.currentViewer);
 

--- a/packages/BioNeMo/src/package.ts
+++ b/packages/BioNeMo/src/package.ts
@@ -148,8 +148,7 @@ export class PackageFunctions {
 }
 
 export async function getApiKey(): Promise<string> {
-  //@ts-ignore
-  const apiKey = (await _package.getSettings())['apiKey'];
+  const apiKey = _package.settings['apiKey'];
   if (apiKey)
     return apiKey;
   throw new Error('API key is not set in package credentials');

--- a/packages/BiostructureViewer/playwright/context-panel-widgets-extension.test.ts
+++ b/packages/BiostructureViewer/playwright/context-panel-widgets-extension.test.ts
@@ -81,7 +81,7 @@ test('BiostructureViewer / context-panel widgets extension (3D Structure / PDB I
       await page.evaluate(() => {
         // Force the context panel visible: the baseline sets simpleMode=true which hides it,
         // and the accordion panes ([name="pane-*"]) only render into a shown context panel.
-        grok.shell.windows.showProperties = true;
+        grok.shell.windows.showContextPanel = true;
         const cell = grok.shell.tv.dataFrame.cell(0, 'structure');
         grok.shell.o = DG.SemanticValue.fromTableCell(cell);
       });
@@ -171,7 +171,7 @@ test('BiostructureViewer / context-panel widgets extension (3D Structure / PDB I
       await page.evaluate(() => {
         // Force the context panel visible: the baseline sets simpleMode=true which hides it,
         // and the accordion panes ([name="pane-*"]) only render into a shown context panel.
-        grok.shell.windows.showProperties = true;
+        grok.shell.windows.showContextPanel = true;
         const cell = grok.shell.tv.dataFrame.cell(0, 'structure');
         grok.shell.o = DG.SemanticValue.fromTableCell(cell);
       });
@@ -209,7 +209,7 @@ test('BiostructureViewer / context-panel widgets extension (3D Structure / PDB I
     await softStep('Scenario 3 — PDB Information pane (PDB_ID) renders async pdbInfoWidget metadata', async () => {
       await page.evaluate(() => {
         // Context panel must be shown for the accordion panes to render (see scenario 1).
-        grok.shell.windows.showProperties = true;
+        grok.shell.windows.showContextPanel = true;
         const cell = grok.shell.tv.dataFrame.cell(0, 'pdb_id');
         grok.shell.o = DG.SemanticValue.fromTableCell(cell);
       });
@@ -255,7 +255,7 @@ test('BiostructureViewer / context-panel widgets extension (3D Structure / PDB I
       const surface = await page.evaluate(async () => {
         // Force the context panel visible: the baseline sets simpleMode=true which hides it,
         // and the accordion panes ([name="pane-*"]) only render into a shown context panel.
-        grok.shell.windows.showProperties = true;
+        grok.shell.windows.showContextPanel = true;
         const cell = grok.shell.tv.dataFrame.cell(0, 'structure');
         grok.shell.o = DG.SemanticValue.fromTableCell(cell);
         // Live-confirm the gating predicate on the fixture.
@@ -344,7 +344,7 @@ test('BiostructureViewer / context-panel widgets extension (3D Structure / PDB I
     await softStep('Scenario 4 Path C — ProLIF panel (PDB_ID) renders pdbIdInteractionsWidget via RCSB fetchProxy', async () => {
       await page.evaluate(() => {
         // Context panel must be shown for the accordion panes to render (see scenario 1).
-        grok.shell.windows.showProperties = true;
+        grok.shell.windows.showContextPanel = true;
         const cell = grok.shell.tv.dataFrame.cell(0, 'pdb_id');
         grok.shell.o = DG.SemanticValue.fromTableCell(cell);
       });

--- a/packages/BiostructureViewer/playwright/ngl-viewer-extension.test.ts
+++ b/packages/BiostructureViewer/playwright/ngl-viewer-extension.test.ts
@@ -566,7 +566,7 @@ test('BiostructureViewer / NGL viewer extension (mount + props + file-routing + 
         // Force the context panel visible and set the current object explicitly to the PDB_ID
         // cell: the baseline sets simpleMode=true (hides the context panel), and the semantic
         // panes only surface into a shown panel driven by grok.shell.o.
-        grok.shell.windows.showProperties = true;
+        grok.shell.windows.showContextPanel = true;
         try { grok.shell.o = DG.SemanticValue.fromTableCell(df.cell(0, 'pdb_id')); } catch (_) { /* fall back to currentCell */ }
         await pollUntil(() => df.currentRowIdx === 0);
         return {

--- a/packages/BiostructureViewer/src/biostructure-viewer.ts
+++ b/packages/BiostructureViewer/src/biostructure-viewer.ts
@@ -53,7 +53,7 @@ export class BioStructureViewer {
       }
     });
 
-    grok.shell.windows.showProperties = false;
+    grok.shell.windows.showContextPanel = false;
     grok.shell.windows.showHelp = false;
     this.bsView.ribbonMenu.clear();
   };

--- a/packages/BiostructureViewer/src/demo/bio06-docking-ngl-old.ts
+++ b/packages/BiostructureViewer/src/demo/bio06-docking-ngl-old.ts
@@ -58,7 +58,7 @@ export async function demoBio06UI(): Promise<void> {
     )
       .step('Loading ligands', async () => {
         grok.shell.windows.showContextPanel = false;
-        grok.shell.windows.showProperties = false;
+        grok.shell.windows.showContextPanel = false;
 
         const sdfBytes: Uint8Array = await _package.files.readAsBytes(ligandsDataFn);
         df = (await grok.functions.call(

--- a/packages/BiostructureViewer/src/demo/bio06-docking-ngl.ts
+++ b/packages/BiostructureViewer/src/demo/bio06-docking-ngl.ts
@@ -79,7 +79,7 @@ export async function demoBio06UI(): Promise<void> {
     )
       .step('Loading ligands', async () => {
         grok.shell.windows.showContextPanel = false;
-        grok.shell.windows.showProperties = false;
+        grok.shell.windows.showContextPanel = false;
 
         const sdfBytes: Uint8Array = await _package.files.readAsBytes(ligandsDataFn);
         df = (await grok.functions.call(

--- a/packages/BiostructureViewer/src/demo/bio07-molecule3d-in-grid.ts
+++ b/packages/BiostructureViewer/src/demo/bio07-molecule3d-in-grid.ts
@@ -17,7 +17,7 @@ export async function demoBio07NoScript(): Promise<void> {
   const pi = DG.TaskBarProgressIndicator.create('Demo Proteins ...');
   try {
     grok.shell.windows.showContextPanel = false;
-    grok.shell.windows.showProperties = false;
+    grok.shell.windows.showContextPanel = false;
 
     let csv: string;
     let df: DG.DataFrame;
@@ -73,7 +73,7 @@ export async function demoBio07UI(): Promise<void> {
     )
       .step('Loading structures', async () => {
         grok.shell.windows.showContextPanel = false;
-        grok.shell.windows.showProperties = false;
+        grok.shell.windows.showContextPanel = false;
 
         df = await _package.files.readCsv(pdbCsvFn);
         view = grok.shell.addTableView(df);

--- a/packages/BiostructureViewer/src/package.ts
+++ b/packages/BiostructureViewer/src/package.ts
@@ -861,7 +861,7 @@ export class PackageFunctions {
     const widget = new DG.Widget(ui.div([]));
     widget.root.append(ui.loader());
     const {dataFrame, column, rowIndex} = molecule.cell;
-    const tableView = grok.shell.getTableView(dataFrame.name);
+    const tableView = grok.shell.tableView(dataFrame.name);
     const {grid} = tableView;
     const gridCell = grid.cell(column.name, rowIndex);
     const renderer = new PdbGridCellRendererBack(null, column);

--- a/packages/BiostructureViewer/src/utils/mol3d-link.ts
+++ b/packages/BiostructureViewer/src/utils/mol3d-link.ts
@@ -82,7 +82,7 @@ export function clearAtomPickerHighlights(smilesCol: DG.Column): void {
     });
     const dfName = smilesCol.dataFrame?.name;
     if (dfName) {
-      const tv = grok.shell.getTableView(dfName);
+      const tv = grok.shell.tableView(dfName);
       tv?.grid?.invalidate();
     }
   } catch (err: unknown) {

--- a/packages/BiostructureViewer/src/utils/prolif.ts
+++ b/packages/BiostructureViewer/src/utils/prolif.ts
@@ -301,7 +301,7 @@ function _dropPriorPlColumns(df: DG.DataFrame): void {
 // finishes. The actual cell rendering is handled by PowerGrid's built-in
 // `RawPNGRenderer` (semType `rawPng`), registered platform-wide via PowerGrid.
 // Look up the TableView by exact DataFrame reference rather than by name —
-// `grok.shell.getTableView(df.name)` returns the wrong view if multiple
+// `grok.shell.tableView(df.name)` returns the wrong view if multiple
 // TableViews share a name (the platform allows duplicates).
 function _adjustGridForDiagrams(df: DG.DataFrame, colNames: string[]): void {
   const tv = Array.from(grok.shell.tableViews).find((v) => v.dataFrame?.id === df?.id);

--- a/packages/BiostructureViewer/src/viewers/twin-p-cells.ts
+++ b/packages/BiostructureViewer/src/viewers/twin-p-cells.ts
@@ -34,7 +34,7 @@ export class TwinProteinView {
   public init(entry: string, bsView: DG.TableView, ligandSelection: { [key: string]: boolean }) {
     // ---- SIDEPANEL REMOVAL ----
     const windows = grok.shell.windows;
-    windows.showProperties = false;
+    windows.showContextPanel = false;
     windows.showHelp = false;
     windows.showConsole = false;
     this.entry = entry;

--- a/packages/BiostructureViewer/src/viewers/twin-p-viewer.ts
+++ b/packages/BiostructureViewer/src/viewers/twin-p-viewer.ts
@@ -36,7 +36,7 @@ export class TwinPviewer {
   public init(entry: string, bsView: DG.TableView, ligandSelection: { [key: string]: boolean }, chains: any) {
     // ---- SIDEPANEL REMOVAL ----
     const windows = grok.shell.windows;
-    windows.showProperties = false;
+    windows.showContextPanel = false;
     windows.showHelp = false;
     windows.showConsole = false;
     this.entry = entry;

--- a/packages/CVMTests/scripts/js/file_test.js
+++ b/packages/CVMTests/scripts/js/file_test.js
@@ -7,6 +7,6 @@
 //input: string dec = "."
 //condition: file.isFile && file.name.endsWith("csv")
 //output: int num_lines
-let data = await new DG.FileSource().readAsText('System:AppData/' + file.path);
+let data = await new DG.FilesDataSource().readAsText('System:AppData/' + file.path);
 let d = await DG.DataFrame.fromCsv(data, {delimiter: separator, decimalSeparator: dec, headerRow: header});
 let num_lines = d.rowCount;

--- a/packages/Chem/src/analysis/chem-search-base-viewer.ts
+++ b/packages/Chem/src/analysis/chem-search-base-viewer.ts
@@ -123,8 +123,8 @@ export class ChemSearchBaseViewer extends DG.JsViewer {
 
   updateMetricsLink(object: any, options: {[key: string]: string}): void {
     const metricsButton = ui.link(` ${this.distanceMetric}, ${this.fingerprint}`, () => {
-      if (!grok.shell.windows.showProperties)
-        grok.shell.windows.showProperties = true;
+      if (!grok.shell.windows.showContextPanel)
+        grok.shell.windows.showContextPanel = true;
       grok.shell.o = object;
     }, 'Distance metric and fingerprint', '');
     Object.keys(options).forEach((it: any) => metricsButton.style[it] = options[it]);

--- a/packages/Chem/src/analysis/molecular-matched-pairs/mmp-viewer/mmp-viewer.ts
+++ b/packages/Chem/src/analysis/molecular-matched-pairs/mmp-viewer/mmp-viewer.ts
@@ -216,7 +216,7 @@ export class MatchedMolecularPairsViewer extends DG.JsViewer {
     const decript3 = 'Molecule pairs analysis on 2d scatter plot';
     const decript4 = 'Generation of molecules based on obtained rules';
 
-    const tabs = ui.tabControl(null, false);
+    const tabs = ui.tabControl(null, {vertical: false});
 
     const transformationsTab = tabs.addPane(MMP_NAMES.TAB_TRANSFORMATIONS, () => {
       return this.getTransformationsTab();

--- a/packages/Chem/src/analysis/mpo.ts
+++ b/packages/Chem/src/analysis/mpo.ts
@@ -245,7 +245,7 @@ export class MpoProfileDialog {
   }
 
   private async createDataDrivenProfile(): Promise<void> {
-    const tableView = grok.shell.getTableView(this.dataFrame.name);
+    const tableView = grok.shell.tableView(this.dataFrame.name);
     if (!tableView) {
       grok.shell.error('No table view found for the current dataframe');
       return;
@@ -366,7 +366,7 @@ export class MpoProfileDialog {
   private addParetoFrontViewer(columnNames: string[]): void {
     if (!isEdaPackageInstalled())
       return;
-    const view = grok.shell.getTableView(this.dataFrame.name);
+    const view = grok.shell.tableView(this.dataFrame.name);
     const paretoFrontViewer = DG.Viewer.fromType('Pareto front', this.dataFrame);
     view.addViewer(paretoFrontViewer);
 
@@ -407,7 +407,7 @@ export class MpoProfileDialog {
   }
 
   private addRadarInCellViewer(desirabilityColumnNames: string[]): void {
-    const view = grok.shell.getTableView(this.dataFrame.name);
+    const view = grok.shell.tableView(this.dataFrame.name);
     if (!checkPackage('PowerGrid', 'radarCellRenderer')) {
       grok.shell.warning('PowerGrid package is not installed');
       return;

--- a/packages/Chem/src/analysis/r-group-analysis.ts
+++ b/packages/Chem/src/analysis/r-group-analysis.ts
@@ -179,7 +179,7 @@ export function rGroupAnalysis(col: DG.Column): void {
         }).call(undefined, undefined, {processed: false});
         const res: RGroupDecompRes = funcCall.getOutputParamValue();
         if (res) {
-          const view = grok.shell.getTableView(col.dataFrame.name);
+          const view = grok.shell.tableView(col.dataFrame.name);
           //make highlight column invisible
           if (res.highlightColName)
             view.grid.col(res.highlightColName)!.visible = false;

--- a/packages/Chem/src/analysis/sar-matrix/sar-matrix-viewer.ts
+++ b/packages/Chem/src/analysis/sar-matrix/sar-matrix-viewer.ts
@@ -280,7 +280,7 @@ export class SarMatrixViewer extends DG.JsViewer {
     this.host.addEventListener('contextmenu', () => this.contextCell = null, true);
 
     // Transfer detection is quadratic in the total row count, so that tab computes on first open.
-    this.tabs = ui.tabControl(null, false);
+    this.tabs = ui.tabControl(null, {vertical: false});
     const matrixPane = this.tabs.addPane(TAB_MATRIX, () => this.host);
     ui.tooltip.bind(matrixPane.header, 'Core × substituent potency matrices, one per series');
     const transferPane = this.tabs.addPane(TAB_TRANSFER, () => this.transferPanel.root);

--- a/packages/Chem/src/descriptors/descriptors-calculation.ts
+++ b/packages/Chem/src/descriptors/descriptors-calculation.ts
@@ -199,7 +199,7 @@ export function getDescriptorsApp(): void {
   const windows = grok.shell.windows;
   windows.showToolbox = false;
   windows.showHelp = false;
-  windows.showProperties = false;
+  windows.showContextPanel = false;
 
   let table = DG.DataFrame.create();
   table.name = 'Descriptors';
@@ -242,7 +242,7 @@ export function getDescriptorsApp(): void {
     if (v.name === view.name) {
       windows.showToolbox = true;
       windows.showHelp = true;
-      windows.showProperties = true;
+      windows.showContextPanel = true;
     }
   });
 }

--- a/packages/Chem/src/mpo/mpo-profiles-view.ts
+++ b/packages/Chem/src/mpo/mpo-profiles-view.ts
@@ -34,7 +34,7 @@ export class MpoProfilesView {
     this.view = DG.View.fromRoot(this.root);
     this.view.name = this.name;
     grok.shell.windows.showHelp = false;
-    grok.shell.windows.showProperties = true;
+    grok.shell.windows.showContextPanel = true;
     updateMpoPath(this.view, MpoPathMode.List);
     attachMpoProfilesAi(this);
   }

--- a/packages/Chem/src/package.ts
+++ b/packages/Chem/src/package.ts
@@ -200,7 +200,7 @@ let mpoTreeBrowserSub: Subscription | null = null;
 async function initChemInt(): Promise<void> {
   chemCommonRdKit.setRdKitWebRoot(_package.webRoot);
   await chemCommonRdKit.initRdKitModuleLocal();
-  _properties = await _package.getProperties();
+  _properties = _package.settings;
   _rdRenderer = new RDKitCellRenderer(PackageFunctions.getRdKitModule());
   renderer = new GridCellRendererProxy(_rdRenderer, 'Molecule');
   let storedSketcherType = grok.userSettings.getValue(DG.chem.STORAGE_NAME, DG.chem.KEY) ?? '';

--- a/packages/Chem/src/utils/demo-utils.ts
+++ b/packages/Chem/src/utils/demo-utils.ts
@@ -63,7 +63,7 @@ export function closeAllAccordionPanes(parent: Element) {
 
 export async function openMoleculeDataset(name: string): Promise<DG.TableView> {
   const table = DG.DataFrame.fromCsv(await _package.files.readAsText(name));
-  grok.shell.windows.showProperties = true;
+  grok.shell.windows.showContextPanel = true;
   return grok.shell.addTableView(table);
 }
 

--- a/packages/Chem/src/utils/reaction-enumeration/data-panel.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/data-panel.ts
@@ -288,7 +288,7 @@ export class DataPanel {
     this.stepTabsHost.innerHTML = '';
     this.stepDots.length = 0;
     this.paneHosts = [];
-    const tc = ui.tabControl(null, false);
+    const tc = ui.tabControl(null, {vertical: false});
     tc.root.style.width = '100%';
     tc.root.style.flex = '1 1 0';
     tc.root.style.minHeight = '0';

--- a/packages/Chem/src/utils/reaction-enumeration/default-files.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/default-files.ts
@@ -59,7 +59,7 @@ export interface EnumerationDefaultTables {
 export async function loadEnumerationDefaults(): Promise<EnumerationDefaultTables> {
   let settings: any = {};
   try {
-    settings = await _package.getProperties() ?? {};
+    settings = _package.settings ?? {};
   } catch (e) {
     _package.logger.debug(`Could not read Chem settings, using bundled enumeration files: ${e}`);
   }

--- a/packages/Chem/src/utils/reaction-enumeration/enumerator-app.ts
+++ b/packages/Chem/src/utils/reaction-enumeration/enumerator-app.ts
@@ -155,7 +155,7 @@ export async function buildEnumeratorView(): Promise<DG.ViewBase> {
     buildPerRoundOverrides, refreshValidation: () => ctx.refreshValidation(),
   });
 
-  const tabs = ui.tabControl(null, false);
+  const tabs = ui.tabControl(null, {vertical: false});
   tabs.root.style.width = '100%';
   tabs.root.style.flex = '1 1 0';
   tabs.root.style.minHeight = '0';

--- a/packages/Chem/src/utils/sdf-utils.ts
+++ b/packages/Chem/src/utils/sdf-utils.ts
@@ -76,7 +76,7 @@ export async function getSdfString(
   const maskedTable = mask.anyFalse ? table.clone(mask) : table;
 
   const grid = grok.shell.tv != null && grok.shell.tv.dataFrame === table ? grok.shell.tv.grid :
-    table.name && grok.shell.getTableView(table.name) ? grok.shell.getTableView(table.name).grid : null;
+    table.name && grok.shell.tableView(table.name) ? grok.shell.tableView(table.name).grid : null;
   const selectedCols = Array.from(exportOptions.selectedColumnsOnly ? table.columns.selected : table.columns);
   const visibleCols = (exportOptions.visibleColumnsOnly && grid != null ? selectedCols.filter((col) => {
     const gridCol = grid.columns.byName(col.name);

--- a/packages/Chem/src/widgets/biochem-properties-widget.ts
+++ b/packages/Chem/src/widgets/biochem-properties-widget.ts
@@ -79,7 +79,7 @@ export async function biochemicalPropertiesDialog(): Promise<void> {
   const desanitizeValue = (value: any): any => {
     if (value && value._type) {
       if (value._type === 'column' && table) return table.col(value.name);
-      if (value._type === 'dataframe') return grok.shell.tableByName(value.name);
+      if (value._type === 'dataframe') return grok.shell.table(value.name);
     }
     return value;
   };

--- a/packages/Chem/src/widgets/scaffold-tree.ts
+++ b/packages/Chem/src/widgets/scaffold-tree.ts
@@ -1869,7 +1869,7 @@ export class ScaffoldTreeViewer extends DG.JsViewer {
     }
 
     if (isNew) {
-      const gridColumn = grok.shell.getTableView(this.dataFrame!.name)?.grid.columns.byName(columnName);
+      const gridColumn = grok.shell.tableView(this.dataFrame!.name)?.grid.columns.byName(columnName);
       if (gridColumn) {
         gridColumn.visible = !hidden;
         gridColumn.isTextColorCoded = !hidden;
@@ -2578,7 +2578,7 @@ export class ScaffoldTreeViewer extends DG.JsViewer {
     this.subs.push(grok.events.onViewRemoving.subscribe((eventData) => {
       const eventView = eventData.args.view;
       if (this.dataFrame.name) {
-        const currentView = grok.shell.getTableView(this.dataFrame.name);
+        const currentView = grok.shell.tableView(this.dataFrame.name);
         if (eventView && currentView && eventView.id === currentView.id)
           this.closeAll = true;
       }

--- a/packages/ClinicalCase/package-lock.json
+++ b/packages/ClinicalCase/package-lock.json
@@ -13,7 +13,7 @@
         "@datagrok-libraries/utils": "^4.7.0",
         "@datagrok/charts": "^1.5.1",
         "cash-dom": "^8.1.5",
-        "datagrok-api": "^1.27.0",
+        "datagrok-api": "^1.27.11",
         "dayjs": "^1.11.13",
         "jstat": "^1.9.5",
         "moment": "^2.29.1",
@@ -62,7 +62,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1160,7 +1159,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1614,7 +1612,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2399,7 +2396,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3723,7 +3719,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3863,9 +3858,10 @@
       }
     },
     "node_modules/datagrok-api": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/datagrok-api/-/datagrok-api-1.27.0.tgz",
-      "integrity": "sha512-OLryeXSkXrpjw6WFS/aRsTBY+Zr8MgNqW/Ww8rPwDke1l/3LWqyPzcLU+TGB2GFHh/pmaL+qN+xzObvC1livrA==",
+      "version": "1.27.11",
+      "resolved": "https://registry.npmjs.org/datagrok-api/-/datagrok-api-1.27.11.tgz",
+      "integrity": "sha512-AuPEpU3eeTTibZAkTlP5wGyWM7Lqj8OiAHWTe5P2JQAy9ia/3rk7JSVyhV9QDhgk9j8SLeta2NgQgHTjVCRo9g==",
+      "deprecated": "Published ahead of the core release; use the datagrok-api",
       "dependencies": {
         "@babel/core": "^7.27.1",
         "@datagrok-libraries/chem-meta": "^1.0.12",
@@ -4126,8 +4122,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz",
       "integrity": "sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -4220,7 +4215,6 @@
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
       "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "6.1.0"
@@ -4408,7 +4402,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7041,7 +7034,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -7237,7 +7229,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
         "cosmiconfig": "9.0.0",
@@ -7719,7 +7710,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8269,8 +8259,7 @@
       "version": "0.154.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.154.0.tgz",
       "integrity": "sha512-Uzz8C/5GesJzv8i+Y2prEMYUwodwZySPcNhuJUdsVMH2Yn4Nm8qlbQe6qRN5fOhg55XB0WiLfTPBxVHxpE60ug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-conic-polygon-geometry": {
       "version": "1.6.6",
@@ -8409,7 +8398,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8617,7 +8605,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8821,7 +8808,6 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -8871,7 +8857,6 @@
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",

--- a/packages/ClinicalCase/package.json
+++ b/packages/ClinicalCase/package.json
@@ -14,16 +14,16 @@
   },
   "dependencies": {
     "@datagrok-libraries/statistics": "^0.1.7",
+    "@datagrok-libraries/test": "^1.1.0",
     "@datagrok-libraries/utils": "^4.7.0",
     "@datagrok/charts": "^1.5.1",
     "cash-dom": "^8.1.5",
-    "datagrok-api": "^1.27.0",
+    "datagrok-api": "^1.27.11",
+    "dayjs": "^1.11.13",
     "jstat": "^1.9.5",
     "moment": "^2.29.1",
     "rxjs": "^6.5.5",
-    "x2js": "^3.4.4",
-    "dayjs": "^1.11.13",
-    "@datagrok-libraries/test": "^1.1.0"
+    "x2js": "^3.4.4"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.32.0",

--- a/packages/ClinicalCase/src/views/laboratory-view.ts
+++ b/packages/ClinicalCase/src/views/laboratory-view.ts
@@ -90,7 +90,7 @@ export class LaboratoryView extends ClinicalCaseViewBase {
 
     this.root.className = 'grok-view ui-box';
 
-    const tabControl = ui.tabControl(null, false);
+    const tabControl = ui.tabControl(null, {vertical: false});
 
     const distributionCreated = checkColumnsAndCreateViewer(
       studies[this.studyId].domains.lb,

--- a/packages/ClinicalCase/src/views/survival-analysis-view.ts
+++ b/packages/ClinicalCase/src/views/survival-analysis-view.ts
@@ -83,7 +83,7 @@ export class SurvivalAnalysisView extends ClinicalCaseViewBase {
 
     const guide = ui.info(SURVIVAL_ANALYSIS_GUIDE, 'Survival Analysis Quick Guide', false);
 
-    this.tabControl = ui.tabControl(null, false);
+    this.tabControl = ui.tabControl(null, {vertical: false});
     this.tabControl.addPane('Dataset', () =>
       ui.splitV([
         ui.splitH([

--- a/packages/ClinicalCase/src/views/validation-view.ts
+++ b/packages/ClinicalCase/src/views/validation-view.ts
@@ -38,7 +38,7 @@ export class ValidationView extends ClinicalCaseViewBase {
       return;
     }
 
-    const tabControl = ui.tabControl(null, false);
+    const tabControl = ui.tabControl(null, {vertical: false});
 
     // Conformance_Details tab - use ui.tableFromMap
     if (validationResults.Conformance_Details) {

--- a/packages/DBTests/src/connections/queries-test.ts
+++ b/packages/DBTests/src/connections/queries-test.ts
@@ -27,7 +27,7 @@ category('Connections', () => {
   }, {stressTest: true});
 
   test('External Provider: grok.data.query no params', async () => {
-    const result: DG.DataFrame = await grok.data.query('DbTests:PostgresqlPatternsAll', null, true);
+    const result: DG.DataFrame = await grok.data.query('DbTests:PostgresqlPatternsAll', null);
     expect(result?.rowCount ?? 0, 30);
   }, {stressTest: true});
 

--- a/packages/Dendrogram/playwright/hierarchical-clustering-chem-api.test.ts
+++ b/packages/Dendrogram/playwright/hierarchical-clustering-chem-api.test.ts
@@ -217,12 +217,12 @@ test('Dendrogram / Hierarchical Clustering (chem) — Distance × Linkage matrix
       const sliced = tmp.clone(sliceFilter);
       sliced.name = 'mol1K_slice60';
       // Open a TableView — the registered Dendrogram:hierarchicalClustering
-      // function calls `grok.shell.getTableView(df.name)` (hierarchical-
+      // function calls `grok.shell.tableView(df.name)` (hierarchical-
       // clustering.ts:96) and throws "TableView has no grid" without one.
       grok.shell.closeAll();
       for (let i = 0; i < 50 && grok.shell.tableViews.length > 0; i++) await new Promise(r => setTimeout(r, 100));
       grok.shell.addTableView(sliced);
-      for (let i = 0; i < 100 && !grok.shell.getTableView('mol1K_slice60')?.grid; i++) await new Promise(r => setTimeout(r, 100));
+      for (let i = 0; i < 100 && !grok.shell.tableView('mol1K_slice60')?.grid; i++) await new Promise(r => setTimeout(r, 100));
       return {rows: sliced.rowCount, molSemType: sliced.col('molecule')?.semType};
     });
     expect(slice.rows, 'slice row count').toBeGreaterThanOrEqual(50);

--- a/packages/Dendrogram/src/tests/hierarchical-clustering-tests.ts
+++ b/packages/Dendrogram/src/tests/hierarchical-clustering-tests.ts
@@ -93,7 +93,7 @@ category('hierarchicalClustering', () => {
     const dataDf: DG.DataFrame = DG.DataFrame.fromCsv('a,b\n1,2\n2,3\n3,4\n4,5');
     dataDf.name = 'testHCUnattached';
     await hierarchicalClusteringUI(dataDf, ['a', 'b'], DistanceMetric.Euclidean, 'average');
-    const tv: DG.TableView = grok.shell.getTableView(dataDf.name);
+    const tv: DG.TableView = grok.shell.tableView(dataDf.name);
     expect(tv != null, true);
     tv.close();
   });

--- a/packages/Dendrogram/src/utils/hierarchical-clustering.ts
+++ b/packages/Dendrogram/src/utils/hierarchical-clustering.ts
@@ -97,7 +97,7 @@ export async function hierarchicalClusteringUI(
     hierarchicalClusteringFilterDfForNulls(df, colNameSet);
   const th: ITreeHelper = new TreeHelper();
 
-  let tv: DG.TableView = options ? options.tableView ?? grok.shell.getTableView(df.name) : grok.shell.getTableView(df.name);
+  let tv: DG.TableView = options ? options.tableView ?? grok.shell.tableView(df.name) : grok.shell.tableView(df.name);
   if (filteredDf.rowCount != df.rowCount) {
     grok.shell.warning('Hierarchical clustering analysis on data filtered out for nulls.');
     tv = grok.shell.addTableView(filteredDf);

--- a/packages/DevTools/src/script-editor.ts
+++ b/packages/DevTools/src/script-editor.ts
@@ -26,7 +26,7 @@ function setScriptRibbon(v: DG.View, doc: any) {
   const viewsMenu = () => {
     const addView = (item) => {
       const cursor = doc.getCursor();
-      const template = `//name: ${item}\n//language: javascript\nlet windows = grok.shell.windows;\nwindows.showToolbox = false;\nwindows.showProperties = false;\nwindows.showHelp = false;\n`;
+      const template = `//name: ${item}\n//language: javascript\nlet windows = grok.shell.windows;\nwindows.showToolbox = false;\nwindows.showContextPanel = false;\nwindows.showHelp = false;\n`;
       switch (item) {
       case 'Simple View':
         doc.replaceRange('grok.shell.newView(\'New view\',[])\n', cursor);

--- a/packages/DevTools/src/tests/dev-panel-test.ts
+++ b/packages/DevTools/src/tests/dev-panel-test.ts
@@ -8,7 +8,7 @@ category('Dev panel', () => {
   const subs = [];
   const delayDuration = 1000;
   const entities: EntityType[] = [];
-  const showPropertyPanel = grok.shell.windows.showProperties;
+  const showPropertyPanel = grok.shell.windows.showContextPanel;
   let currentEntity: EntityType;
   let devPane: DG.AccordionPane;
 
@@ -28,7 +28,7 @@ category('Dev panel', () => {
       df.col('age'),
       DG.View.create(),
     ].filter((ent) => ent != null));
-    grok.shell.windows.showProperties = true;
+    grok.shell.windows.showContextPanel = true;
   });
 
   test('Dev panel opens', () => new Promise(async (resolve, reject) => {
@@ -97,6 +97,6 @@ category('Dev panel', () => {
 
   after(async () => {
     subs.forEach((sub) => sub.unsubscribe());
-    grok.shell.windows.showProperties = showPropertyPanel;
+    grok.shell.windows.showContextPanel = showPropertyPanel;
   });
 });

--- a/packages/DiffStudio/src/app.ts
+++ b/packages/DiffStudio/src/app.ts
@@ -375,7 +375,7 @@ export class DiffStudio {
     grok.shell.windows.help.showHelp(divHelp);
     grok.shell.windows.context.visible = true;
     grok.shell.windows.showContextPanel = false;
-    grok.shell.windows.showProperties = false;
+    grok.shell.windows.showContextPanel = false;
     grok.shell.windows.help.visible = true;
     await this.runSolving();
   } // runSolverDemoApp

--- a/packages/DiffStudio/src/hub.ts
+++ b/packages/DiffStudio/src/hub.ts
@@ -30,7 +30,7 @@ export class DiffStudioHub {
     this.view.name = this.name;
     this.view.helpUrl = LINK.DIF_STUDIO_REL;
     grok.shell.windows.showHelp = false;
-    grok.shell.windows.showProperties = false;
+    grok.shell.windows.showContextPanel = false;
   }
 
   /** Render the full hub view */

--- a/packages/DiffStudio/src/model.ts
+++ b/packages/DiffStudio/src/model.ts
@@ -35,7 +35,7 @@ export class Model {
     grok.shell.windows.help.showHelp(divHelp);
     grok.shell.windows.context.visible = true;
     grok.shell.windows.showContextPanel = false;
-    grok.shell.windows.showProperties = false;
+    grok.shell.windows.showContextPanel = false;
     grok.shell.windows.help.visible = true;
   }
 

--- a/packages/Docking/src/demo/demo.ts
+++ b/packages/Docking/src/demo/demo.ts
@@ -5,7 +5,7 @@ import {_package} from '../utils/constants';
 
 export async function openMoleculeDataset(name: string): Promise<DG.TableView> {
   const table = DG.DataFrame.fromCsv(await grok.dapi.files.readAsText(name));
-  grok.shell.windows.showProperties = true;
+  grok.shell.windows.showContextPanel = true;
   return grok.shell.addTableView(table);
 }
 
@@ -14,7 +14,7 @@ export function showHelpPanel(): void {
   grok.shell.windows.help.showHelp('/help/develop/domains/chem/docking');
   grok.shell.windows.context.visible = true;
   grok.shell.windows.showContextPanel = true;
-  grok.shell.windows.showProperties = true;
+  grok.shell.windows.showContextPanel = true;
 }
 
 export async function _demoDocking(): Promise<void> {

--- a/packages/Docking/src/package.ts
+++ b/packages/Docking/src/package.ts
@@ -143,7 +143,7 @@ export class PackageFunctions{
       if (!BINDING_ENERGY_COL_UNUSED || !POSE_COL_UNUSED)
         return;
 
-      const {grid} = grok.shell.getTableView(table.name);
+      const {grid} = grok.shell.tableView(table.name);
 
       addColorCoding(grid.columns.byName(BINDING_ENERGY_COL_UNUSED)!);
       grid.sort([BINDING_ENERGY_COL_UNUSED]);

--- a/packages/EDA/src/anova/anova-ui.ts
+++ b/packages/EDA/src/anova/anova-ui.ts
@@ -72,7 +72,7 @@ function pValueColumnFormat(p: number): string {
 /** Add one-way ANOVA results. When `showReport` is false, only the box plot is shown (no results table). */
 function addVizualization(df: DG.DataFrame, factorsName: string, featuresName: string,
   report: OneWayAnovaReport, showReport: boolean): void {
-  const view = grok.shell.getTableView(df.name);
+  const view = grok.shell.tableView(df.name);
   grok.shell.v = view;
 
   const test = report.anovaTable.fStat > report.fCritical;
@@ -387,7 +387,7 @@ export function runOneWayAnova(): void {
   });
 
   const dlg = ui.dialog({title: 'ANOVA', helpUrl: ANOVA_HELP_URL});
-  const view = grok.shell.getTableView(df.name);
+  const view = grok.shell.tableView(df.name);
   view.root.appendChild(dlg.root);
   dlg.addButton('Run', () => {
     dlg.close();

--- a/packages/EDA/src/control-comparisons/control-comparisons-ui.ts
+++ b/packages/EDA/src/control-comparisons/control-comparisons-ui.ts
@@ -221,7 +221,7 @@ function getControlComparisonsGrid(report: ControlComparisonsReport, factor: DG.
 /** Box plot docked right + (optionally) the titled results grid docked below. */
 function addVisualization(df: DG.DataFrame, factor: DG.Column, feature: DG.Column,
   report: ControlComparisonsReport, showReport: boolean): void {
-  const view = grok.shell.getTableView(df.name);
+  const view = grok.shell.tableView(df.name);
   grok.shell.v = view;
 
   const controlLabel = labelOf(factor, report.controlCode);
@@ -392,7 +392,7 @@ export function runControlComparisons(): void {
 
 
   const dlg = ui.dialog({title: 'Control comparisons', helpUrl: HELP_URL});
-  const view = grok.shell.getTableView(df.name);
+  const view = grok.shell.tableView(df.name);
   view.root.appendChild(dlg.root);
 
   dlg.addButton('Run', () => {

--- a/packages/EDA/src/pareto-optimization/pareto-front-viewer.ts
+++ b/packages/EDA/src/pareto-optimization/pareto-front-viewer.ts
@@ -224,7 +224,7 @@ export class ParetoFrontViewer extends DG.JsViewer {
   } // computeParetoFront
 
   private markResColWithColor(col: DG.Column): void {
-    col.colors.setCategorical({
+    col.meta.colors.setCategorical({
       'optimal': '#2ca02c',
       'non-optimal': '#e3e3e3',
     });

--- a/packages/EDA/src/pareto-optimization/pareto-optimizer.ts
+++ b/packages/EDA/src/pareto-optimization/pareto-optimizer.ts
@@ -33,7 +33,7 @@ export class ParetoOptimizer {
     this.numColNames = this.numCols.map((col) => col.name);
     this.numColsCount = this.numCols.length;
     this.rowCount = df.rowCount;
-    this.view = grok.shell.getTableView(df.name);
+    this.view = grok.shell.tableView(df.name);
 
     this.paretoFrontViewer = DG.Viewer.fromType('Pareto front', df);
 
@@ -92,7 +92,7 @@ export class ParetoOptimizer {
           this.inputFormNode = null;
         }
 
-        this.numCols.forEach((col) => col.colors.setDisabled());
+        this.numCols.forEach((col) => col.meta.colors.setDisabled());
         this.features.clear();
       }),
     ];
@@ -212,7 +212,7 @@ export class ParetoOptimizer {
   }
 
   private markOptColsWithColor(): void {
-    this.numCols.forEach((col) => col.colors.setDisabled());
+    this.numCols.forEach((col) => col.meta.colors.setDisabled());
 
     this.features.forEach((fea, name) => {
       if (!fea.toOptimize)
@@ -221,7 +221,7 @@ export class ParetoOptimizer {
       const col = this.df.col(name);
 
       if (col != null)
-        col.colors.setLinear(getOutputPalette(fea.optType), {min: col.stats.min, max: col.stats.max});
+        col.meta.colors.setLinear(getOutputPalette(fea.optType), {min: col.stats.min, max: col.stats.max});
     });
   } // markOptColsWithColor
 

--- a/packages/EDA/src/pls/pls-tools.ts
+++ b/packages/EDA/src/pls/pls-tools.ts
@@ -377,8 +377,8 @@ export async function addMvaResults(input: PlsInput, names: MvaNames, components
 function addMvaViewers(input: MvaInput, names: MvaNames, analysisType: PLS_ANALYSIS): void {
   const sourceTable = input.table;
   const view = grok.shell.tableView(sourceTable.name);
-  const loadingsRegrCoefsTable = grok.shell.tableByName(names.analysisTable);
-  const explVarsDF = grok.shell.tableByName(names.explVarTable);
+  const loadingsRegrCoefsTable = grok.shell.table(names.analysisTable);
+  const explVarsDF = grok.shell.table(names.explVarTable);
   const model: MvaModel = JSON.parse(sourceTable.getTag(MVA_MODEL_TAG)!);
 
   // 1. Predicted vs Reference scatter plot
@@ -740,7 +740,7 @@ export async function runDemoMVA(): Promise<void> {
   grok.shell.windows.help.visible = true;
   grok.shell.windows.help.showHelp(ui.markdown(DEMO_INTRO_MD));
   grok.shell.windows.showContextPanel = false;
-  grok.shell.windows.showProperties = false;
+  grok.shell.windows.showContextPanel = false;
 
   const cols = table.columns.toList();
   const numCols = cols.filter((col) =>

--- a/packages/EDA/src/probabilistic-scoring/pmpo-utils.ts
+++ b/packages/EDA/src/probabilistic-scoring/pmpo-utils.ts
@@ -116,7 +116,7 @@ export function addSelectedDescriptorsCol(descrStats: DG.DataFrame, selected: st
     colors[descr[i]] = res ? COLORS.SELECTED : COLORS.SKIPPED;
   }
 
-  descrCol.colors.setCategorical(colors);
+  descrCol.meta.colors.setCategorical(colors);
 
   // Added selected column
   descrStats.columns.add(DG.Column.fromList(DG.COLUMN_TYPE.BOOL, SELECTED_TITLE, selArr));

--- a/packages/EDA/src/probabilistic-scoring/prob-scoring.ts
+++ b/packages/EDA/src/probabilistic-scoring/prob-scoring.ts
@@ -637,7 +637,7 @@ export class Pmpo {
     this.setNulls(prediction, indecesOfMissingVals);
 
     // Mark predictions with a color
-    prediction.colors.setLinear(getOutputPalette(OPT_TYPE.MAX), {min: prediction.stats.min, max: prediction.stats.max});
+    prediction.meta.colors.setLinear(getOutputPalette(OPT_TYPE.MAX), {min: prediction.stats.min, max: prediction.stats.max});
 
     // Remove existing prediction column and add the new one
     df.columns.remove(this.predictionName);

--- a/packages/EDA/src/tests/mva-project-tests.ts
+++ b/packages/EDA/src/tests/mva-project-tests.ts
@@ -65,7 +65,7 @@ async function saveAndOpenProject(tv: DG.TableView, names: MvaNames, dataSync: b
 
   // the viewers of the analysis tables are docked in the same view, so a project keeps them too
   for (const name of [names.analysisTable, names.explVarTable]) {
-    const df = grok.shell.tableByName(name);
+    const df = grok.shell.table(name);
     const info = df.getTableInfo();
     project.addChild(info);
     await grok.dapi.tables.uploadDataFrame(df);
@@ -87,7 +87,7 @@ async function checkResults(tableName: string, names: MvaNames): Promise<void> {
   await awaitCheck(() => grok.shell.tableNames.includes(tableName),
     `The '${tableName}' table has not been opened`, CHECK_TIMEOUT);
 
-  const table = grok.shell.tableByName(tableName);
+  const table = grok.shell.table(tableName);
 
   await awaitCheck(() => expected.every((name) => table.col(name) !== null),
     `The analysis columns are missing, expected: ${expected.join(', ')}`, CHECK_TIMEOUT);
@@ -105,7 +105,7 @@ category('Multivariate analysis: projects', () => {
     for (const name of names.xScores.concat(names.yScores).concat([names.prediction]))
       expect(df.col(name) !== null, true, `The '${name}' column has not been added`);
 
-    const analysis = grok.shell.tableByName(names.analysisTable);
+    const analysis = grok.shell.table(names.analysisTable);
 
     for (const name of [TITLE.FEATURE, TITLE.REGR_COEFS, `${TITLE.XLOADING}1`, TITLE.VIP])
       expect(analysis.col(name) !== null, true, `The '${name}' column of the analysis table is missing`);

--- a/packages/EDA/src/ttest/ttest-ui.ts
+++ b/packages/EDA/src/ttest/ttest-ui.ts
@@ -202,7 +202,7 @@ function getTTestGrid(res: TwoSampleTTest, label0: string, label1: string, featu
  *  When `showReport` is false, only the box plot is shown (no results table). */
 function addVisualization(df: DG.DataFrame, factor: DG.Column, feature: DG.Column,
   res: TwoSampleTTest, showReport: boolean): void {
-  const view = grok.shell.getTableView(df.name);
+  const view = grok.shell.tableView(df.name);
   grok.shell.v = view;
 
   const significant = res.pValue < res.alpha;
@@ -409,7 +409,7 @@ export function runTwoSampleTTest(): void {
   });
 
   const dlg = ui.dialog({title: 'Two-sample t-test', helpUrl: T_TEST_HELP_URL});
-  const view = grok.shell.getTableView(df.name);
+  const view = grok.shell.tableView(df.name);
   view.root.appendChild(dlg.root);
 
   dlg.addButton('Run', () => {

--- a/packages/FileEditors/package-lock.json
+++ b/packages/FileEditors/package-lock.json
@@ -13,7 +13,7 @@
         "cash-dom": "^8.1.5",
         "codemirror": "^6.0.2",
         "codemirror-lang-latex": "^0.1.0-alpha.2",
-        "datagrok-api": "^1.26.0",
+        "datagrok-api": "^1.27.11",
         "dayjs": "^1.11.13",
         "docx-preview": "^0.1.18",
         "latex.js": "^0.12.6",
@@ -2884,9 +2884,10 @@
       }
     },
     "node_modules/datagrok-api": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/datagrok-api/-/datagrok-api-1.26.0.tgz",
-      "integrity": "sha512-qAQZ7ynMQyjb50woLGBpBU14vegm2W7/SRVWvDm/5Ciot4vzTCQ0JOKwgKYFogITQdch/HabmiGprIyNLf/50A==",
+      "version": "1.27.11",
+      "resolved": "https://registry.npmjs.org/datagrok-api/-/datagrok-api-1.27.11.tgz",
+      "integrity": "sha512-AuPEpU3eeTTibZAkTlP5wGyWM7Lqj8OiAHWTe5P2JQAy9ia/3rk7JSVyhV9QDhgk9j8SLeta2NgQgHTjVCRo9g==",
+      "deprecated": "Published ahead of the core release; use the datagrok-api",
       "dependencies": {
         "@babel/core": "^7.27.1",
         "@datagrok-libraries/chem-meta": "^1.0.12",

--- a/packages/FileEditors/package.json
+++ b/packages/FileEditors/package.json
@@ -13,7 +13,7 @@
     "cash-dom": "^8.1.5",
     "codemirror": "^6.0.2",
     "codemirror-lang-latex": "^0.1.0-alpha.2",
-    "datagrok-api": "^1.26.0",
+    "datagrok-api": "^1.27.11",
     "dayjs": "^1.11.13",
     "docx-preview": "^0.1.18",
     "latex.js": "^0.12.6",

--- a/packages/FileEditors/src/latex/latex-viewer.ts
+++ b/packages/FileEditors/src/latex/latex-viewer.ts
@@ -147,7 +147,7 @@ export class LatexViewer {
   private async saveFile(): Promise<void> {
     if (this.isPlatformFile) {
       try {
-        const source = new DG.FileSource();
+        const source = new DG.FilesDataSource();
 
         await source.writeAsText(this.file, this.editorView!.state.doc.toString());
         grok.shell.info('Saved');

--- a/packages/Flow/src/compiler/script-emitter.ts
+++ b/packages/Flow/src/compiler/script-emitter.ts
@@ -296,7 +296,7 @@ function emitUtilityStep(step: CompiledStep): string | null {
     const names = Array.from(new Set([raw, noSpaces, lowerFirst]));
     const expr = names.map((n) => {
       const q = JSON.stringify(n);
-      return `grok.shell.tableByName(${q}) ?? grok.shell.getVar(${q})`;
+      return `grok.shell.table(${q}) ?? grok.shell.getVar(${q})`;
     }).join(' ?? ');
     // Fail fast with the table name — a null table would surface as a cryptic
     // downstream error far from the node that caused it.

--- a/packages/Flow/src/panel/function-browser.ts
+++ b/packages/Flow/src/panel/function-browser.ts
@@ -303,7 +303,7 @@ export class FunctionBrowser {
   }
 
   private buildTopTabs(): HTMLElement {
-    const tabs = DG.TabControl.create(false, TOOLBOX_TABS_KEY);
+    const tabs = DG.TabControl.create({vertical: false, key: TOOLBOX_TABS_KEY});
     this.topTabs = tabs;
     this.queriesTabContent = setTid(ui.div([], 'funcflow-tab-content'), 'browser-queries');
     this.workflowsTabContent = setTid(ui.div([], 'funcflow-tab-content'), 'browser-workflows');

--- a/packages/Flow/src/rete/builtin-catalog.ts
+++ b/packages/Flow/src/rete/builtin-catalog.ts
@@ -62,7 +62,7 @@ export const BUILTIN_SECTIONS: BuiltinSection[] = [
     nodes: [
       {name: 'Select Column', type: 'Utilities/Select Column', desc: 'Gets a column from a table by name'},
       {name: 'Select Columns', type: 'Utilities/Select Columns', desc: 'Gets multiple columns by names (comma-separated)'},
-      {name: 'Select Table', type: 'Utilities/Select Table', desc: 'Gets an open table by name via grok.shell.tableByName()'},
+      {name: 'Select Table', type: 'Utilities/Select Table', desc: 'Gets an open table by name via grok.shell.table()'},
       {name: 'Add Table View', type: 'Utilities/Add Table View', desc: 'Opens a table in a new view via grok.shell.addTableView()'},
       {name: 'Log', type: 'Utilities/Log', desc: 'Logs a value to the browser console'},
       {name: 'Info', type: 'Utilities/Info', desc: 'Shows an info balloon via grok.shell.info()'},

--- a/packages/Flow/src/tests/compiler-tests.ts
+++ b/packages/Flow/src/tests/compiler-tests.ts
@@ -263,7 +263,7 @@ category('Flow: script emitter', () => {
       await e.flow.addConnectionByKeys(sel.id, 'table', out.id, 'table');
 
       const script = emitScript(e.flow, SETTINGS);
-      expect(script.includes('grok.shell.tableByName("My Table")'), true, 'name lookup emitted');
+      expect(script.includes('grok.shell.table("My Table")'), true, 'name lookup emitted');
       expect(script.includes('throw new Error("Select Table: no open table or variable named'), true,
         'a null table throws with the table name instead of failing downstream');
       const inst = emitScript(e.flow, SETTINGS, {instrumented: true, runId: 'run-sel'});

--- a/packages/Flow/src/tests/creation-script-import-tests.ts
+++ b/packages/Flow/src/tests/creation-script-import-tests.ts
@@ -401,8 +401,8 @@ category('Flow: creation script import', () => {
       expect(errors.length, 0, `validation errors: ${errors.map((x) => x.message).join('; ')}`);
 
       const script = emitScript(e.flow, SETTINGS);
-      expect(script.includes('grok.shell.tableByName("demog")'), true, 'table1 via tableByName');
-      expect(script.includes('grok.shell.tableByName("demog (2)")'), true, 'table2 via tableByName');
+      expect(script.includes('grok.shell.table("demog")'), true, 'table1 via tableByName');
+      expect(script.includes('grok.shell.table("demog (2)")'), true, 'table2 via tableByName');
       expect(script.includes('ResolveTable'), false, 'no ResolveTable in generated script');
       expect(script.includes(`.col('USUBJID')`), true, 'key columns via table.col()');
     } finally {

--- a/packages/GIS/src/gis-openlayer.ts
+++ b/packages/GIS/src/gis-openlayer.ts
@@ -1055,7 +1055,7 @@ export class OpenLayers {
 
         // don't show GIS property panel
         //grok.shell.o = gisObj;
-        grok.shell.windows.showProperties = true;
+        grok.shell.windows.showContextPanel = true;
       }, 50);
     }
 

--- a/packages/GIS/src/gis-viewer.ts
+++ b/packages/GIS/src/gis-viewer.ts
@@ -414,7 +414,7 @@ export class GisViewer extends DG.JsViewer {
         this.root.removeChild(loadingDiv);
 
         grok.shell.o = this;
-        grok.shell.windows.showProperties = true;
+        grok.shell.windows.showContextPanel = true;
       }, 100);
     }
   }
@@ -528,7 +528,7 @@ export class GisViewer extends DG.JsViewer {
       } else { //if no features were clicked - just show properties for map
         setTimeout(() => {
           grok.shell.o = this;
-          grok.shell.windows.showProperties = true;
+          grok.shell.windows.showContextPanel = true;
         }, 50);
       }
     }

--- a/packages/GIS/src/package.ts
+++ b/packages/GIS/src/package.ts
@@ -443,7 +443,7 @@ export class PackageFunctions {
     'outputs': [{'name': 'result', 'type': 'viewer'}],
   })
   static gisViewer(): GisViewer {
-    // setTimeout(() => {grok.shell.windows.showProperties = true;}, 500);
+    // setTimeout(() => {grok.shell.windows.showContextPanel = true;}, 500);
     return new GisViewer();
   }
 

--- a/packages/GIS/src/tests/gis-viewer-tests.ts
+++ b/packages/GIS/src/tests/gis-viewer-tests.ts
@@ -18,7 +18,7 @@ category('MapViewer', async () => {
 
     // await grok.functions.call('');
     // await delay(9000);
-    // const v = grok.shell.getTableView('');
+    // const v = grok.shell.tableView('');
   });
 
   test('Map', async () => {
@@ -31,7 +31,7 @@ category('MapViewer', async () => {
     // temporarily, because ids are undefined
     // expect(mapViewer.table.id, testDF.id);
 
-    // const v = grok.shell.getTableView('Map');
+    // const v = grok.shell.tableView('Map');
     // expect(v.name === 'Map', true);
     // expect(allViews.every(item => grok.shell.view(item) !== undefined), true);
     // expect(allTableViews.every(item => grok.shell.view(item) !== undefined), true);

--- a/packages/HitTriage/src/packageSettingsEditor.ts
+++ b/packages/HitTriage/src/packageSettingsEditor.ts
@@ -32,18 +32,12 @@ export async function parseUserGroupString(s: string | null) {
 
 export async function getDefaultSharingSettings(): Promise<HTDefaultCampaignSharing> {
   try {
-    const ps = (_package.settings ?? await _package.getSettings()) as unknown as Map<string, any> | Record<string, any>;
+    const ps = _package.settings;
     const settings: HTDefaultCampaignSharing = {view: [], edit: []};
     if (!ps)
       return settings;
-    // this hack is needed because api says it will return Map, but it actually returns object...
-    if (ps instanceof Map) {
-      settings.view = await parseUserGroupString(ps.get('view') ?? '');
-      settings.edit = await parseUserGroupString(ps.get('edit') ?? '');
-    } else {
-      settings.view = await parseUserGroupString(ps.view ?? '');
-      settings.edit = await parseUserGroupString(ps.edit ?? '');
-    }
+    settings.view = await parseUserGroupString(ps.view ?? '');
+    settings.edit = await parseUserGroupString(ps.edit ?? '');
     return settings;
   } catch (e) {
     console.error(e);
@@ -52,10 +46,10 @@ export async function getDefaultSharingSettings(): Promise<HTDefaultCampaignShar
 }
 
 export async function getDefaultCampaignStorageSettings(): Promise<string> {
-  const ps = (_package.settings ?? await _package.getSettings()) as unknown as Map<string, any> | Record<string, any>;
+  const ps = _package.settings;
   if (!ps)
     return defaultCampaignStorage;
-  const res = (ps instanceof Map ? ps.get(defaultCampaignStoragePropName) : ps[defaultCampaignStoragePropName]) ?? defaultCampaignStorage;
+  const res = ps[defaultCampaignStoragePropName] ?? defaultCampaignStorage;
   // check if it exists
   if (!(await grok.dapi.files.exists(res)))
     return defaultCampaignStorage;

--- a/packages/NLP/src/stemming-tools/stemming-tools.ts
+++ b/packages/NLP/src/stemming-tools/stemming-tools.ts
@@ -199,7 +199,7 @@ export function getMarkedString(curIdx: number, queryIdx: number, strToBeMarked:
       e.stopImmediatePropagation();
       e.preventDefault();
 
-      stemCash.filters = grok.shell.getTableView(df.name).getFiltersGroup();
+      stemCash.filters = grok.shell.tableView(df.name).getFiltersGroup();
 
       setTimeout(() => {
         const state = stemCash.filters!.getStates(stemCash.colName!, 'text')[0];

--- a/packages/OligoBatchCalculator/src/package.ts
+++ b/packages/OligoBatchCalculator/src/package.ts
@@ -12,7 +12,7 @@ import {opticalDensityCalc, molecularMassCalc, nMoleCalc} from './calculations-s
 
 export const _package = new DG.Package();
 const windows = grok.shell.windows;
-windows.showProperties = false;
+windows.showContextPanel = false;
 windows.showToolbox = false;
 windows.showHelp = false;
 export * from './package.g';

--- a/packages/Peptides/playwright/peptide-sar-demo-dashboard.test.ts
+++ b/packages/Peptides/playwright/peptide-sar-demo-dashboard.test.ts
@@ -226,7 +226,7 @@ test('Peptide SAR demo dashboard + Peptides app landing — entry-point smokes',
             flags: {
               showToolbox: grok.shell.windows.showToolbox,
               showHelp: grok.shell.windows.showHelp,
-              showProperties: grok.shell.windows.showProperties,
+              showProperties: grok.shell.windows.showContextPanel,
             },
           };
         });

--- a/packages/Peptides/src/model.ts
+++ b/packages/Peptides/src/model.ts
@@ -1407,7 +1407,7 @@ export class PeptidesModel {
       minClusterSize: mclParams.minClusterSize,
     } satisfies MCLSerializableOptions);
 
-    const tv = this.analysisView ?? grok.shell.getTableView(this.df.name);
+    const tv = this.analysisView ?? grok.shell.tableView(this.df.name);
     if (tv) {
       const func = DG.Func.find({package: 'EDA', name: 'markovClusteringViewer'})[0];
       if (!func)

--- a/packages/Peptides/src/package.ts
+++ b/packages/Peptides/src/package.ts
@@ -74,7 +74,7 @@ async function openDemoData(chosenFile: string): Promise<void> {
   peptides.name = 'Peptides';
   const view = grok.shell.addTableView(peptides);
   view.name = 'PeptidesView';
-  grok.shell.windows.showProperties = true;
+  grok.shell.windows.showContextPanel = true;
   pi.close();
 }
 
@@ -108,7 +108,7 @@ export class PackageFunctions {
     const windows = grok.shell.windows;
     windows.showToolbox = false;
     windows.showHelp = false;
-    windows.showProperties = false;
+    windows.showContextPanel = false;
 
     const view = View.create();
     view.name = 'Peptides';

--- a/packages/Peptides/src/tests/core.ts
+++ b/packages/Peptides/src/tests/core.ts
@@ -73,7 +73,7 @@ category('Core', () => {
     model = await startAnalysis(simpleActivityCol, simpleAlignedSeqCol, null, simpleTable, simpleScaledCol,
       C.SCALING_METHODS.MINUS_LG);
 
-    let v = grok.shell.getTableView('Peptides analysis');
+    let v = grok.shell.tableView('Peptides analysis');
 
     const d = v.dataFrame;
     const layout = v.saveLayout();
@@ -93,7 +93,7 @@ category('Core', () => {
       'Table never closed', 3000);
 
     await sp.open();
-    v = grok.shell.getTableView('Peptides analysis');
+    v = grok.shell.tableView('Peptides analysis');
 
     await grok.dapi.layouts.delete(sl);
     await grok.dapi.tables.delete(sti);

--- a/packages/Plates/src/plate/plate-widget/plate-widget.ts
+++ b/packages/Plates/src/plate/plate-widget/plate-widget.ts
@@ -32,7 +32,7 @@ export class PlateWidget extends DG.Widget {
   wellDetailsDiv?: HTMLElement;
   plateDetailsDiv?: HTMLElement;
   plateActionsDiv?: HTMLElement;
-  tabs: DG.TabControl = DG.TabControl.create(true);
+  tabs: DG.TabControl = DG.TabControl.create({vertical: true});
   tabsContainer: HTMLElement = ui.divH([], 'assay-plates--plate-widget__tabs-container');
   _editable: boolean = false;
   mapFromRowFunc: (row: DG.Row) => Record<string, any> = mapFromRow;

--- a/packages/PowerPack/src/package.ts
+++ b/packages/PowerPack/src/package.ts
@@ -381,7 +381,7 @@ export class PackageFunctions {
     setupDBQueryCellHandler(); // db-explorer for any query result - lazy without await
     initSearch();
 
-    _properties = await _package.getProperties();
+    _properties = _package.settings;
     registerDGUserHandler(); // lazy without await
 
     // saving and restoring the scrolls when changing views

--- a/packages/PowerPack/src/search/templates-search.ts
+++ b/packages/PowerPack/src/search/templates-search.ts
@@ -25,7 +25,7 @@ export async function initTemplates(): Promise<void> {
 
   return; //TODO: bring it back once we can cache app folders. We don't need to load it on each start.
 
-  //let templatesPath = (await _package.getProperties()).get('searchTemplatePaths');
+  //let templatesPath = (_package.settings).get('searchTemplatePaths');
   let templatesPath = 'System:AppData/PowerPack/search-templates';
 
   async function loadTemplates(): Promise<void> {

--- a/packages/PowerPack/src/spotlight/spotlight-widget.ts
+++ b/packages/PowerPack/src/spotlight/spotlight-widget.ts
@@ -97,7 +97,7 @@ export class SpotlightWidget extends DG.Widget {
       'Learn': () => new LearningWidget().root,
     };
 
-    this.tabControl = ui.tabControl(tabs, true, 'spotlight-widget');
+    this.tabControl = ui.tabControl(tabs, {vertical: true, key: 'spotlight-widget'});
     this.subs.push(this.tabControl.onTabChanged.subscribe((tabPane: DG.TabPane) => {
       this.cleanLists();
       if (tabPane.name !== 'Workspace')

--- a/packages/PowerPack/src/windows-manager.ts
+++ b/packages/PowerPack/src/windows-manager.ts
@@ -36,8 +36,8 @@ topmenuToggle.addEventListener('click', ()=> {
 });
 
 propertiesToggle.addEventListener('click', ()=> {
-  window.showProperties ? window.showProperties = false : window.showProperties = true;
-  setToggleState(window.showProperties, propertiesToggle);
+  window.showContextPanel ? window.showContextPanel = false : window.showContextPanel = true;
+  setToggleState(window.showContextPanel, propertiesToggle);
 });
 
 helpToggle.addEventListener('click', ()=> {
@@ -82,7 +82,7 @@ function setButtonsToggleState() {
   setToggleState(window.showAI, aiToggle);
   window.simpleMode ? topmenuToggle.className = 'windows-manager-toggle' : topmenuToggle.className = 'windows-manager-toggle active';
   setToggleState(window.showToolbox, toolboxToogle);
-  setToggleState(window.showProperties, propertiesToggle);
+  setToggleState(window.showContextPanel, propertiesToggle);
   setToggleState(window.showHelp, helpToggle);
   setToggleState(window.showVariables, vairablesToggle);
   setToggleState(window.showConsole, consoleToggle);

--- a/packages/PubChemApi/src/tests/chem-panels.ts
+++ b/packages/PubChemApi/src/tests/chem-panels.ts
@@ -9,7 +9,7 @@ category('UI info panel', () => {
 
   before(async () => {
     grok.shell.closeAll();
-    grok.shell.windows.showProperties = true;
+    grok.shell.windows.showContextPanel = true;
   });
 
 

--- a/packages/SequenceTranslator/src/apps/common/model/oligo-toolkit-package.ts
+++ b/packages/SequenceTranslator/src/apps/common/model/oligo-toolkit-package.ts
@@ -86,8 +86,7 @@ export class OligoToolkitPackage extends DG.Package implements ITranslationHelpe
   async initLibData(): Promise<void> {
     if (!this.initLibDataPromise) {
       this.initLibDataPromise = (async () => {
-        const packageSettings = await this.getSettings();
-        let monomersPath: string = packageSettings instanceof Map ? packageSettings.get('MonomersPath') : packageSettings['MonomersPath'];
+        let monomersPath: string = this.settings['MonomersPath'];
         if (!monomersPath || !(await grok.dapi.files.exists(monomersPath))) {
           this.logger.warning(`Monomers path '${monomersPath}' not found. ` +
             `Fallback to monomers sample path '${FALLBACK_LIB_PATH}'.`);

--- a/packages/SequenceTranslator/src/apps/common/view/isolated-app-ui.ts
+++ b/packages/SequenceTranslator/src/apps/common/view/isolated-app-ui.ts
@@ -31,7 +31,7 @@ export abstract class IsolatedAppUIBase extends AppUIBase {
     this.view.name = this.appName;
 
     const windows = grok.shell.windows;
-    windows.showProperties = false;
+    windows.showContextPanel = false;
     windows.showToolbox = false;
     windows.showHelp = false;
   }

--- a/packages/SequenceTranslator/src/apps/translator/view/ui.ts
+++ b/packages/SequenceTranslator/src/apps/translator/view/ui.ts
@@ -182,7 +182,7 @@ class TranslatorAppLayout {
     // update the view
 
     grok.data.detectSemanticTypes(selectedTable);
-    grok.shell.v = grok.shell.getTableView(selectedTable.name);
+    grok.shell.v = grok.shell.tableView(selectedTable.name);
   }
 
   private constructSingleSequenceControls(): HTMLDivElement {

--- a/packages/SequenceTranslator/src/polytool/conversion/pt-rules.ts
+++ b/packages/SequenceTranslator/src/polytool/conversion/pt-rules.ts
@@ -362,7 +362,7 @@ export class Rules {
 }
 
 export async function getRules(ruleFiles: string[]): Promise<Rules> {
-  const fileSource = new DG.FileSource(RULES_PATH);
+  const fileSource = new DG.FilesDataSource(RULES_PATH);
   const rules: Rules = new Rules(null, null, [], []);
 
   for (let i = 0; i < ruleFiles.length; i++) {

--- a/packages/SequenceTranslator/src/polytool/pt-chem-enum-settings.ts
+++ b/packages/SequenceTranslator/src/polytool/pt-chem-enum-settings.ts
@@ -41,11 +41,10 @@ export function parseChemEnumDefaults(json: string | null | undefined): ChemEnum
 
 export async function getMarkushDefaults(): Promise<ChemEnumHistoryEntry | null> {
   try {
-    const ps = (_package.settings ?? await _package.getSettings()) as unknown as Map<string, any> | Record<string, any>;
+    const ps = _package.settings;
     if (!ps)
       return null;
-    // this hack is needed because api says it will return Map, but it actually returns object...
-    const value = ps instanceof Map ? ps.get(markushDefaultsPropName) : ps[markushDefaultsPropName];
+    const value = ps[markushDefaultsPropName];
     return parseChemEnumDefaults(value ?? null);
   } catch (e) {
     console.error(e);

--- a/packages/Tutorials/src/demo-app/demo-app.ts
+++ b/packages/Tutorials/src/demo-app/demo-app.ts
@@ -671,7 +671,7 @@ export class DemoView extends DG.ViewBase {
     grok.shell.windows.showToolbox = false;
     grok.shell.windows.showRibbon = true;
     grok.shell.windows.showHelp = false;
-    grok.shell.windows.showProperties = false;
+    grok.shell.windows.showContextPanel = false;
     grok.shell.windows.help.syncCurrentObject = false;
   }
 }

--- a/packages/Tutorials/src/demo-app/widget.ts
+++ b/packages/Tutorials/src/demo-app/widget.ts
@@ -23,7 +23,7 @@ export class DemoAppWidget extends DG.Widget {
 
         grok.shell.windows.showRibbon = true;
         grok.shell.windows.showHelp = true;
-        grok.shell.windows.showProperties = true;
+        grok.shell.windows.showContextPanel = true;
         grok.shell.windows.help.syncCurrentObject = true;
 
         let tree = ui.tree();

--- a/packages/UITests/src/gui/grid.ts
+++ b/packages/UITests/src/gui/grid.ts
@@ -8,7 +8,7 @@ import { checkDialog } from './gui-utils';
 category('GUI: Grid', () => {
   before(async () => {
     showToolbox();
-    grok.shell.windows.showProperties = true;
+    grok.shell.windows.showContextPanel = true;
   });
 
   test('grid.dataSearch', async () => {

--- a/packages/UITests/src/gui/viewers/bar-chart.ts
+++ b/packages/UITests/src/gui/viewers/bar-chart.ts
@@ -78,7 +78,7 @@ category('Viewers: Bar Chart', () => {
     await uploadProject('Test project with Bar Chart', demog.getTableInfo(), v, demog);
     grok.shell.closeAll();
     await grok.dapi.projects.open('Test project with Bar Chart');
-    v = grok.shell.getTableView('demog 1000');
+    v = grok.shell.tableView('demog 1000');
     isViewerPresent(Array.from(v.viewers), 'Bar chart');
     const barChart = findViewer('Bar chart', v);
 

--- a/packages/UITests/src/gui/viewers/box-plot.ts
+++ b/packages/UITests/src/gui/viewers/box-plot.ts
@@ -77,7 +77,7 @@ category('Viewers: Box Plot', () => {
     await uploadProject('Test project with Box Plot', demog.getTableInfo(), v, demog);
     grok.shell.closeAll();
     await grok.dapi.projects.open('Test project with Box Plot');
-    v = grok.shell.getTableView('demog 1000');
+    v = grok.shell.tableView('demog 1000');
     isViewerPresent(Array.from(v.viewers), 'Box plot');
     const boxPlot = findViewer('Box plot', v);
 

--- a/packages/UITests/src/gui/viewers/density-plot.ts
+++ b/packages/UITests/src/gui/viewers/density-plot.ts
@@ -69,7 +69,7 @@ category('Viewers: Density plot', () => {
     await uploadProject('Test project with Density plot', demog.getTableInfo(), v, demog);
     grok.shell.closeAll();
     await grok.dapi.projects.open('Test project with Density plot');
-    v = grok.shell.getTableView('demog 1000');
+    v = grok.shell.tableView('demog 1000');
     isViewerPresent(Array.from(v.viewers), 'Density plot');
     const densityPlot = findViewer('Density plot', v);
 

--- a/packages/UITests/src/gui/viewers/histogram.ts
+++ b/packages/UITests/src/gui/viewers/histogram.ts
@@ -83,7 +83,7 @@ category('Viewers: Histogram', () => {
     await uploadProject('Test project with Histogram', demog.getTableInfo(), v, demog);
     grok.shell.closeAll();
     await grok.dapi.projects.open('Test project with Histogram');
-    v = grok.shell.getTableView('demog 1000');
+    v = grok.shell.tableView('demog 1000');
     isViewerPresent(Array.from(v.viewers), 'Histogram');
     const histogram = findViewer('Histogram', v);
 

--- a/packages/UITests/src/gui/viewers/matrix-plot.ts
+++ b/packages/UITests/src/gui/viewers/matrix-plot.ts
@@ -64,7 +64,7 @@ category('Viewers: Matrix Plot', () => {
     await uploadProject('Test project with Matrix Plot', demog.getTableInfo(), v, demog);
     grok.shell.closeAll();
     await grok.dapi.projects.open('Test project with Matrix Plot');
-    v = grok.shell.getTableView('demog 1000');
+    v = grok.shell.tableView('demog 1000');
     isViewerPresent(Array.from(v.viewers), 'Matrix plot');
     const matrixPlot = findViewer('Matrix plot', v);
     

--- a/packages/UITests/src/gui/viewers/network-diagram.ts
+++ b/packages/UITests/src/gui/viewers/network-diagram.ts
@@ -74,7 +74,7 @@ category('Viewers: Network Diagram', () => {
     await uploadProject('Test project with Network Diagram', demog.getTableInfo(), v, demog);
     grok.shell.closeAll();
     await grok.dapi.projects.open('Test project with Network Diagram');
-    v = grok.shell.getTableView('demog 1000');
+    v = grok.shell.tableView('demog 1000');
     isViewerPresent(Array.from(v.viewers), 'Network diagram');
     const networkDiagram = findViewer('Network diagram', v);
 

--- a/packages/UITests/src/gui/viewers/pc-plot.ts
+++ b/packages/UITests/src/gui/viewers/pc-plot.ts
@@ -78,7 +78,7 @@ category('Viewers: PC Plot', () => {
     await uploadProject('Test project with P C Plot', demog.getTableInfo(), v, demog);
     grok.shell.closeAll();
     await grok.dapi.projects.open('Test project with P C Plot');
-    v = grok.shell.getTableView('demog 1000');
+    v = grok.shell.tableView('demog 1000');
     isViewerPresent(Array.from(v.viewers), 'PC Plot');
     const pcPlot = findViewer('PC Plot', v);
 

--- a/packages/UITests/src/gui/viewers/pie-chart.ts
+++ b/packages/UITests/src/gui/viewers/pie-chart.ts
@@ -71,7 +71,7 @@ category('Viewers: Pie Chart', () => {
     await uploadProject('Test project with Pie Chart', demog.getTableInfo(), v, demog);
     grok.shell.closeAll();
     await grok.dapi.projects.open('Test project with Pie Chart');
-    v = grok.shell.getTableView('demog 1000');
+    v = grok.shell.tableView('demog 1000');
     isViewerPresent(Array.from(v.viewers), 'Pie chart');
     const pieChart = findViewer('Pie chart', v);
 

--- a/packages/UITests/src/gui/viewers/scatter-plot-3d.ts
+++ b/packages/UITests/src/gui/viewers/scatter-plot-3d.ts
@@ -80,7 +80,7 @@ category('Viewers: 3D Scatter Plot', () => {
     await uploadProject('Test project with 3 D Scatter Plot', demog.getTableInfo(), v, demog);
     grok.shell.closeAll();
     await grok.dapi.projects.open('Test project with 3 D Scatter Plot');
-    v = grok.shell.getTableView('demog 1000');
+    v = grok.shell.tableView('demog 1000');
     isViewerPresent(Array.from(v.viewers), '3d scatter plot');
     const scatterPlot3D = findViewer('3d scatter plot', v);
 

--- a/packages/UITests/src/ui/groups.ts
+++ b/packages/UITests/src/ui/groups.ts
@@ -93,7 +93,7 @@ category('UI: Groups', () => {
       return false;
     }, 'cannot load all users', 10000);
     const group = document.querySelector('.grok-gallery-grid')!.children[0] as HTMLElement;
-    grok.shell.windows.showProperties = true;
+    grok.shell.windows.showContextPanel = true;
     group.click();
     const regex = new RegExp('MANAGE', 'g');
     await awaitCheck(() => {

--- a/packages/UITests/src/ui/tables.ts
+++ b/packages/UITests/src/ui/tables.ts
@@ -21,7 +21,7 @@ category('UI: Tables', () => {
 
   before(async () => {
     v = grok.shell.newView('');
-    grok.shell.windows.showProperties = true;
+    grok.shell.windows.showContextPanel = true;
   });
 
   test('table.root', async () => {

--- a/packages/UITests/src/ui/users.ts
+++ b/packages/UITests/src/ui/users.ts
@@ -93,7 +93,7 @@ category('UI: Users', () => {
       return false;
     }, 'cannot load all users', 3000);
     const user = document.querySelector('.grok-gallery-grid')!.children[0] as HTMLElement;
-    grok.shell.windows.showProperties = true;
+    grok.shell.windows.showContextPanel = true;
     const regex = new RegExp('Member of', 'g');
     user.click();
     await delay(100);

--- a/packages/UsageAnalysis/files/TestTrack/Connections/helpers.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Connections/helpers.ts
@@ -370,7 +370,7 @@ export async function applyAutomationSetup(page: Page): Promise<void> {
 export async function showContextPanel(page: Page): Promise<void> {
   await page.evaluate(() => {
     const g = (window as unknown as { grok: any }).grok;
-    g.shell.windows.showProperties = true;
+    g.shell.windows.showContextPanel = true;
   });
 }
 

--- a/packages/UsageAnalysis/files/TestTrack/Peptides/peptide-sar-demo-dashboard-spec.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Peptides/peptide-sar-demo-dashboard-spec.ts
@@ -200,7 +200,7 @@ test('Peptide SAR demo dashboard + Peptides app landing — entry-point smokes',
             flags: {
               showToolbox: grok.shell.windows.showToolbox,
               showHelp: grok.shell.windows.showHelp,
-              showProperties: grok.shell.windows.showProperties,
+              showProperties: grok.shell.windows.showContextPanel,
             },
           };
         });

--- a/packages/UsageAnalysis/files/TestTrack/Queries/helpers.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Queries/helpers.ts
@@ -60,7 +60,7 @@ export async function openDbConnectionView(page: Page, provider: string, connect
 export async function showContextPanel(page: Page): Promise<void> {
   await page.evaluate(() => {
     const g = (window as unknown as { grok: { shell: { windows: { showProperties: boolean } } } }).grok;
-    g.shell.windows.showProperties = true;
+    g.shell.windows.showContextPanel = true;
   });
 }
 

--- a/packages/UsageAnalysis/files/TestTrack/Viewers/Grid/grid-helpers.ts
+++ b/packages/UsageAnalysis/files/TestTrack/Viewers/Grid/grid-helpers.ts
@@ -240,7 +240,7 @@ export interface ShellFlags { showContextPanel: boolean; showToolbox: boolean; s
 export function readShellFlags(page: Page): Promise<ShellFlags> {
   return page.evaluate(() => {
     const w = grok.shell.windows;
-    return {showContextPanel: w.showContextPanel, showToolbox: w.showToolbox, showProperties: w.showProperties, showHelp: w.showHelp};
+    return {showContextPanel: w.showContextPanel, showToolbox: w.showToolbox, showProperties: w.showContextPanel, showHelp: w.showHelp};
   });
 }
 

--- a/packages/UsageAnalysis/queries/test_dashboards/correctness_tests/tests_dashboard.js
+++ b/packages/UsageAnalysis/queries/test_dashboards/correctness_tests/tests_dashboard.js
@@ -103,7 +103,7 @@ async function postprocess() {
   // let ticketsStatusCol = await pivot.columns.addNewCalculated(`${builds[0]} tickets status`, `UsageAnalysis:getTicketsVerdict(\${${builds[0]} concat unique(result)})`, DG.TYPE.STRING);
   //let stickyMetaStatusCol = await pivot.columns.addNewCalculated(`ignore status`, `UsageAnalysis:getTicketsVerdict(\${ignoreReason})`, DG.TYPE.STRING);
   if (ticketsStatusCol)
-    ticketsStatusCol.colors.setCategorical({
+    ticketsStatusCol.meta.colors.setCategorical({
       'Fixed': '#2ca02c',
       'Partially Fixed (Lowest)': '#ffe51c',
       'Partially Fixed (Low)': '#ffa500',
@@ -115,7 +115,7 @@ async function postprocess() {
       'Wasn\'t Fixed (Blocker)': '#7b2d24',
     })
   if (stickyMetaStatusCol)
-    stickyMetaStatusCol.colors.setCategorical({
+    stickyMetaStatusCol.meta.colors.setCategorical({
       'Fixed': '#2ca02c',
       'Partially Fixed (Lowest)': '#ffe51c',
       'Partially Fixed (Low)': '#ffa500',

--- a/packages/UsageAnalysis/queries/test_dashboards/manual_tests/test_track_dashboard.js
+++ b/packages/UsageAnalysis/queries/test_dashboards/manual_tests/test_track_dashboard.js
@@ -36,7 +36,7 @@ async function postprocess() {
     replaceColumn(batchNames[i], ' concat unique(result)', ' verdict');
     let statusCol = pivot.col(`${batchNames[i]} concat unique(status)`);
     if (statusCol)
-      statusCol.colors.setCategorical({
+      statusCol.meta.colors.setCategorical({
         'passed': '#2ca02c',
         'skipped': '#ffa500',
         'failed': '#8e342a',
@@ -48,7 +48,7 @@ async function postprocess() {
     }
     let ticketsStatusCol = await pivot.columns.addNewCalculated(`${batchNames[i]} tickets status`, `UsageAnalysis:getTicketsVerdict(\${${batchNames[i]} concat unique(result)})`, DG.TYPE.STRING);
     if (ticketsStatusCol)
-      ticketsStatusCol.colors.setCategorical({
+      ticketsStatusCol.meta.colors.setCategorical({
         'Fixed': '#2ca02c',
         'Partially Fixed (Lowest)': '#ffe51c',
         'Partially Fixed (Low)': '#ffa500',


### PR DESCRIPTION
Epic: GROK-20848 — JS API: Audit. Follow-up to #4057: moves `public/packages` and `public/libraries` off the datagrok-api members the audit deprecated, for every member whose replacement already exists in the published datagrok-api 1.27.11. Ledger with the removal schedule: `core/docs/reviews/js-api-audit/deprecations.md`; the codemod is `core/docs/reviews/js-api-audit/data/migrate-deprecated.cjs` (core PR alongside).

## What changed (124 files, 33 packages and libraries, 171+/180−)

| Deprecated | Replacement | Sites |
|---|---|---:|
| `grok.shell.windows.showProperties` | `showContextPanel` (same Dart call) | 63 |
| `grok.shell.getTableView(name)` | `grok.shell.tableView(name)` | 54 |
| `grok.shell.tableByName(name)` | `grok.shell.table(name)` | 15 |
| `column.colors.set*` | `column.meta.colors.set*` | 12 |
| `ui.tabControl(pages, vertical[, key])`, `DG.TabControl.create(vertical[, key])` | `{vertical, key}` options object | 11 |
| `await _package.getProperties()` / `getSettings()` | `_package.settings` (sync; same map, see below) | 10 |
| `new DG.FileSource(...)` | `new DG.FilesDataSource(...)` | 4 |
| `grok.data.query(name, params, adHoc)` | drop the ignored third argument | 1 |

`Package.settings` returns the same map the async forms did (`GrokPackageMeta.getPropertiesByName` just awaits the sync getter), as a plain object. The five sites that had `instanceof Map` fallbacks (HitTriage, SequenceTranslator) lost them; Bio builds its `BioPackageProperties` (a `Map` subclass) from `Object.entries(_package.settings ?? {})`. Also updated: the DevTools script template that emits `windows.showProperties`.

Left alone on purpose: `ApiTests/src/ai/widgets/tab-control-js-api.ts` (tests the boolean overload itself), `libraries/u2/tests/func-form-tables.test.js` (its `Shell` is u2's own), and `ShellFlags.showProperties` in the TestTrack Playwright helpers (their own record; it now reads `showContextPanel`).

## Not in this PR

- `SpaceChildrenClient.filter(types)` → `ofTypes` (12 sites) and `revoke(group, entity)` → `revoke(entity, group)` (28 sites): the replacements only exist in the unpublished datagrok-api; follow-up after the next publish.
- `grok.dapi.userDataStorage` → `grok.userSettings` (25 sites: Proteomics, OligoBatchCalculator, compute-utils): **not a rename.** `UserSettingsStorage` is a client-side cache loaded from `GrokStartupData` and pushed to `dapi.userDataStorage` every 10 s, sync API, strings only, no pull. Proteomics uses `userDataStorage` as a cache for fetched gene-label and subcellular-location data (that would move into the startup payload), and its tests monkey-patch the async `put`/`get`. Needs a ruling: either un-deprecate `userDataStorage` as the server-direct store (tier D), or add an explicit server round-trip to `userSettings`. Recorded in the ledger.
- Package changelog entries and version bumps: pure renames, no behaviour change, no publish needed.

## CI on this PR

The Packages workflow builds every touched package. Seven build steps failed on the first run:

- **ClinicalCase, FileEditors — caused by this PR, fixed in `66ff1b9d75`.** Their lockfiles pinned datagrok-api 1.27.0 and 1.26.0, which predate `ITabControlOptions` and `FilesDataSource`. Both now depend on `^1.27.11`. Lesson recorded in the ledger: a package's lockfile, not its `^` range, decides which API it compiles against, so a migration to a newer member needs the dependency bump alongside.
- **PowerPack, GIS, DevTools, Tutorials, UsageAnalysis — pre-existing, not touched by the codemod:** duplicate datagrok-api typings via `libraries/u2/node_modules` (PowerPack), `IWidgetStatus` missing from the 1.26.2 the lockfile pins (GIS), the `clone` options overload against `../../js-api` (DevTools), `Tutorial.start` (Tutorials), missing `@playwright/test` / `@datagrok-libraries/bdd` (UsageAnalysis). None of the failing lines are in this diff.

## Verification

Every affected TypeScript package and library (29) type-checked against the published datagrok-api 1.27.11 typings before and after the codemod: **no new errors** (two pre-existing `TS7006` lines moved because the files got shorter). Remaining deprecated call sites: zero, except the two deliberate ones above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5D9nKbMuuEo4h9SmVtAcY
