### PR TITLE
GROK-20848: js-api: save keeps the source's includes; ApiTests: follow the audit's hexToPercentRgb and getGridPart fixes

### DIFF
--- a/js-api/CHANGELOG.md
+++ b/js-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* GROK-20848: `HttpDataSource.save` keeps the source's `include`s (immutable data sources reset them, so `include('session.user').save(call)` came back without an author)
 * GROK-20862: Form layout: a choice input is sized to its widest option, so a 200-character option (the ChEMBL FRAC mechanisms) stretched the select and the whole dialog to the viewport width. The select now caps at 80vw; longer options are clipped.
 * GROK-20848: `package.json`: `react` and `@types/react` dropped (nothing imported them since `Widget.react` went away), `@babel/core` moved to `devDependencies`, `files` added so the tarball ships the build output and docs but not sources, configs or scripts.
 * GROK-20848: Options-object forms next to the positional ones: `Accordion.addPane(name, getContent, {expanded, before, allowDragOut})` (and `addCountPane`), `ui.rangeSlider({minRange, maxRange, min, max, vertical, style})`, `grok.data.linkTables(..., {initialSync, filterAllOnNoRowsSelected})`, `grok.ml.pca(table, features, {components, center, scale})`, `DataFrame.clone({rows, columns, saveSelection, saveTags})`, `DataFrame.join(t2, {keys, keys2, columns, columns2, type, inPlace})`, `grok.dapi.files.list(path, {recursive, pattern})`

--- a/js-api/scripts/inventory-baseline.json
+++ b/js-api/scripts/inventory-baseline.json
@@ -1,5 +1,5 @@
 {
-  "undocumentedMembers": 1360,
+  "undocumentedMembers": 1358,
   "undocumentedClasses": 115,
   "darkMembers": 460,
   "anyInSignature": 338,

--- a/js-api/src/dapi.ts
+++ b/js-api/src/dapi.ts
@@ -329,8 +329,7 @@ export class HttpDataSource<T> {
     return Object.assign(copy, this, {query: {...this.query, ...patch}});
   }
 
-  private prepare(): any {
-    const q = this.query;
+  private prepare(q: DataSourceQuery = this.query): any {
     let d = api.grok_DataSource_ResetQuery(this.dart);
     if (q.allPackageVersions)
       d = api.grok_DataSource_AllPackageVersions(d);
@@ -384,9 +383,9 @@ export class HttpDataSource<T> {
     return api.grok_DataSource_Find(this.prepare(), id);
   }
 
-  /** Saves an entity. */
+  /** Saves an entity; the saved copy comes back with this source's {@link include}s loaded. */
   save(e: Entity): Promise<T> {
-    return api.grok_DataSource_Save(api.grok_DataSource_ResetQuery(this.dart), e.dart);
+    return api.grok_DataSource_Save(this.prepare({includes: this.query.includes}), e.dart);
   }
 
   /** Deletes an entity. */

--- a/js-api/src/dataframe/column-helpers.ts
+++ b/js-api/src/dataframe/column-helpers.ts
@@ -139,6 +139,7 @@ export class ColumnMarkerHelper {
     this.column = column;
   }
 
+  /** Draws [category] with [marker] on scatter plots; chainable. */
   assign(category: string, marker: MarkerCodingType): ColumnMarkerHelper {
     let jsonTxt: string | null = this.column.getTag(TAGS.MARKER_CODING);
     const jsonMap: {[key: string]: string} = jsonTxt ? JSON.parse(jsonTxt) : {};
@@ -148,6 +149,7 @@ export class ColumnMarkerHelper {
     return this;
   }
 
+  /** The marker for every category that {@link assign} gave none; chainable. */
   default(marker: MarkerCodingType): ColumnMarkerHelper {
     return this.assign('~DEFAULT', marker);
   }

--- a/packages/ApiTests/src/ai/color/color-static-helpers.ts
+++ b/packages/ApiTests/src/ai/color/color-static-helpers.ts
@@ -50,13 +50,13 @@ category('AI: Color: static helpers', () => {
   test('hexToPercentRgb happy path', async () => {
     const res = DG.Color.hexToPercentRgb('#00bfff');
     expect(res != null, true);
-    expectArray(res!, [0 / 256, 0xbf / 256, 0xff / 256, 0.3]);
+    expectArray(res!, [0 / 255, 0xbf / 255, 0xff / 255, 0.3]);
   });
 
   test('hexToPercentRgb with explicit alpha', async () => {
     const res = DG.Color.hexToPercentRgb('#00bfff80');
     expect(res != null, true);
-    expectArray(res!, [0 / 256, 0xbf / 256, 0xff / 256, 0x80 / 256]);
+    expectArray(res!, [0 / 255, 0xbf / 255, 0xff / 255, 0x80 / 255]);
   });
 
   test('hexToPercentRgb invalid input', async () => {

--- a/packages/ApiTests/src/ai/utils/geometry-helpers.ts
+++ b/packages/ApiTests/src/ai/utils/geometry-helpers.ts
@@ -54,8 +54,7 @@ category('AI: Utils: Geometry', () => {
     const r = new DG.Rect(10, 20, 100, 40);
     expectRect(r.getTopPart(4, 1), 10, 30, 100, 10);
     expectRect(r.getLeftPart(4, 1), 35, 20, 25, 40);
-    // getGridPart has a latent bug (height divides by y index, not yCount); pin as-coded behavior.
-    expectRect(r.getGridPart(2, 2, 1, 1), 60, 40, 50, 40);
+    expectRect(r.getGridPart(2, 2, 1, 1), 60, 40, 50, 20);
     expectRect(r.getTopScaled(0.25), 10, 20, 100, 10);
     expectRect(r.getLeftScaled(0.25), 10, 20, 25, 40);
   });


### PR DESCRIPTION
## Summary

Fallout of the JS API audit (#4057) seen in Build-Datagrok #133 (master, RUN_TESTS):

- `HttpDataSource.save()` reset the query and dropped `include(...)`, so `grok.dapi.functions.calls.include(\"session.user\").save(call)` returned a call without an author (ApiTests `Dapi: functions calls :: save & get author`). `save` now applies the source includes.
- ApiTests `hexToPercentRgb` expectations still divided by 256; the audit scales by 255 (its own `scripts/unit/color.test.cjs` pins that).
- ApiTests `Rect.getGridPart` pinned the old height bug; the audit divides by `yCount` (`scripts/unit/rect.test.cjs`).

The separate Node-runtime crash (`grok_DataSource_ResetQuery is not available under Node.js`, which took DBTests/CVMTests out of #133) is a stale committed Node bundle; Metadata-Rebuild #60 regenerates it from master.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wx2UqgtEPaXMA6m2vQpedM