### PR TITLE
GROK-20488: PowerPack: Most Recent Entities filters by id sets, not per-row joins

### DIFF
--- a/packages/PowerPack/CHANGELOG.md
+++ b/packages/PowerPack/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v.next
 
+* GROK-20488: Home: Optimized the "Most Recent Entities" query — parameters and entity types are filtered through id sets instead of per-row joins (dev: 1.1 s → 0.5 s warm, 3.3 s → 0.5 s cold)
 * GROK-20753: Added the columnless "Filter Builder" filter (`PowerPack:filterBuilder`); the saved state is `{model, query}`; the status line is off by default (`showStatus`)
 * GROK-20753: Semantic-type operators are discovered from `meta.role: filterOperators` package functions; `@datagrok-libraries/u2` and `datagrok-api` are referenced in-repo by relative path
 * Search: Apps and functions are now matched ignoring case and spaces, so "modelhub" finds "Model Hub" — previously only the exact spelling with the space worked, because a package function's name is its JS export symbol and the `//name:` annotation lands in friendlyName. `meta.keywords` is searched too, and an app no longer appears under both Apps and Functions (the exclusion checked tags only, missing apps declared via `meta.role`)

--- a/packages/PowerPack/queries/activity-dashboard.sql
+++ b/packages/PowerPack/queries/activity-dashboard.sql
@@ -3,12 +3,14 @@
 --description: Entities the user interacted with most recently (last 30 days)
 --connection: System:Datagrok
 --input: string user [User ID whose recent activity to fetch]
+-- Parameter and entity-type filters are id sets rather than joins: the joins were evaluated
+-- per parameter value (tens of thousands of lookups per call) and dominated the query.
 WITH user_events AS (
   SELECT e.id, e.event_time
   FROM events e
   JOIN event_parameter_values vu ON vu.event_id = e.id
-  JOIN event_parameters pu ON pu.id = vu.parameter_id
-  WHERE pu.name = 'user' AND vu.value_uuid = @user
+  WHERE vu.parameter_id IN (SELECT id FROM event_parameters WHERE name = 'user')
+    AND vu.value_uuid = @user
     AND e.event_time > NOW() - INTERVAL '30 days'
 )
 SELECT
@@ -16,13 +18,11 @@ SELECT
   EXTRACT(EPOCH FROM MAX(ue.event_time) AT TIME ZONE 'UTC') * 1000 AS last_event_time
 FROM user_events ue
 JOIN event_parameter_values v ON v.event_id = ue.id
-JOIN event_parameters p ON p.id = v.parameter_id
 JOIN entities en ON en.id = v.value_uuid
-JOIN entity_types et ON et.id = en.entity_type_id
-WHERE p.type = 'entity_id'
-  AND et.name NOT IN ('FuncCall', 'UserGroup', 'User', 'GrokPackage', 'UserReport',
-                      'TableInfo', 'PackageFunc', 'Func', 'ViewInfo', 'DataConnection',
-                      'ColumnInfo')
+WHERE v.parameter_id IN (SELECT id FROM event_parameters WHERE type = 'entity_id')
+  AND en.entity_type_id NOT IN (SELECT id FROM entity_types WHERE name IN (
+    'FuncCall', 'UserGroup', 'User', 'GrokPackage', 'UserReport',
+    'TableInfo', 'PackageFunc', 'Func', 'ViewInfo', 'DataConnection', 'ColumnInfo'))
 GROUP BY en.id
 ORDER BY last_event_time DESC
 LIMIT 16;


### PR DESCRIPTION
## Summary

- The Home "Most Recent Entities" query (`packages/PowerPack/queries/activity-dashboard.sql`) joined `event_parameters` and `entity_types` once per parameter value of the user's events — tens of thousands of lookups per call — and was the third heaviest statement on dev over two days (1,309 calls, 4,624 s).
- The parameter-name, parameter-type and entity-type filters are now `IN (SELECT id …)` sets, which Postgres hashes once. Rows are identical (checked with EXCEPT both ways on dev); 1.1 s → 0.49 s warm, 3.3 s → 0.49 s cold.
- "Recently Shared With Me" got the same rewrite on dev with no gain, so it is unchanged.

Companion core PR: https://bitbucket.org/skalkin/reddata/pull-requests/1004 (GROK-20488).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkVxSH51X8cMpfCuLStHDt