### PR TITLE
Tools: grok publish builds the image when the fallback lookup fails

### DIFF
--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Datagrok-tools changelog
 
+## 6.5.11 (2026-09-12)
+
+* `grok publish` — when no local image exists and the `latest-compatible` lookup fails (a transient network or auth error), the image is now built and pushed like a first publish. It used to record the container with no image at all, so the package landed on the server with that container in `error` (seen with Grokky's `mcp-server` after one `ECONNABORTED` on the login call).
+
 ## 6.5.10 (2026-09-11)
 
 * `grok s pull` — a bundle file name is capped at 200 bytes plus a digest of the full name, so it stays unique and stable across pulls. A nested view under a long space spells a longer name than a path component may hold (255 bytes on ext4 and NTFS): one TWIG snapshot reached 268 and the write failed with `ENAMETOOLONG`, taking down the whole part rather than the entity — a `--by-namespace` part that only touched the space as a dependency died with it.

--- a/tools/bin/commands/publish.ts
+++ b/tools/bin/commands/publish.ts
@@ -417,8 +417,11 @@ async function processDockerImages(
         color.log(`  Build it with: docker build -t ${img.fullLocalName} -f ${dockerfilePath} ${dockerfileDir}`);
         const fallback = await fallbackImage(img, host, devKey, registry, version, contentHash);
         if (fallback.serverError) {
-          color.error(`Cannot resolve fallback: ${fallback.serverError}`);
-          result = {image: null, fallback: true, requestedVersion: registryTag};
+          // A lookup error says nothing about the Dockerfile; build it like a first publish.
+          color.warn(`Cannot resolve fallback: ${fallback.serverError}. Building the image...`);
+          result = buildAndPush() ?? {image: null, fallback: true, requestedVersion: registryTag};
+          if (!result.image)
+            color.error(`No image for ${img.imageName}: build or push failed. No container will be available.`);
         }
         else if (fallback.image && fallback.hashMatch === true) {
           result = fallback;

--- a/tools/package.json
+++ b/tools/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/datagrok-ai/public.git"
   },
-  "version": "6.5.10",
+  "version": "6.5.11",
   "description": "Utility to upload and publish packages to Datagrok",
   "homepage": "https://github.com/datagrok-ai/public/tree/master/tools#readme",
   "dependencies": {


### PR DESCRIPTION
## Summary

- `grok publish`, no local image: a transient error on the `latest-compatible` lookup (here one `ECONNABORTED` on the login call) made the CLI record the container with `image: null` and go on, so the package reached the server with that container in `error`. Observed today publishing Grokky to dev: `grokky-mcp-server` ended up `error` while the other two images were fine.
- A lookup error says nothing about the Dockerfile, so the CLI now builds and pushes the image like a first publish and only records no image when the build or push itself fails.
- Bump to 6.5.11 with a changelog entry.

## Verification

- `npm run build` in `tools/` compiles.
- A second `grok publish dev` of the same package (server reachable) built and pushed `grokky-mcp-server:alex.aprm` through the same code path's success branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D92mBZgvsBnVfrJaJNjxv9